### PR TITLE
changed key/value seperator from : to =

### DIFF
--- a/src/de/blau/android/osm/OsmElement.java
+++ b/src/de/blau/android/osm/OsmElement.java
@@ -326,7 +326,7 @@ public abstract class OsmElement implements Serializable, XmlSerializable, JosmX
 		for (String tag : importantTags) {
 			String value = getTagWithKey(tag);
 			if (value != null && value.length() > 0) {
-				return (withType ? getName() + " " : "") + tag + ":" + value;
+				return (withType ? getName() + " " : "") + tag + "=" + value;
 			}
 		}
 		// Failing the above, the OSM ID


### PR DESCRIPTION
Changed the description of all osm elements from key:value to match osm standard key=value

fixes #287 