### PR TITLE
Replace degree symbol with corresponding UTF-8 character.

### DIFF
--- a/src/de/blau/android/util/IssueAlert.java
+++ b/src/de/blau/android/util/IssueAlert.java
@@ -71,7 +71,7 @@ public class IssueAlert {
 			    index += 360;
 			index = index / 45;
 
-			// message = "in " + distance + "m " /* + bearing + "° " */ + bearings[index] + "\n";
+			// message = "in " + distance + "m " /* + bearing + "Â° " */ + bearings[index] + "\n";
 			message = main.getString(R.string.alert_distance_direction, distance, bearings[index]) + "\n";
 			ticker = ticker + " " + message;
 		}
@@ -152,7 +152,7 @@ public class IssueAlert {
 			    index += 360;
 			index = index / 45;
 
-			// message = "in " + distance + "m " /* + bearing + "° " */ + bearings[index] + "\n";
+			// message = "in " + distance + "m " /* + bearing + "Â° " */ + bearings[index] + "\n";
 			message = main.getString(R.string.alert_distance_direction, distance, bearings[index]) + "\n";
 			ticker = ticker + " " + message;
 		}


### PR DESCRIPTION
+ This removes the error `unmappable character for encoding UTF-8` show
  when building with Gradle.