### PR TITLE
Avoid inefficient layout weight.

### DIFF
--- a/res/layout/location_picker_view.xml
+++ b/res/layout/location_picker_view.xml
@@ -101,7 +101,7 @@
 					android:id="@+id/location_search_edit"
 					android:imeOptions="actionSearch" 
     				android:inputType="text"
-					android:layout_width="fill_parent"
+					android:layout_width="0dp"
 					android:layout_height="wrap_content"
 					android:singleLine="true"
 					android:layout_weight="1"

--- a/res/layout/query_entry.xml
+++ b/res/layout/query_entry.xml
@@ -13,7 +13,7 @@
 			android:id="@+id/location_search_edit"
 			android:imeOptions="actionSearch" 
   			android:inputType="text"
-			android:layout_width="fill_parent"
+			android:layout_width="0dp"
 			android:layout_height="wrap_content"
 			android:singleLine="true"
 			android:layout_weight="1"

--- a/res/layout/save_file.xml
+++ b/res/layout/save_file.xml
@@ -12,7 +12,7 @@
 		   
 			android:id="@+id/save_file_edit"
   			android:inputType="text"
-			android:layout_width="fill_parent"
+			android:layout_width="0dp"
 			android:layout_height="wrap_content"
 			android:singleLine="true"
 			android:layout_weight="1"


### PR DESCRIPTION
+ With a declared width of 0dp the view does not have to measure its
  own size first. It will absorb all the remaining space anyway.