### PR TITLE
Use StorageDelegator provided by Application.

### DIFF
--- a/src/de/blau/android/DialogFactory.java
+++ b/src/de/blau/android/DialogFactory.java
@@ -36,6 +36,7 @@ import de.blau.android.osm.Node;
 import de.blau.android.osm.OsmElement;
 import de.blau.android.osm.Relation;
 import de.blau.android.osm.Server;
+import de.blau.android.osm.StorageDelegator;
 import de.blau.android.osm.Way;
 import de.blau.android.prefs.Preferences;
 import de.blau.android.util.Search;
@@ -550,13 +551,14 @@ public class DialogFactory {
 			uploadConflict.setNeutralButton(R.string.use_server_version,new OnClickListener() {
 				@Override
 				public void onClick(DialogInterface dialog, int which) {
-					Application.getDelegator().removeFromUpload(elementLocal);
+					StorageDelegator storageDelegator = Application.getDelegator();
+					storageDelegator.removeFromUpload(elementLocal);
 					if (elementOnServer != null) {
 						Main.getLogic().updateElement(elementLocal.getName(), elementLocal.getOsmId());
 					} else { // delete local element
 						Main.getLogic().updateToDeleted(elementLocal);
 					}
-					if (!Application.getDelegator().getApiStorage().isEmpty()) {
+					if (!storageDelegator.getApiStorage().isEmpty()) {
 						caller.confirmUpload();
 					}
 				}

--- a/src/de/blau/android/Main.java
+++ b/src/de/blau/android/Main.java
@@ -492,7 +492,7 @@ public class Main extends SherlockFragmentActivity implements ServiceConnection,
 	@Override
 	protected void onNewIntent(Intent intent) {
 		super.onNewIntent(intent);
-		Log.d(DEBUG_TAG, "onNewIntent storage dirty " + getLogic().getDelegator().isDirty());
+		Log.d(DEBUG_TAG, "onNewIntent storage dirty " + Application.getDelegator().isDirty());
 		setIntent(intent);
 		geoData = (GeoUrlData)getIntent().getSerializableExtra(GeoUrlActivity.GEODATA);
 		rcData = (RemoteControlUrlData)getIntent().getSerializableExtra(RemoteControlUrlActivity.RCDATA);
@@ -557,7 +557,7 @@ public class Main extends SherlockFragmentActivity implements ServiceConnection,
 	 */
 	protected void processIntents() {
 		if (geoData != null) {
-			Log.d(DEBUG_TAG,"got position from geo: url " + geoData.getLat() + "/" + geoData.getLon() + " storage dirty is " + getLogic().getDelegator().isDirty());
+			Log.d(DEBUG_TAG,"got position from geo: url " + geoData.getLat() + "/" + geoData.getLon() + " storage dirty is " + Application.getDelegator().isDirty());
 			if (prefs.getDownloadRadius() != 0) { // download
 				BoundingBox bbox;
 				try {
@@ -1044,7 +1044,7 @@ public class Main extends SherlockFragmentActivity implements ServiceConnection,
 			return true;
 			
 		case R.id.menu_gps_import:
-			if (getLogic() == null || getLogic().getDelegator() == null) return true;
+			if (Application.getDelegator() == null) return true;
 			showFileChooser(READ_GPX_FILE_SELECT_CODE);
 			return true;
 			
@@ -1103,18 +1103,20 @@ public class Main extends SherlockFragmentActivity implements ServiceConnection,
 			}
 			return true;
 		
-		case R.id.menu_transfer_export:
-			if (getLogic() == null || getLogic().getDelegator() == null) return true;
-			SavingHelper.asyncExport(this, getLogic().getDelegator());
+
+		case R.id.menu_transfer_export: {
+			StorageDelegator storageDelegator = Application.getDelegator();
+			if (storageDelegator == null) return true;
+			SavingHelper.asyncExport(this, storageDelegator);
 			return true;
-			
+		}
 		case R.id.menu_transfer_read_file:
-			if (getLogic() == null || getLogic().getDelegator() == null) return true;
+			if (Application.getDelegator() == null) return true;
 			showFileChooser(READ_OSM_FILE_SELECT_CODE);
 			return true;
 			
 		case R.id.menu_transfer_save_file:
-			if (getLogic() == null || getLogic().getDelegator() == null) return true;
+			if (Application.getDelegator() == null) return true;
 			showDialog(DialogFactory.SAVE_FILE);
 //			showFileChooser(WRITE_OSM_FILE_SELECT_CODE);
 			return true;
@@ -1826,7 +1828,8 @@ public class Main extends SherlockFragmentActivity implements ServiceConnection,
 		}
 	
 		if (selectedElement != null) {
-			if (getLogic().getDelegator().getOsmElement(selectedElement.getName(), selectedElement.getOsmId()) != null) {
+			StorageDelegator storageDelegator = Application.getDelegator();
+			if (storageDelegator.getOsmElement(selectedElement.getName(), selectedElement.getOsmId()) != null) {
 				Intent startTagEditor = new Intent(getApplicationContext(), PropertyEditor.class);
 				PropertyEditorData[] single = new PropertyEditorData[1];
 				single[0] = new PropertyEditorData(selectedElement, focusOn);
@@ -1841,9 +1844,9 @@ public class Main extends SherlockFragmentActivity implements ServiceConnection,
 	public void performTagEdit(final ArrayList<OsmElement> selection, boolean applyLastAddressTags, boolean showPresets) {
 		
 		ArrayList<PropertyEditorData> multiple = new ArrayList<PropertyEditorData>();
-		
+		StorageDelegator storageDelegator = Application.getDelegator();
 		for (OsmElement e:selection) {
-			if (getLogic().getDelegator().getOsmElement(e.getName(), e.getOsmId()) != null) {
+			if (storageDelegator.getOsmElement(e.getName(), e.getOsmId()) != null) {
 				multiple.add(new PropertyEditorData(e, null));
 			}
 		}

--- a/src/de/blau/android/easyedit/EasyEditManager.java
+++ b/src/de/blau/android/easyedit/EasyEditManager.java
@@ -62,6 +62,7 @@ import de.blau.android.osm.OsmElement.ElementType;
 import de.blau.android.osm.Relation;
 import de.blau.android.osm.RelationMember;
 import de.blau.android.osm.Server;
+import de.blau.android.osm.StorageDelegator;
 import de.blau.android.osm.Tags;
 import de.blau.android.osm.Way;
 import de.blau.android.prefs.Preferences;
@@ -713,6 +714,7 @@ public class EasyEditManager {
 			ArrayList<String> matches = data.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS);
 
 			// 
+			StorageDelegator storageDelegator = Application.getDelegator();
 			for (String v:matches) {
 				String[] words = v.split("\\s+", 2);
 				if (words.length > 0) {
@@ -770,7 +772,7 @@ public class EasyEditManager {
 								for (String k:map.keySet()) {
 									tags.put(k, map.get(k));
 								}
-								Application.getDelegator().setTags(node,tags); // note doesn't create a new undo checkpoint
+								storageDelegator.setTags(node,tags); // note doesn't create a new undo checkpoint
 								main.startActionMode(new NodeSelectionActionModeCallback(node));
 								return;
 							}

--- a/src/de/blau/android/osb/BugFragment.java
+++ b/src/de/blau/android/osb/BugFragment.java
@@ -18,6 +18,7 @@ import de.blau.android.osm.Node;
 import de.blau.android.osm.OsmElement;
 import de.blau.android.osm.Relation;
 import de.blau.android.osm.RelationMember;
+import de.blau.android.osm.StorageDelegator;
 import de.blau.android.osm.Tags;
 import de.blau.android.osm.Way;
 import de.blau.android.prefs.Preferences;
@@ -164,6 +165,7 @@ public class BugFragment extends SherlockDialogFragment {
     	} else if (bug instanceof OsmoseBug) {
     		builder.setTitle(R.string.openstreetbug_bug_title);
     		comments.setText(Html.fromHtml(((OsmoseBug)bug).getLongDescription(getActivity(), false)));
+    		final StorageDelegator storageDelegator = Application.getDelegator();
     		for (final OsmElement e:((OsmoseBug)bug).getElements()) {
     			String text;
     			if (e.getOsmVersion() < 0) { // fake element
@@ -184,7 +186,7 @@ public class BugFragment extends SherlockDialogFragment {
 								Application.mainActivity.getLogic().downloadBox(GeoMath.createBoundingBoxForCoordinates(latE7/1E7D, lonE7/1E7, 50, true), true, new PostAsyncActionHandler(){
 									@Override
 									public void execute(){
-										OsmElement osm = Application.getDelegator().getOsmElement(e.getName(),e.getOsmId());
+										OsmElement osm = storageDelegator.getOsmElement(e.getName(), e.getOsmId());
 										if (osm != null) {
 											Application.mainActivity.zoomToAndEdit(lonE7, latE7, osm);
 										}

--- a/src/de/blau/android/osb/OsmoseBug.java
+++ b/src/de/blau/android/osb/OsmoseBug.java
@@ -20,6 +20,7 @@ import de.blau.android.osm.Node;
 import de.blau.android.osm.OsmElement;
 import de.blau.android.osm.OsmElementFactory;
 import de.blau.android.osm.Relation;
+import de.blau.android.osm.StorageDelegator;
 import de.blau.android.osm.Way;
 import de.blau.android.util.jsonreader.JsonReader;
 import android.content.Context;
@@ -146,22 +147,23 @@ public class OsmoseBug extends Bug implements Serializable {
 	public ArrayList<OsmElement> getElements() {
 		ArrayList<OsmElement> result = new ArrayList<OsmElement>();
 		String[] elements = elems.split("_");
+		StorageDelegator storageDelegator = Application.getDelegator();
 		for (String e:elements) {
 			try {
 				if (elems.startsWith("way")) {
-					OsmElement osm = Application.getDelegator().getOsmElement(Way.NAME,Long.valueOf(e.substring(3)));
+					OsmElement osm = storageDelegator.getOsmElement(Way.NAME, Long.valueOf(e.substring(3)));
 					if (osm == null) {
 						osm = OsmElementFactory.createWay(Long.valueOf(e.substring(3)), -1, (byte) -1);
 					}
 					result.add(osm);
 				} else if (elems.startsWith("node")) {
-					OsmElement osm = Application.getDelegator().getOsmElement(Node.NAME,Long.valueOf(e.substring(4)));
+					OsmElement osm = storageDelegator.getOsmElement(Node.NAME, Long.valueOf(e.substring(4)));
 					if (osm == null) {
 						osm = OsmElementFactory.createNode(Long.valueOf(e.substring(4)), -1, (byte) -1, 0, 0);
 					}
 					result.add(osm);
 				} else if (elems.startsWith("relation")) {
-					OsmElement osm = Application.getDelegator().getOsmElement(Relation.NAME,Long.valueOf(e.substring(8)));
+					OsmElement osm = storageDelegator.getOsmElement(Relation.NAME, Long.valueOf(e.substring(8)));
 					if (osm == null) {
 						osm = OsmElementFactory.createRelation(Long.valueOf(e.substring(8)), -1, (byte) -1);
 					}

--- a/src/de/blau/android/propertyeditor/Address.java
+++ b/src/de/blau/android/propertyeditor/Address.java
@@ -16,6 +16,7 @@ import de.blau.android.osm.BoundingBox;
 import de.blau.android.osm.Node;
 import de.blau.android.osm.OsmElement;
 import de.blau.android.osm.Relation;
+import de.blau.android.osm.StorageDelegator;
 import de.blau.android.osm.Tags;
 import de.blau.android.osm.Way;
 import de.blau.android.prefs.Preferences;
@@ -168,6 +169,7 @@ public class Address implements Serializable {
 		}
 		boolean hasPlace = newAddress.tags.containsKey(Tags.KEY_ADDR_PLACE);
 		boolean hasNumber = current.containsKey(Tags.KEY_ADDR_HOUSENUMBER); // if the object already had a number don't overwrite it
+		StorageDelegator storageDelegator = Application.getDelegator();
 		if (es != null /* || hasPlace */) {
 			// the arrays should now be calculated, retrieve street names if any
 			ArrayList<String> streetNames = new ArrayList<String>(Arrays.asList(es.getStreetNames()));
@@ -223,11 +225,11 @@ public class Address implements Serializable {
 								streetId = es.getStreetId(street);
 							}
 							// nodes
-							for (Node n:Application.getDelegator().getCurrentStorage().getNodes()) {
+							for (Node n: storageDelegator.getCurrentStorage().getNodes()) {
 								seedAddressList(street,streetId,(OsmElement)n,lastAddresses);
 							}
 							// ways
-							for (Way w:Application.getDelegator().getCurrentStorage().getWays()) {
+							for (Way w: storageDelegator.getCurrentStorage().getWays()) {
 								seedAddressList(street,streetId,(OsmElement)w,lastAddresses);
 							}
 							// and try again
@@ -342,7 +344,7 @@ public class Address implements Serializable {
 		if (elementType.equals(Node.NAME)) {
 			boolean isOnBuilding = false;
 			// we can't call wayForNodes here because Logic may not be around
-			for (Way w:Application.getDelegator().getCurrentStorage().getWays((Node)Application.getDelegator().getOsmElement(Node.NAME, elementOsmId))) {
+			for (Way w: storageDelegator.getCurrentStorage().getWays((Node) storageDelegator.getOsmElement(Node.NAME, elementOsmId))) {
 				if (w.hasTagKey(Tags.KEY_BUILDING)) {
 					isOnBuilding = true;
 				} else if (w.getParentRelations() != null) { // need to check relations too

--- a/src/de/blau/android/propertyeditor/RelationMembershipFragment.java
+++ b/src/de/blau/android/propertyeditor/RelationMembershipFragment.java
@@ -42,6 +42,7 @@ import de.blau.android.HelpViewer;
 import de.blau.android.Main;
 import de.blau.android.R;
 import de.blau.android.osm.Relation;
+import de.blau.android.osm.StorageDelegator;
 import de.blau.android.presets.Preset;
 import de.blau.android.presets.Preset.PresetItem;
 
@@ -144,8 +145,9 @@ public class RelationMembershipFragment extends SherlockFragment implements OnIt
 	protected void loadParents(LinearLayout membershipVerticalLayout, final Map<Long,String> parents) {
 		membershipVerticalLayout.removeAllViews();
 		if (parents != null && parents.size() > 0) {
+			StorageDelegator storageDelegator = Application.getDelegator();
 			for (Long id :  parents.keySet()) {
-				Relation r = (Relation) Application.getDelegator().getOsmElement(Relation.NAME, id.longValue());
+				Relation r = (Relation) storageDelegator.getOsmElement(Relation.NAME, id.longValue());
 				insertNewMembership(membershipVerticalLayout, parents.get(id),r,0, false);
 			}
 		}

--- a/src/de/blau/android/services/TrackerService.java
+++ b/src/de/blau/android/services/TrackerService.java
@@ -58,6 +58,7 @@ import de.blau.android.exception.StorageException;
 import de.blau.android.osb.TransferBugs;
 import de.blau.android.osm.BoundingBox;
 import de.blau.android.osm.OsmParser;
+import de.blau.android.osm.StorageDelegator;
 import de.blau.android.osm.Track;
 import de.blau.android.osm.UndoStorage;
 import de.blau.android.osm.Track.TrackPoint;
@@ -832,7 +833,8 @@ public class TrackerService extends Service implements LocationListener, NmeaLis
 		// speed needs to be <= 6km/h (aka brisk walking speed) 
 		int radius = prefs.getDownloadRadius();
 		if ((location.getSpeed() < prefs.getMaxDownloadSpeed()/3.6f) && (previousLocation==null || location.distanceTo(previousLocation) > radius/8)) {
-			ArrayList<BoundingBox> bbList = new ArrayList<BoundingBox>(Application.getDelegator().getBoundingBoxes());
+			StorageDelegator storageDelegator = Application.getDelegator();
+			ArrayList<BoundingBox> bbList = new ArrayList<BoundingBox>(storageDelegator.getBoundingBoxes());
 			BoundingBox newBox = getNextBox(bbList,previousLocation, location,radius);
 			if (newBox != null) {
 				if (radius != 0) { // download
@@ -843,7 +845,7 @@ public class TrackerService extends Service implements LocationListener, NmeaLis
 							Log.d(TAG,"getNextCenter very small bb " + b.toString());
 							continue;
 						}
-						Application.getDelegator().addBoundingBox(b);  // will be filled once download is complete
+						storageDelegator.addBoundingBox(b);  // will be filled once download is complete
 						Log.d(TAG,"getNextCenter loading " + b.toString());
 						Logic.autoDownloadBox(this,prefs.getServer(), b); 
 					}


### PR DESCRIPTION
+ Reduce redundant lookup within for-loops.

--- 

Quoting @simonpoole [here](https://github.com/MarcusWolschon/osmeditor4android/pull/348#commitcomment-13778227):
> ... the StorageDelegator singleton now lives in Application (you can simply call Application.getDelegator()). (the code simply hasn't been adapted all over the place)