### PR TITLE
Intents

### DIFF
--- a/src/de/blau/android/DialogFactory.java
+++ b/src/de/blau/android/DialogFactory.java
@@ -220,9 +220,7 @@ public class DialogFactory {
 		newbie.setNeutralButton(R.string.read_introduction, 	new OnClickListener() {
 					@Override
 					public void onClick(DialogInterface dialog, int which) {
-						Intent startHelpViewer = new Intent(caller.getApplicationContext(), HelpViewer.class);
-						startHelpViewer.putExtra(HelpViewer.TOPIC, R.string.help_introduction);
-						caller.startActivity(startHelpViewer);
+						HelpViewer.start(caller.getApplicationContext(), R.string.help_introduction);
 					}
 				});
 		
@@ -238,9 +236,7 @@ public class DialogFactory {
 		newVersion.setNeutralButton(R.string.read_upgrade, 	new OnClickListener() {
 					@Override
 					public void onClick(DialogInterface dialog, int which) {
-						Intent startHelpViewer = new Intent(caller.getApplicationContext(), HelpViewer.class);
-						startHelpViewer.putExtra(HelpViewer.TOPIC, R.string.help_upgrade);
-						caller.startActivity(startHelpViewer);
+						HelpViewer.start(caller.getApplicationContext(), R.string.help_upgrade);
 					}
 				});
 	}

--- a/src/de/blau/android/HelpViewer.java
+++ b/src/de/blau/android/HelpViewer.java
@@ -15,6 +15,7 @@ import java.util.Locale;
 
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
+import android.content.Context;
 import android.content.Intent;
 import android.content.res.TypedArray;
 import android.graphics.drawable.ColorDrawable;
@@ -23,6 +24,8 @@ import android.os.Build;
 import android.os.Bundle;
 
 
+import android.support.annotation.NonNull;
+import android.support.annotation.StringRes;
 import android.support.v4.app.ActionBarDrawerToggle;
 import android.support.v4.widget.DrawerLayout;
 import android.util.Log;
@@ -86,6 +89,12 @@ public class HelpViewer extends SherlockActivity {
 	private DrawerLayout mDrawerLayout;
 	private ListView mDrawerList;
 	ArrayAdapter<HelpItem> tocAdapter;
+
+	public static void start(@NonNull Context context, @StringRes int topic) {
+		Intent intent = new Intent(context, HelpViewer.class);
+		intent.putExtra(TOPIC, topic);
+		context.startActivity(intent);
+	}
 
 	@SuppressLint("NewApi")
 	@Override

--- a/src/de/blau/android/Main.java
+++ b/src/de/blau/android/Main.java
@@ -947,7 +947,7 @@ public class Main extends SherlockFragmentActivity implements ServiceConnection,
 		final Server server = prefs.getServer();
 		switch (item.getItemId()) {
 		case R.id.menu_config:
-			startActivity(new Intent(getApplicationContext(), PrefEditor.class));
+			PrefEditor.start(getApplicationContext());
 			return true;
 			
 		case R.id.menu_find:

--- a/src/de/blau/android/Main.java
+++ b/src/de/blau/android/Main.java
@@ -1864,13 +1864,10 @@ public class Main extends SherlockFragmentActivity implements ServiceConnection,
 		if (selectedElement != null) {
 			StorageDelegator storageDelegator = Application.getDelegator();
 			if (storageDelegator.getOsmElement(selectedElement.getName(), selectedElement.getOsmId()) != null) {
-				Intent startTagEditor = new Intent(getApplicationContext(), PropertyEditor.class);
 				PropertyEditorData[] single = new PropertyEditorData[1];
 				single[0] = new PropertyEditorData(selectedElement, focusOn);
-				startTagEditor.putExtra(PropertyEditor.TAGEDIT_DATA, single);
-				startTagEditor.putExtra(PropertyEditor.TAGEDIT_LAST_ADDRESS_TAGS, Boolean.valueOf(applyLastAddressTags));
-				startTagEditor.putExtra(PropertyEditor.TAGEDIT_SHOW_PRESETS, Boolean.valueOf(showPresets));
-				startActivityForResult(startTagEditor, Main.REQUEST_EDIT_TAG);
+				PropertyEditor.startForResult(this, single, applyLastAddressTags,
+						showPresets, REQUEST_EDIT_TAG);
 			}
 		}
 	}
@@ -1888,12 +1885,9 @@ public class Main extends SherlockFragmentActivity implements ServiceConnection,
 			Log.d(DEBUG_TAG, "performTagEdit no valid elements");
 			return;
 		}
-		Intent startTagEditor = new Intent(getApplicationContext(), PropertyEditor.class);
 		PropertyEditorData[] multipleArray = multiple.toArray(new PropertyEditorData[multiple.size()]);
-		startTagEditor.putExtra(PropertyEditor.TAGEDIT_DATA, multipleArray);
-		startTagEditor.putExtra(PropertyEditor.TAGEDIT_LAST_ADDRESS_TAGS, Boolean.valueOf(applyLastAddressTags));
-		startTagEditor.putExtra(PropertyEditor.TAGEDIT_SHOW_PRESETS, Boolean.valueOf(showPresets));
-		startActivityForResult(startTagEditor, Main.REQUEST_EDIT_TAG);
+		PropertyEditor.startForResult(this, multipleArray, applyLastAddressTags,
+				showPresets, REQUEST_EDIT_TAG);
 	}
 
 	/**

--- a/src/de/blau/android/Main.java
+++ b/src/de/blau/android/Main.java
@@ -955,9 +955,7 @@ public class Main extends SherlockFragmentActivity implements ServiceConnection,
 			return true;
 			
 		case R.id.menu_help:
-			Intent startHelpViewer = new Intent(getApplicationContext(), HelpViewer.class);
-			startHelpViewer.putExtra(HelpViewer.TOPIC, R.string.help_main);
-			startActivity(startHelpViewer);
+			HelpViewer.start(getApplicationContext(), R.string.help_main);
 			return true;
 			
 //		case R.id.menu_voice:		

--- a/src/de/blau/android/easyedit/EasyEditManager.java
+++ b/src/de/blau/android/easyedit/EasyEditManager.java
@@ -502,9 +502,7 @@ public class EasyEditManager {
 			Log.d("EasyEditActionModeCallback", "onActionItemClicked");
 			if (item.getItemId() == MENUITEM_HELP) {
 				if (helpTopic != 0) {
-					Intent startHelpViewer = new Intent(main.getApplicationContext(), HelpViewer.class);
-					startHelpViewer.putExtra(HelpViewer.TOPIC, helpTopic);
-					main.startActivity(startHelpViewer);
+					HelpViewer.start(main.getApplicationContext(), helpTopic);
 				} else {
 					Toast.makeText(main, R.string.toast_nohelp, Toast.LENGTH_LONG).show(); // this is essentially just an error message
 				}

--- a/src/de/blau/android/imageryoffset/BackgroundAlignmentActionModeCallback.java
+++ b/src/de/blau/android/imageryoffset/BackgroundAlignmentActionModeCallback.java
@@ -21,9 +21,7 @@ import java.util.concurrent.TimeoutException;
 import android.app.AlertDialog;
 import android.app.AlertDialog.Builder;
 import android.app.Dialog;
-import android.content.Context;
 import android.content.DialogInterface;
-import android.content.Intent;
 import android.content.DialogInterface.OnClickListener;
 import android.os.AsyncTask;
 import android.util.Log;
@@ -43,6 +41,7 @@ import de.blau.android.Application;
 import de.blau.android.DialogFactory;
 import de.blau.android.HelpViewer;
 import de.blau.android.Logic.Mode;
+import de.blau.android.Main;
 import de.blau.android.Map;
 import de.blau.android.R;
 import de.blau.android.osm.BoundingBox;
@@ -137,9 +136,7 @@ public class BackgroundAlignmentActionModeCallback implements Callback {
 		case MENUITEM_SAVELOCAL:
 			break;
 		case MENUITEM_HELP:
-			Intent startHelpViewer = new Intent(Application.mainActivity, HelpViewer.class);
-			startHelpViewer.putExtra(HelpViewer.TOPIC, R.string.help_aligningbackgroundiamgery);
-			Application.mainActivity.startActivity(startHelpViewer);
+			HelpViewer.start(Application.mainActivity, R.string.help_aligningbackgroundiamgery);
 			return true;
 		default: return false;
 		}

--- a/src/de/blau/android/listener/GotoPreferencesListener.java
+++ b/src/de/blau/android/listener/GotoPreferencesListener.java
@@ -3,7 +3,7 @@ package de.blau.android.listener;
 import android.app.Activity;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
-import android.content.Intent;
+
 import de.blau.android.prefs.PrefEditor;
 
 /**
@@ -22,6 +22,6 @@ public class GotoPreferencesListener implements OnClickListener {
 
 	@Override
 	public void onClick(final DialogInterface dialog, final int which) {
-		caller.startActivity(new Intent(caller, PrefEditor.class));
+		PrefEditor.start(caller);
 	}
 }

--- a/src/de/blau/android/prefs/APIEditorActivity.java
+++ b/src/de/blau/android/prefs/APIEditorActivity.java
@@ -3,10 +3,14 @@ package de.blau.android.prefs;
 import java.util.List;
 import java.util.Map.Entry;
 
+import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnCancelListener;
+import android.content.Intent;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.view.ContextMenu;
 import android.view.ContextMenu.ContextMenuInfo;
 import android.view.View;
@@ -29,6 +33,17 @@ public class APIEditorActivity extends URLListEditActivity {
 		super();
 	}
 	
+	public static void startForResult(@NonNull Activity activity,
+									  @NonNull String apiName,
+									  @NonNull String apiUrl,
+									  int requestCode) {
+		Intent intent = new Intent(activity, APIEditorActivity.class);
+		intent.setAction(ACTION_NEW);
+		intent.putExtra(EXTRA_NAME, apiName);
+		intent.putExtra(EXTRA_VALUE, apiUrl);
+		activity.startActivityForResult(intent, requestCode);
+	}
+
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		Preferences prefs = new Preferences(this);

--- a/src/de/blau/android/prefs/AdvancedPrefEditor.java
+++ b/src/de/blau/android/prefs/AdvancedPrefEditor.java
@@ -78,7 +78,7 @@ public class AdvancedPrefEditor extends SherlockPreferenceActivity {
 			@Override
 			public boolean onPreferenceClick(Preference preference) {
 				Log.d("AdvancedPrefEditor", "onPreferenceClick");
-				startActivity(new Intent(AdvancedPrefEditor.this, PresetEditorActivity.class));
+				PresetEditorActivity.start(AdvancedPrefEditor.this);
 				return true;
 			}
 		});

--- a/src/de/blau/android/prefs/PrefEditor.java
+++ b/src/de/blau/android/prefs/PrefEditor.java
@@ -1,5 +1,6 @@
 package de.blau.android.prefs;
 
+import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
 import android.os.Bundle;
@@ -7,6 +8,7 @@ import android.preference.CheckBoxPreference;
 import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.Preference.OnPreferenceChangeListener;
+import android.support.annotation.NonNull;
 import android.util.Log;
 
 import com.actionbarsherlock.app.ActionBar;
@@ -36,6 +38,11 @@ public class PrefEditor extends SherlockPreferenceActivity {
 	private String KEY_ADDRPREFS;
 	private String KEY_LICENSE;
 	private String KEY_DEBUG;
+
+	public static void start(@NonNull Context context) {
+		Intent intent = new Intent(context, PrefEditor.class);
+		context.startActivity(intent);
+	}
 	
 	@Override
 	protected void onCreate(final Bundle savedInstanceState) {

--- a/src/de/blau/android/prefs/PresetEditorActivity.java
+++ b/src/de/blau/android/prefs/PresetEditorActivity.java
@@ -14,13 +14,17 @@ import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnCancelListener;
 import android.content.DialogInterface.OnClickListener;
+import android.content.Intent;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.util.Log;
 import android.widget.Toast;
 import de.blau.android.Application;
@@ -43,6 +47,22 @@ public class PresetEditorActivity extends URLListEditActivity {
 		addAdditionalContextMenuItem(MENU_RELOAD, R.string.preset_update);
 	}
 		
+	public static void start(@NonNull Context context) {
+		Intent intent = new Intent(context, PresetEditorActivity.class);
+		context.startActivity(intent);
+	}
+
+	public static void startForResult(@NonNull Activity activity,
+									  @NonNull String presetName,
+									  @NonNull String presetUrl,
+									  int requestCode) {
+		Intent intent = new Intent(activity, PresetEditorActivity.class);
+		intent.setAction(ACTION_NEW);
+		intent.putExtra(EXTRA_NAME, presetName);
+		intent.putExtra(EXTRA_VALUE, presetUrl);
+		activity.startActivityForResult(intent, requestCode);
+	}
+
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		Preferences prefs = new Preferences(this);

--- a/src/de/blau/android/prefs/VespucciURLActivity.java
+++ b/src/de/blau/android/prefs/VespucciURLActivity.java
@@ -161,17 +161,12 @@ public class VespucciURLActivity extends Activity implements OnClickListener {
 
 	@Override
 	public void onClick(View v) {
-		Intent intent;
 		switch (v.getId()) {
 		case R.id.urldialog_buttonAddPreset:
 			PresetEditorActivity.startForResult(this, presetname, preseturl, REQUEST_PRESETEDIT);
 			break;
 		case R.id.urldialog_buttonAddAPI:
-			intent = new Intent(this, APIEditorActivity.class);
-			intent.setAction(URLListEditActivity.ACTION_NEW);
-			intent.putExtra(URLListEditActivity.EXTRA_NAME, apiname);
-			intent.putExtra(URLListEditActivity.EXTRA_VALUE, apiurl);
-			startActivityForResult(intent, REQUEST_APIEDIT);
+			APIEditorActivity.startForResult(this, apiname, apiurl, REQUEST_APIEDIT);
 			break;
 		}
 	}

--- a/src/de/blau/android/prefs/VespucciURLActivity.java
+++ b/src/de/blau/android/prefs/VespucciURLActivity.java
@@ -164,11 +164,7 @@ public class VespucciURLActivity extends Activity implements OnClickListener {
 		Intent intent;
 		switch (v.getId()) {
 		case R.id.urldialog_buttonAddPreset:
-			intent = new Intent(this, PresetEditorActivity.class);
-			intent.setAction(URLListEditActivity.ACTION_NEW);
-			intent.putExtra(URLListEditActivity.EXTRA_NAME, presetname);
-			intent.putExtra(URLListEditActivity.EXTRA_VALUE, preseturl);
-			startActivityForResult(intent, REQUEST_PRESETEDIT);
+			PresetEditorActivity.startForResult(this, presetname, preseturl, REQUEST_PRESETEDIT);
 			break;
 		case R.id.urldialog_buttonAddAPI:
 			intent = new Intent(this, APIEditorActivity.class);

--- a/src/de/blau/android/propertyeditor/MemberSelectedActionModeCallback.java
+++ b/src/de/blau/android/propertyeditor/MemberSelectedActionModeCallback.java
@@ -4,7 +4,6 @@ package de.blau.android.propertyeditor;
 
 import java.util.ArrayList;
 
-import android.content.Intent;
 import android.view.View;
 import android.widget.LinearLayout;
 
@@ -75,9 +74,7 @@ public class MemberSelectedActionModeCallback implements Callback {
 			}
 			break;
 		case MENUITEM_HELP:
-			Intent startHelpViewer = new Intent(Application.mainActivity, HelpViewer.class);
-			startHelpViewer.putExtra(HelpViewer.TOPIC, R.string.help_propertyeditor);
-			Application.mainActivity.startActivity(startHelpViewer);
+			HelpViewer.start(Application.mainActivity, R.string.help_propertyeditor);
 			return true;
 		default: return false;
 		}

--- a/src/de/blau/android/propertyeditor/ParentSelectedActionModeCallback.java
+++ b/src/de/blau/android/propertyeditor/ParentSelectedActionModeCallback.java
@@ -4,7 +4,6 @@ package de.blau.android.propertyeditor;
 
 import java.util.ArrayList;
 
-import android.content.Intent;
 import android.view.View;
 import android.widget.LinearLayout;
 
@@ -75,9 +74,7 @@ public class ParentSelectedActionModeCallback implements Callback {
 			}
 			break;
 		case MENUITEM_HELP:
-			Intent startHelpViewer = new Intent(Application.mainActivity, HelpViewer.class);
-			startHelpViewer.putExtra(HelpViewer.TOPIC,R.string.help_propertyeditor);
-			Application.mainActivity.startActivity(startHelpViewer);
+			HelpViewer.start(Application.mainActivity, R.string.help_propertyeditor);
 			return true;
 		default: return false;
 		}

--- a/src/de/blau/android/propertyeditor/PresetFragment.java
+++ b/src/de/blau/android/propertyeditor/PresetFragment.java
@@ -12,8 +12,6 @@ import com.actionbarsherlock.view.MenuItem;
 
 import android.app.Activity;
 import android.app.Dialog;
-import android.content.Context;
-import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
@@ -311,9 +309,7 @@ public class PresetFragment extends SherlockFragment implements PresetClickHandl
 			}
 			return true;
 		case R.id.preset_menu_help:
-			Intent startHelpViewer = new Intent(getActivity(), HelpViewer.class);
-			startHelpViewer.putExtra(HelpViewer.TOPIC, R.string.help_presets);
-			startActivity(startHelpViewer);
+			HelpViewer.start(getActivity(), R.string.help_presets);
 			return true;
 		}
 		

--- a/src/de/blau/android/propertyeditor/PropertyEditor.java
+++ b/src/de/blau/android/propertyeditor/PropertyEditor.java
@@ -8,8 +8,8 @@ import java.util.Map;
 import org.acra.ACRA;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.app.AlertDialog;
-import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
@@ -17,6 +17,7 @@ import android.content.res.Configuration;
 import android.graphics.Point;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentPagerAdapter;
@@ -136,6 +137,18 @@ public class PropertyEditor extends SherlockFragmentActivity implements
 	private PresetFragment presetFragment;
 	ExtendedViewPager    mViewPager;
 	boolean usePaneLayout = false;
+
+	public static void startForResult(@NonNull Activity activity,
+									  @NonNull PropertyEditorData[] dataClass,
+									  boolean applyLastTags,
+									  boolean showPresets,
+									  int requestCode) {
+		Intent intent = new Intent(activity, PropertyEditor.class);
+		intent.putExtra(TAGEDIT_DATA, dataClass);
+		intent.putExtra(TAGEDIT_LAST_ADDRESS_TAGS, Boolean.valueOf(applyLastTags));
+		intent.putExtra(TAGEDIT_SHOW_PRESETS, Boolean.valueOf(showPresets));
+		activity.startActivityForResult(intent, requestCode);
+	}
 
 	@SuppressLint("NewApi")
 	@Override

--- a/src/de/blau/android/propertyeditor/RelationMembersFragment.java
+++ b/src/de/blau/android/propertyeditor/RelationMembersFragment.java
@@ -10,7 +10,6 @@ import java.util.Set;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
-import android.content.Intent;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.util.AttributeSet;
@@ -488,9 +487,7 @@ public class RelationMembersFragment extends SherlockFragment {
 			doRevert();
 			return true;
 		case R.id.tag_menu_help:
-			Intent startHelpViewer = new Intent(getActivity(), HelpViewer.class);
-			startHelpViewer.putExtra(HelpViewer.TOPIC, R.string.help_propertyeditor);
-			startActivity(startHelpViewer);
+			HelpViewer.start(getActivity(), R.string.help_propertyeditor);
 			return true;
 		}
 		

--- a/src/de/blau/android/propertyeditor/RelationMembershipFragment.java
+++ b/src/de/blau/android/propertyeditor/RelationMembershipFragment.java
@@ -11,7 +11,6 @@ import java.util.Set;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
-import android.content.Intent;
 import android.os.Bundle;
 import android.util.AttributeSet;
 import android.util.Log;
@@ -541,9 +540,7 @@ public class RelationMembershipFragment extends SherlockFragment implements OnIt
 			addToRelation();
 			return true;
 		case R.id.tag_menu_help:
-			Intent startHelpViewer = new Intent(getActivity(), HelpViewer.class);
-			startHelpViewer.putExtra(HelpViewer.TOPIC, R.string.help_propertyeditor);
-			startActivity(startHelpViewer);
+			HelpViewer.start(getActivity(), R.string.help_propertyeditor);
 			return true;
 		}
 		

--- a/src/de/blau/android/propertyeditor/TagEditorFragment.java
+++ b/src/de/blau/android/propertyeditor/TagEditorFragment.java
@@ -1286,9 +1286,7 @@ public class TagEditorFragment extends SherlockFragment {
 			Address.resetLastAddresses();
 			return true;
 		case R.id.tag_menu_help:
-			Intent startHelpViewer = new Intent(getActivity(), HelpViewer.class);
-			startHelpViewer.putExtra(HelpViewer.TOPIC, R.string.help_propertyeditor);
-			startActivity(startHelpViewer);
+			HelpViewer.start(getActivity(), R.string.help_propertyeditor);
 			return true;
 		}
 		

--- a/src/de/blau/android/propertyeditor/TagSelectedActionModeCallback.java
+++ b/src/de/blau/android/propertyeditor/TagSelectedActionModeCallback.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import android.content.Intent;
 import android.view.View;
 import android.widget.EditText;
 import android.widget.LinearLayout;
@@ -130,9 +129,7 @@ public class TagSelectedActionModeCallback implements Callback {
 			}
 			break;
 		case MENUITEM_HELP:
-			Intent startHelpViewer = new Intent(Application.mainActivity, HelpViewer.class);
-			startHelpViewer.putExtra(HelpViewer.TOPIC, R.string.help_propertyeditor);
-			Application.mainActivity.startActivity(startHelpViewer);
+			HelpViewer.start(Application.mainActivity, R.string.help_propertyeditor);
 			return true;
 		default: return false;
 		}


### PR DESCRIPTION
As a follow up of #367 I followed [@simonpoole advice to encapsulate the `Intent` creation in the targeted classes](https://github.com/MarcusWolschon/osmeditor4android/pull/367#issuecomment-152515796), where possible.

I have chosen `.start()` and `.startForResult()` as the method names based on `.startActivity()` and `.startActivityForResult()`.