### PR TITLE
Remove duplicate config_maxInlineValues_summary string.

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -463,7 +463,6 @@
     <string name="config_maxInlineValues_summary">Maximum number of inline values displayed in tag form</string>
     <string name="config_maxTileDownloadThreads_title">Max. number of download threads</string>
     <string name="config_maxTileDownloadThreads_summary">Maximum number of threads for downloading tiles</string>
-    <string name="config_maxInlineValues_summary">Maximum number of inline values displayed in tag form</string>
     <string name="config_notificationCacheSize_title">Max. number of displayed notifications</string>
     <string name="config_notificationCacheSize_summary">Maximum number of displayed notifications per type</string>
     <!-- preset downloader messages -->


### PR DESCRIPTION
+ Introduced in commit 23de9481a467167bc7ccbd37cc3a2cf83d374b2e.