### PR TITLE
Align content and title of the element information dialog.

### DIFF
--- a/res/layout/element_info_view.xml
+++ b/res/layout/element_info_view.xml
@@ -1,14 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content" >
+    android:layout_height="wrap_content"
+    android:padding="@dimen/alert_dialog_content_margin"
+    tools:background="@android:color/holo_green_dark"
+    tools:layout_width="match_parent">
 
     <TableLayout
         android:id="@+id/element_info_vertical_layout"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:padding="5dp" >
+        tools:background="@android:color/holo_orange_light">
     </TableLayout>
 
 </ScrollView>

--- a/res/values/dimens.xml
+++ b/res/values/dimens.xml
@@ -1,3 +1,5 @@
 <resources>
     <dimen name="spl_default_splitter_size">12dp</dimen>
+    <!-- See: https://www.google.de/design/spec/components/dialogs.html#dialogs-specs -->
+    <dimen name="alert_dialog_content_margin">24dp</dimen>
 </resources>


### PR DESCRIPTION
+ Resolves #488.

![dialog](https://cloud.githubusercontent.com/assets/144518/19535558/79041150-9648-11e6-82d6-68c9fab8adb7.png)
