### PR TITLE
Improve UX of upload changes dialog. Add form field validation.

### DIFF
--- a/src/main/java/de/blau/android/dialogs/ConfirmUpload.java
+++ b/src/main/java/de/blau/android/dialogs/ConfirmUpload.java
@@ -172,7 +172,7 @@ public class ConfirmUpload extends DialogFragment
 	/**
 	 * @return a list of all pending changes to upload (contains newlines)
 	 */
-	public String getPendingChanges(Context ctx) {
+	private String getPendingChanges(Context ctx) {
 		List<String> changes = App.getLogic().getPendingChanges(ctx);
 		StringBuilder builder = new StringBuilder();
 		for (String change : changes) {

--- a/src/main/java/de/blau/android/dialogs/ConfirmUpload.java
+++ b/src/main/java/de/blau/android/dialogs/ConfirmUpload.java
@@ -51,6 +51,7 @@ public class ConfirmUpload extends DialogFragment
 	private static final String TAG = "fragment_confirm_upload";
 	
 	private static final char LINE_DELIMITER = '\n';
+	private static final String LINE_PREFIX = "- ";
 
 	static public void showDialog(FragmentActivity activity) {
 		dismissDialog(activity);
@@ -176,7 +177,7 @@ public class ConfirmUpload extends DialogFragment
 		List<String> changes = App.getLogic().getPendingChanges(ctx);
 		StringBuilder builder = new StringBuilder();
 		for (String change : changes) {
-			builder.append(change).append(LINE_DELIMITER);
+			builder.append(LINE_PREFIX).append(change).append(LINE_DELIMITER);
 		}
 		return builder.toString();
 	}

--- a/src/main/java/de/blau/android/dialogs/ConfirmUpload.java
+++ b/src/main/java/de/blau/android/dialogs/ConfirmUpload.java
@@ -172,11 +172,11 @@ public class ConfirmUpload extends DialogFragment
 	 */
 	public String getPendingChanges(Context ctx) {
 		List<String> changes = App.getLogic().getPendingChanges(ctx);
-		StringBuilder retval = new StringBuilder();
+		StringBuilder builder = new StringBuilder();
 		for (String change : changes) {
-			retval.append(change).append('\n');
+			builder.append(change).append('\n');
 		}
-		return retval.toString();
+		return builder.toString();
 	}
     
 	/**

--- a/src/main/java/de/blau/android/dialogs/ConfirmUpload.java
+++ b/src/main/java/de/blau/android/dialogs/ConfirmUpload.java
@@ -1,5 +1,6 @@
 package de.blau.android.dialogs;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.acra.ACRA;
@@ -36,6 +37,8 @@ import de.blau.android.listener.UploadListener;
 import de.blau.android.prefs.Preferences;
 import de.blau.android.util.FilterlessArrayAdapter;
 import de.blau.android.util.ThemeUtils;
+import de.blau.android.validation.NotEmptyValidator;
+import de.blau.android.validation.FormValidation;
 
 /**
  * Dialog for final review of changes and adding comment and source tags before upload
@@ -162,13 +165,21 @@ public class ConfirmUpload extends DialogFragment
 		source.setOnClickListener(autocompleteOnClick);
 		source.setThreshold(1);
 		source.setOnKeyListener(new MyKeyListener());
-		
-		builder.setPositiveButton(R.string.transfer_download_current_upload, 
-				new UploadListener((Main) activity, comment, source, closeChangeset));
+
+		FormValidation commentValidator = new NotEmptyValidator(comment,
+				getString(R.string.upload_validation_error_empty_comment));
+		FormValidation sourceValidator = new NotEmptyValidator(source,
+				getString(R.string.upload_validation_error_empty_source));
+		List<FormValidation> validators = Arrays.asList(commentValidator, sourceValidator);
+
+		builder.setPositiveButton(R.string.transfer_download_current_upload, null);
 		builder.setNegativeButton(R.string.no, doNothingListener);
 
-    	return builder.create();
-    }	
+		AlertDialog dialog = builder.create();
+		dialog.setOnShowListener(new UploadListener((Main) activity,
+				comment, source, closeChangeset, validators));
+		return dialog;
+    }
     
 	/**
 	 * @return a list of all pending changes to upload (contains newlines)

--- a/src/main/java/de/blau/android/dialogs/ConfirmUpload.java
+++ b/src/main/java/de/blau/android/dialogs/ConfirmUpload.java
@@ -135,7 +135,7 @@ public class ConfirmUpload extends DialogFragment
 		CheckBox closeChangeset = (CheckBox)layout.findViewById(R.id.upload_close_changeset);
 		closeChangeset.setChecked(new Preferences(activity).closeChangesetOnSave());
 		AutoCompleteTextView comment = (AutoCompleteTextView)layout.findViewById(R.id.upload_comment);
-        FilterlessArrayAdapter<String> commentAdapter = new FilterlessArrayAdapter<String>(activity,
+        FilterlessArrayAdapter<String> commentAdapter = new FilterlessArrayAdapter<>(activity,
                 android.R.layout.simple_dropdown_item_1line, App.getLogic().getLastComments());
         comment.setAdapter(commentAdapter);
 		String lastComment = App.getLogic().getLastComment();
@@ -153,7 +153,7 @@ public class ConfirmUpload extends DialogFragment
 		comment.setOnKeyListener(new MyKeyListener());
 		
 		AutoCompleteTextView source = (AutoCompleteTextView)layout.findViewById(R.id.upload_source);
-		FilterlessArrayAdapter<String> sourceAdapter = new FilterlessArrayAdapter<String>(activity,
+		FilterlessArrayAdapter<String> sourceAdapter = new FilterlessArrayAdapter<>(activity,
                 android.R.layout.simple_dropdown_item_1line, App.getLogic().getLastSources());
         source.setAdapter(sourceAdapter);
 		String lastSource = App.getLogic().getLastSource();

--- a/src/main/java/de/blau/android/dialogs/ConfirmUpload.java
+++ b/src/main/java/de/blau/android/dialogs/ConfirmUpload.java
@@ -95,7 +95,7 @@ public class ConfirmUpload extends DialogFragment
         super.onAttach(activity);
         Log.d(DEBUG_TAG, "onAttach");
         if (!(activity instanceof Main)) {
-            throw new ClassCastException(activity.toString() + " can ownly be called from Main");
+            throw new ClassCastException(activity.toString() + " can only be called from Main");
         }
     }
     

--- a/src/main/java/de/blau/android/dialogs/ConfirmUpload.java
+++ b/src/main/java/de/blau/android/dialogs/ConfirmUpload.java
@@ -50,6 +50,8 @@ public class ConfirmUpload extends DialogFragment
 	
 	private static final String TAG = "fragment_confirm_upload";
 	
+	private static final char LINE_DELIMITER = '\n';
+
 	static public void showDialog(FragmentActivity activity) {
 		dismissDialog(activity);
 
@@ -174,7 +176,7 @@ public class ConfirmUpload extends DialogFragment
 		List<String> changes = App.getLogic().getPendingChanges(ctx);
 		StringBuilder builder = new StringBuilder();
 		for (String change : changes) {
-			builder.append(change).append('\n');
+			builder.append(change).append(LINE_DELIMITER);
 		}
 		return builder.toString();
 	}

--- a/src/main/java/de/blau/android/listener/UploadListener.java
+++ b/src/main/java/de/blau/android/listener/UploadListener.java
@@ -1,36 +1,80 @@
 package de.blau.android.listener;
 
 import android.content.DialogInterface;
-import android.content.DialogInterface.OnClickListener;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AlertDialog;
+import android.view.View;
+import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
+
+import java.util.List;
+
 import de.blau.android.Main;
 import de.blau.android.dialogs.ConfirmUpload;
+import de.blau.android.util.mapbox.utils.TextUtils;
+import de.blau.android.validation.FormValidation;
 
 /**
  * @author mb
  */
-public class UploadListener implements OnClickListener {
-	
+public class UploadListener implements DialogInterface.OnShowListener, View.OnClickListener {
+
 	private final Main caller;
 	private final EditText commentField;
 	private final EditText sourceField;
 	private final CheckBox closeChangeset;
-	
+	@NonNull
+	private final List<FormValidation> validations;
+
 	/**
 	 * @param caller
 	 * @param closeChangeset TODO
 	 */
-	public UploadListener(final Main caller, final EditText commentField, final EditText sourceField, final CheckBox closeChangeset) {
+	public UploadListener(final Main caller,
+						  final EditText commentField,
+						  final EditText sourceField,
+						  final CheckBox closeChangeset,
+						  @NonNull final List<FormValidation> validations) {
 		this.caller = caller;
 		this.commentField = commentField;
 		this.sourceField = sourceField;
 		this.closeChangeset = closeChangeset;
+		this.validations = validations;
 	}
-	
+
 	@Override
-	public void onClick(final DialogInterface dialog, final int which) {
-		ConfirmUpload.dismissDialog(caller);
-		caller.performUpload(commentField.getText().toString(), sourceField.getText().toString(), closeChangeset.isChecked());
+	public void onShow(final DialogInterface dialog) {
+		Button button = ((AlertDialog) dialog).getButton(DialogInterface.BUTTON_POSITIVE);
+		button.setOnClickListener(this);
+	}
+
+	@Override
+	public void onClick(View view) {
+		validateFields();
+		if (canBeUploaded()) {
+			ConfirmUpload.dismissDialog(caller);
+			caller.performUpload(
+					commentField.getText().toString(),
+					sourceField.getText().toString(),
+					closeChangeset.isChecked());
+		}
+	}
+
+	private void validateFields() {
+		for (FormValidation validation : validations) {
+			validation.validate();
+		}
+	}
+
+	@SuppressWarnings("RedundantIfStatement")
+	private boolean canBeUploaded() {
+		if (!TextUtils.isEmpty(commentField.getError())) {
+			return false;
+		}
+		if (!TextUtils.isEmpty(sourceField.getError())) {
+			return false;
+		}
+		return true;
 	}
 }

--- a/src/main/java/de/blau/android/validation/EditTextValidator.java
+++ b/src/main/java/de/blau/android/validation/EditTextValidator.java
@@ -1,0 +1,56 @@
+package de.blau.android.validation;
+
+import android.support.annotation.NonNull;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.widget.EditText;
+
+abstract class EditTextValidator implements TextWatcher, FormValidation {
+
+    private static final String EMPTY_TEXT = "";
+
+    @NonNull
+    private final EditText editText;
+
+    EditTextValidator(@NonNull EditText editText) {
+        this.editText = editText;
+        this.editText.addTextChangedListener(this);
+    }
+
+    @Override
+    public void beforeTextChanged(CharSequence charSequence, int start, int count, int after) {
+        // Nothing to do here.
+    }
+
+    @Override
+    public void onTextChanged(CharSequence charSequence, int start, int before, int count) {
+        // Nothing to do here.
+    }
+
+    @Override
+    public void afterTextChanged(Editable editable) {
+        validate();
+    }
+
+    @Override
+    public void validate() {
+        Editable editable = editText.getText();
+        String text = editable == null ? EMPTY_TEXT : editable.toString();
+        if (isValid(text)) {
+            clearError();
+        } else {
+            showError(getErrorText());
+        }
+    }
+
+    protected abstract boolean isValid(@NonNull String text);
+
+    private void showError(@NonNull String errorText) {
+        editText.setError(errorText);
+    }
+
+    private void clearError() {
+        editText.setError(null);
+    }
+
+}

--- a/src/main/java/de/blau/android/validation/FormValidation.java
+++ b/src/main/java/de/blau/android/validation/FormValidation.java
@@ -1,0 +1,12 @@
+package de.blau.android.validation;
+
+import android.support.annotation.NonNull;
+
+public interface FormValidation {
+
+    void validate();
+
+    @NonNull
+    String getErrorText();
+
+}

--- a/src/main/java/de/blau/android/validation/NotEmptyValidator.java
+++ b/src/main/java/de/blau/android/validation/NotEmptyValidator.java
@@ -1,0 +1,27 @@
+package de.blau.android.validation;
+
+import android.support.annotation.NonNull;
+import android.widget.EditText;
+
+public class NotEmptyValidator extends EditTextValidator {
+
+    @NonNull
+    private final String errorText;
+
+    public NotEmptyValidator(@NonNull EditText editText, @NonNull String errorText) {
+        super(editText);
+        this.errorText = errorText;
+    }
+
+    @Override
+    protected boolean isValid(@NonNull String text) {
+        return !text.isEmpty();
+    }
+
+    @NonNull
+    @Override
+    public String getErrorText() {
+        return errorText;
+    }
+
+}

--- a/src/main/res/layout/upload_comment.xml
+++ b/src/main/res/layout/upload_comment.xml
@@ -20,11 +20,12 @@
 	      android:id="@+id/upload_comment"
 	      android:layout_below="@id/upload_comment_label"
 	      android:layout_alignLeft="@id/upload_comment_label"
+	      android:layout_alignStart="@id/upload_comment_label"
 	      android:layout_width="fill_parent"
 	      android:layout_height="wrap_content"
 	      android:inputType="text"
 	      />
-	
+
 	  <TextView
 	      android:id="@+id/upload_source_label"
 	      android:layout_width="wrap_content"
@@ -38,6 +39,7 @@
 	      android:layout_width="fill_parent"
 	      android:layout_height="wrap_content"
 	      android:layout_alignLeft="@id/upload_source_label"
+	      android:layout_alignStart="@id/upload_source_label"
 	      android:inputType="text"/>
 		<TextView
 	      android:id="@+id/upload_close_changeset_label"
@@ -52,6 +54,7 @@
 	       android:layout_height="48dp"
 	       android:gravity="center_vertical"
 	       android:layout_below="@id/upload_source"
+	       android:layout_alignEnd="@id/upload_source"
 	       android:layout_alignRight="@id/upload_source"
 	       android:layout_alignBottom="@id/upload_close_changeset_label"
 	       android:layout_alignTop="@id/upload_close_changeset_label"
@@ -59,7 +62,7 @@
 	     />
 
 	</RelativeLayout>
- 
+
   <ScrollView
     android:layout_alignParentTop="true"
     android:layout_above="@id/upload_comment_controls"

--- a/src/main/res/layout/upload_comment.xml
+++ b/src/main/res/layout/upload_comment.xml
@@ -1,79 +1,85 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="fill_parent"
-  android:layout_height="fill_parent">
-
-  <RelativeLayout
-      android:id="@+id/upload_comment_controls"
-      android:layout_marginRight="?attr/dialogPreferredPadding"
-      android:layout_marginLeft="?attr/dialogPreferredPadding"
-      android:layout_width="fill_parent"
-	  android:layout_height="wrap_content"
-      android:layout_alignParentBottom="true">
-	    <TextView
-	      android:id="@+id/upload_comment_label"
-	      android:layout_width="wrap_content"
-	      android:layout_height="48dp"
-	      android:gravity="center_vertical"
-	      android:text="@string/upload_comment_label"/>
-	    <AutoCompleteTextView
-	      android:id="@+id/upload_comment"
-	      android:layout_below="@id/upload_comment_label"
-	      android:layout_alignLeft="@id/upload_comment_label"
-	      android:layout_alignStart="@id/upload_comment_label"
-	      android:layout_width="fill_parent"
-	      android:layout_height="wrap_content"
-	      android:inputType="text"
-	      />
-
-	  <TextView
-	      android:id="@+id/upload_source_label"
-	      android:layout_width="wrap_content"
-	      android:layout_height="36dp"
-	      android:gravity="center_vertical"
-	      android:layout_below="@id/upload_comment"
-	      android:text="@string/upload_source_label"/>
-	   <AutoCompleteTextView
-	      android:id="@+id/upload_source"
-	      android:layout_below="@id/upload_source_label"
-	      android:layout_width="fill_parent"
-	      android:layout_height="wrap_content"
-	      android:layout_alignLeft="@id/upload_source_label"
-	      android:layout_alignStart="@id/upload_source_label"
-	      android:inputType="text"/>
-		<TextView
-	      android:id="@+id/upload_close_changeset_label"
-	      android:layout_width="wrap_content"
-	      android:layout_height="36dp"
-	      android:gravity="center_vertical"
-	      android:layout_below="@id/upload_source"
-	      android:text="@string/upload_close_changeset_label"/>
-	   <CheckBox
-	       android:id="@+id/upload_close_changeset"
-	       android:layout_width="wrap_content"
-	       android:layout_height="48dp"
-	       android:gravity="center_vertical"
-	       android:layout_below="@id/upload_source"
-	       android:layout_alignEnd="@id/upload_source"
-	       android:layout_alignRight="@id/upload_source"
-	       android:layout_alignBottom="@id/upload_close_changeset_label"
-	       android:layout_alignTop="@id/upload_close_changeset_label"
-	       android:text=""
-	     />
-
-	</RelativeLayout>
-
-  <ScrollView
-    android:layout_alignParentTop="true"
-    android:layout_above="@id/upload_comment_controls"
     android:layout_width="fill_parent"
-    android:layout_height="wrap_content"
-    android:paddingLeft="?attr/dialogPreferredPadding"
-    android:paddingRight="?attr/dialogPreferredPadding" >
-    <TextView
-      android:id="@+id/upload_changes"
-      android:layout_width="fill_parent"
-      android:layout_height="wrap_content"
-      android:text=""/>
-  </ScrollView>
+    android:layout_height="fill_parent">
+
+    <RelativeLayout
+        android:id="@+id/upload_comment_controls"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_marginLeft="?attr/dialogPreferredPadding"
+        android:layout_marginRight="?attr/dialogPreferredPadding">
+
+        <TextView
+            android:id="@+id/upload_comment_label"
+            android:layout_width="wrap_content"
+            android:layout_height="48dp"
+            android:gravity="center_vertical"
+            android:text="@string/upload_comment_label" />
+
+        <AutoCompleteTextView
+            android:id="@+id/upload_comment"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignLeft="@id/upload_comment_label"
+            android:layout_alignStart="@id/upload_comment_label"
+            android:layout_below="@id/upload_comment_label"
+            android:inputType="text" />
+
+        <TextView
+            android:id="@+id/upload_source_label"
+            android:layout_width="wrap_content"
+            android:layout_height="36dp"
+            android:layout_below="@id/upload_comment"
+            android:gravity="center_vertical"
+            android:text="@string/upload_source_label" />
+
+        <AutoCompleteTextView
+            android:id="@+id/upload_source"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignLeft="@id/upload_source_label"
+            android:layout_alignStart="@id/upload_source_label"
+            android:layout_below="@id/upload_source_label"
+            android:inputType="text" />
+
+        <TextView
+            android:id="@+id/upload_close_changeset_label"
+            android:layout_width="wrap_content"
+            android:layout_height="36dp"
+            android:layout_below="@id/upload_source"
+            android:gravity="center_vertical"
+            android:text="@string/upload_close_changeset_label" />
+
+        <CheckBox
+            android:id="@+id/upload_close_changeset"
+            android:layout_width="wrap_content"
+            android:layout_height="48dp"
+            android:layout_alignBottom="@id/upload_close_changeset_label"
+            android:layout_alignEnd="@id/upload_source"
+            android:layout_alignRight="@id/upload_source"
+            android:layout_alignTop="@id/upload_close_changeset_label"
+            android:layout_below="@id/upload_source"
+            android:gravity="center_vertical"
+            android:text="" />
+
+    </RelativeLayout>
+
+    <ScrollView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_above="@id/upload_comment_controls"
+        android:layout_alignParentTop="true"
+        android:paddingLeft="?attr/dialogPreferredPadding"
+        android:paddingRight="?attr/dialogPreferredPadding">
+
+        <TextView
+            android:id="@+id/upload_changes"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="" />
+
+    </ScrollView>
+
 </RelativeLayout>

--- a/src/main/res/layout/upload_comment.xml
+++ b/src/main/res/layout/upload_comment.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent">
 
@@ -78,7 +79,8 @@
             android:id="@+id/upload_changes"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:text="" />
+            android:text=""
+            tools:text="@string/confirm_multiple_upload_text" />
 
     </ScrollView>
 

--- a/src/main/res/layout/upload_comment.xml
+++ b/src/main/res/layout/upload_comment.xml
@@ -1,77 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
 
-    <RelativeLayout
-        android:id="@+id/upload_comment_controls"
+    <LinearLayout
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:layout_marginLeft="?attr/dialogPreferredPadding"
-        android:layout_marginRight="?attr/dialogPreferredPadding">
-
-        <TextView
-            android:id="@+id/upload_comment_label"
-            android:layout_width="wrap_content"
-            android:layout_height="48dp"
-            android:gravity="center_vertical"
-            android:text="@string/upload_comment_label" />
-
-        <AutoCompleteTextView
-            android:id="@+id/upload_comment"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignLeft="@id/upload_comment_label"
-            android:layout_alignStart="@id/upload_comment_label"
-            android:layout_below="@id/upload_comment_label"
-            android:inputType="text" />
-
-        <TextView
-            android:id="@+id/upload_source_label"
-            android:layout_width="wrap_content"
-            android:layout_height="36dp"
-            android:layout_below="@id/upload_comment"
-            android:gravity="center_vertical"
-            android:text="@string/upload_source_label" />
-
-        <AutoCompleteTextView
-            android:id="@+id/upload_source"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignLeft="@id/upload_source_label"
-            android:layout_alignStart="@id/upload_source_label"
-            android:layout_below="@id/upload_source_label"
-            android:inputType="text" />
-
-        <TextView
-            android:id="@+id/upload_close_changeset_label"
-            android:layout_width="wrap_content"
-            android:layout_height="36dp"
-            android:layout_below="@id/upload_source"
-            android:gravity="center_vertical"
-            android:text="@string/upload_close_changeset_label" />
-
-        <CheckBox
-            android:id="@+id/upload_close_changeset"
-            android:layout_width="wrap_content"
-            android:layout_height="48dp"
-            android:layout_alignBottom="@id/upload_close_changeset_label"
-            android:layout_alignEnd="@id/upload_source"
-            android:layout_alignRight="@id/upload_source"
-            android:layout_alignTop="@id/upload_close_changeset_label"
-            android:layout_below="@id/upload_source"
-            android:gravity="center_vertical"
-            android:text="" />
-
-    </RelativeLayout>
-
-    <ScrollView
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_above="@id/upload_comment_controls"
-        android:layout_alignParentTop="true"
+        android:orientation="vertical"
         android:paddingLeft="?attr/dialogPreferredPadding"
         android:paddingRight="?attr/dialogPreferredPadding">
 
@@ -82,6 +19,67 @@
             android:text=""
             tools:text="@string/confirm_multiple_upload_text" />
 
-    </ScrollView>
+        <RelativeLayout
+            android:id="@+id/upload_comment_controls"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:gravity="bottom">
 
-</RelativeLayout>
+            <TextView
+                android:id="@+id/upload_comment_label"
+                android:layout_width="wrap_content"
+                android:layout_height="48dp"
+                android:gravity="center_vertical"
+                android:text="@string/upload_comment_label" />
+
+            <AutoCompleteTextView
+                android:id="@+id/upload_comment"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_alignLeft="@id/upload_comment_label"
+                android:layout_alignStart="@id/upload_comment_label"
+                android:layout_below="@id/upload_comment_label"
+                android:inputType="text" />
+
+            <TextView
+                android:id="@+id/upload_source_label"
+                android:layout_width="wrap_content"
+                android:layout_height="36dp"
+                android:layout_below="@id/upload_comment"
+                android:gravity="center_vertical"
+                android:text="@string/upload_source_label" />
+
+            <AutoCompleteTextView
+                android:id="@+id/upload_source"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_alignLeft="@id/upload_source_label"
+                android:layout_alignStart="@id/upload_source_label"
+                android:layout_below="@id/upload_source_label"
+                android:inputType="text" />
+
+            <TextView
+                android:id="@+id/upload_close_changeset_label"
+                android:layout_width="wrap_content"
+                android:layout_height="36dp"
+                android:layout_below="@id/upload_source"
+                android:gravity="center_vertical"
+                android:text="@string/upload_close_changeset_label" />
+
+            <CheckBox
+                android:id="@+id/upload_close_changeset"
+                android:layout_width="wrap_content"
+                android:layout_height="48dp"
+                android:layout_alignBottom="@id/upload_close_changeset_label"
+                android:layout_alignEnd="@id/upload_source"
+                android:layout_alignRight="@id/upload_source"
+                android:layout_alignTop="@id/upload_close_changeset_label"
+                android:layout_below="@id/upload_source"
+                android:gravity="center_vertical"
+                android:text="" />
+
+        </RelativeLayout>
+
+    </LinearLayout>
+
+</ScrollView>

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -560,7 +560,7 @@
   <string name="changes_changed">\"%1$s\" verändert</string>
   <string name="changes_created">\"%1$s\" angelegt</string>
   <string name="confirm_upload_title">Hochladen?</string>
-  <string name="confirm_one_upload_text">Soll die folgende Änderung hochgeladen werden?\n%1$s</string>
+  <string name="confirm_one_upload_text">Soll die folgende Änderung hochgeladen werden?\n\n%1$s</string>
   <string name="confirm_multiple_upload_text">Sollen folgende %1$d Änderungen hochgeladen werden?\n%2$s</string>
   <!--url handler activity-->
   <string name="urldialog_add_preset">Vorlage hinzufügen</string>

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -64,6 +64,8 @@
   <string name="upload_gpx_description_label">Beschreibung</string>
   <string name="upload_gpx_tags_label">Tags</string>
   <string name="upload_gpx_visibility_label">Sichtbarkeit</string>
+  <string name="upload_validation_error_empty_comment">Kommentar kann nicht leer sein</string>
+  <string name="upload_validation_error_empty_source">Quelle kann nicht leer sein</string>
   <string name="openstreetbug_new_title">Neue Notiz</string>
   <string name="openstreetbug_new_bug">Fehler melden</string>
   <string name="openstreetbug_bug_title">Problem</string>

--- a/src/main/res/values-gl/strings.xml
+++ b/src/main/res/values-gl/strings.xml
@@ -558,8 +558,8 @@
   <string name="changes_changed">\"%1$s\" modificado</string>
   <string name="changes_created">\"%1$s\" creado</string>
   <string name="confirm_upload_title">Subir?</string>
-  <string name="confirm_one_upload_text">Cargar a seguinte modificación?\n %1$s</string>
-  <string name="confirm_multiple_upload_text">Subir os seguintes %1$d trocos?\n%2$s</string>
+  <string name="confirm_one_upload_text">Cargar a seguinte modificación?\n\n%1$s</string>
+  <string name="confirm_multiple_upload_text">Subir os seguintes %1$d trocos?\n\n%2$s</string>
   <!--url handler activity-->
   <string name="urldialog_add_preset">Engadir preaxuste</string>
   <string name="urldialog_preset_exists">Este preaxuste xa existe</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -564,8 +564,8 @@
     <string name="changes_changed">"%1$s" changed</string>
     <string name="changes_created">"%1$s" created</string>
     <string name="confirm_upload_title">Upload?</string>
-    <string name="confirm_one_upload_text">Upload the following change?\n%1$s</string>
-    <string name="confirm_multiple_upload_text">Upload the following %1$d changes?\n%2$s</string>
+    <string name="confirm_one_upload_text">Upload the following change?\n\n%1$s</string>
+    <string name="confirm_multiple_upload_text">Upload the following %1$d changes?\n\n%2$s</string>
     <!-- url handler activity -->
     <string name="urldialog_add_preset">Add preset</string>
     <string name="urldialog_preset_exists">This preset already exists</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -65,6 +65,8 @@
     <string name="upload_gpx_description_label">Description</string>
     <string name="upload_gpx_tags_label">Tags</string>
     <string name="upload_gpx_visibility_label">Visibility</string>
+    <string name="upload_validation_error_empty_comment">Comment cannot be empty</string>
+    <string name="upload_validation_error_empty_source">Source cannot be empty</string>
     <string name="openstreetbug_new_title">New Note</string>
     <string name="openstreetbug_new_bug">Report Issue</string>
     <string name="openstreetbug_bug_title">Issue</string>


### PR DESCRIPTION
I refactored the "upload changes" dialog a bit so that the user can scroll the whole content (changes list and form fields). Before it was quite tricky to review the list of changes once the keyboard is open. The screen recording shows the new behavior.

![vespucci](https://user-images.githubusercontent.com/144518/27699896-29c0534e-5cfc-11e7-8bf5-74e707d17ae0.gif)
