### PR TITLE
issue template: hide hint in later issue

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -31,4 +31,4 @@ Please note that some components are maintained in upstream repositories and rel
 <!-- required -->
 
 ## Any other potentially relevant information
-<!-- required -->
+<!-- optional -->

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -7,28 +7,28 @@ Please note that some components are maintained in upstream repositories and rel
 * opening hours user interface: https://github.com/simonpoole/OpeningHoursFragment
 
 ## Vespucci Version
-(required, see advanced preference of debug information screen in the preferences)
+<!-- required, see advanced preference of debug information screen in the preferences -->
 
 ## Download source
-(from where did you obtain the app? google play store, amazon, f-droid, github, ...)
+<!-- from where did you obtain the app? google play store, amazon, f-droid, github, ... -->
 
 ## Device (Manufacturer and Model)
-(required)
+<!-- required -->
 
 ## Android Version 
-(required, please indicate if you are using a custom version)
+<!-- required, please indicate if you are using a custom version -->
 
 ## Behaviour/Symptoms
-(required)
+<!-- required -->
 
 ## Expected Behaviour
-(required)
+<!-- required -->
 
 ## How to recreate
-(required)
+<!-- required -->
 
 ## Crash dump submitted (no or yes + date)
-(required)
+<!-- required -->
 
 ## Any other potentially relevant information
-(optional)
+<!-- required -->


### PR DESCRIPTION
It is quite confusing reading an issue like #688 
You have to read every line to know if it was a question or an answer.

inspired from [typescript template](https://raw.githubusercontent.com/Microsoft/TypeScript/master/issue_template.md).