### PR TITLE
issue template: hide more text in new created issues

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,3 +1,4 @@
+<!--
 When reporting issues, please use this template, if you are asking for an enhancement you can delete the text.
 
 Please note that some components are maintained in upstream repositories and relevant issues should be reported there, these are specifically:
@@ -6,6 +7,7 @@ Please note that some components are maintained in upstream repositories and rel
 * presets: https://github.com/simonpoole/beautified-JOSM-preset
 * opening hours user interface: https://github.com/simonpoole/OpeningHoursFragment
 * name-related tag suggestions database: https://github.com/osmlab/name-suggestion-index
+-->
 
 ## Vespucci Version
 <!-- required, see advanced preference of debug information screen in the preferences -->


### PR DESCRIPTION
follow up from #689

Since a few weeks we can have [multiple issue template](https://help.github.com/articles/about-issue-and-pull-request-templates/). Again [typescript repository](https://github.com/Microsoft/TypeScript/issues/new/choose) as an example.
But i am not sure if we need it here. 