### PR TITLE
Update Urls.java

### DIFF
--- a/src/main/java/de/blau/android/contract/Urls.java
+++ b/src/main/java/de/blau/android/contract/Urls.java
@@ -12,24 +12,24 @@ public interface Urls {
     String DEFAULT_SANDBOX_API       = "https://master.apis.dev.openstreetmap.org/api/0.6/";
     String DEFAULT_SANDBOX_API_NAME  = "OpenStreetMap sandbox";
 
-    String DEFAULT_NOMINATIM_SERVER = "http://nominatim.openstreetmap.org/";
-    String DEFAULT_PHOTON_SERVER    = "http://photon.komoot.de/";
+    String DEFAULT_NOMINATIM_SERVER = "httsp://nominatim.openstreetmap.org/";
+    String DEFAULT_PHOTON_SERVER    = "https://photon.komoot.de/";
 
-    String DEFAULT_OSMOSE_SERVER = "http://osmose.openstreetmap.fr/";
+    String DEFAULT_OSMOSE_SERVER = "https://osmose.openstreetmap.fr/";
 
     String DEFAULT_OFFSET_SERVER = "http://offsets.textual.ru/";
 
     String DEFAULT_TAGINFO_SERVER = "https://taginfo.openstreetmap.org/";
 
     // currently not configurable
-    String WIKIPEDIA = "http://en.wikipedia.org/wiki/";
-    String WIKIDATA  = "http://wikidata.org/wiki/";
+    String WIKIPEDIA = "https://en.wikipedia.org/wiki/";
+    String WIKIDATA  = "https://wikidata.org/wiki/";
 
     String OSM       = "https://openstreetmap.org";
     String OSM_LOGIN = "https://www.openstreetmap.org/login";
     String OSM_WIKI  = "https://wiki.openstreetmap.org/";
 
-    String ELI = "https://raw.githubusercontent.com/osmlab/editor-layer-index/gh-pages/imagery.geojson";
+    String ELI = "https://osmlab.github.io/editor-layer-index/imagery.geojson";
 
     String OAM_SERVER = "https://api.openaerialmap.org/";
 }


### PR DESCRIPTION
Use a stable URL for imagery.geojson and upgrade URLs to https where possible.

DEFAULT_API_NO_HTTPS will now redirect to https anyway, I'm not sure it should be kept.