### PR TITLE
DEFAULT_MAX_ZOOM -> 22

### DIFF
--- a/src/main/java/de/blau/android/resources/TileLayerServer.java
+++ b/src/main/java/de/blau/android/resources/TileLayerServer.java
@@ -357,7 +357,7 @@ public class TileLayerServer {
     private static final int PREFERENCE_BEST    = 10;
 
     public static final int DEFAULT_MIN_ZOOM     = 0;
-    public static final int DEFAULT_MAX_ZOOM     = 18;
+    public static final int DEFAULT_MAX_ZOOM     = 22;
     public static final int DEFAULT_MAX_OVERZOOM = 4;
 
     public static final int DEFAULT_TILE_SIZE = 256;


### PR DESCRIPTION
The current DEFAULT_MAX_ZOOM of 18 is quite conservative. This brings it up to 22, which matches iD's behaviour.