### PR TITLE
make translation documentation more accessible

### DIFF
--- a/TRANSLATIONS.md
+++ b/TRANSLATIONS.md
@@ -4,9 +4,7 @@ You can translate this program into your language using [transifex](https://www.
 
 ## Technical issues
 
-All the translatable text in Vespucci has been concentrated into one file per language called 'strings.xml'.
-
-There are strings elsewhere in Vespucci that would be nice to be translated, but it is currently technically difficult to make them available. The background layer descriptions are one example.
+The background/overlay names and descriptions are not translatable as iD traslation system for them is non-standard. Somebody would need to code a workaround to fix that part.
 
 NOTE: for building we assume for now that the github repository contains the current language files which the maintainers will commit now and then. If you want to add or change one of the existing default (English) strings you need to make a pull request against this repository.
 

--- a/TRANSLATIONS.md
+++ b/TRANSLATIONS.md
@@ -1,10 +1,12 @@
+## Translating Vespucci
+
+You can translate this program into your language using [transifex](https://www.transifex.com/projects/p/vespucci/) project.
+
+## Technical issues
+
 All the translatable text in Vespucci has been concentrated into one file per language called 'strings.xml'.
 
 There are strings elsewhere in Vespucci that would be nice to be translated, but it is currently technically difficult to make them available. The background layer descriptions are one example.
-
-## transifex
-
-The translations are managed on [transifex](https://www.transifex.com/projects/p/vespucci/)
 
 NOTE: for building we assume for now that the github repository contains the current language files which the maintainers will commit now and then. If you want to add or change one of the existing default (English) strings you need to make a pull request against this repository.
 


### PR DESCRIPTION
it is typical that many people in software projects contribute solely by translating

this change intends to make documentation more accessible for them and make it more likely
that person looking at it will contrubute to translating effort