### PR TITLE
Trust jcenter the least.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,11 +28,11 @@ import de.undercouch.gradle.tasks.download.Download
 allprojects {
     repositories {
         mavenCentral()
-        jcenter()
         maven { url 'https://dl.bintray.com/content/simonpoole/div' }
         maven { url 'https://dl.bintray.com/content/simonpoole/android' }
         maven { url "https://maven.google.com" }
         maven { url "https://jitpack.io" }
+        jcenter()
         //		flatDir {
         //        	dirs 'lib'
         //    	}


### PR DESCRIPTION
+ See: https://blog.autsoft.hu/a-confusing-dependency/
+ I recommend to empty your local cache such as `~/.gradle/caches/modules-2/files-2.1/*` and the cache on your CI machine if available.