### PR TITLE
Adding marker to shareOnOsm.org url

### DIFF
--- a/src/main/java/de/blau/android/ShareOnOpenStreetMap.java
+++ b/src/main/java/de/blau/android/ShareOnOpenStreetMap.java
@@ -26,7 +26,7 @@ public class ShareOnOpenStreetMap extends Activity {
         Log.d(DEBUG_TAG, data.toString());
         GeoUrlData geoUrlData = GeoUrlData.parse(data.getSchemeSpecificPart());
         if (geoUrlData != null) {
-            String url = Urls.OSM + "#map=" + (geoUrlData.hasZoom() ? geoUrlData.getZoom() : 18) + "/" + geoUrlData.getLat() + "/" + geoUrlData.getLon();
+            String url = Urls.OSM + "/?mlat=" + geoUrlData.getLat() + "&mlon=" + geoUrlData.getLon() +  "#map=" + (geoUrlData.hasZoom() ? geoUrlData.getZoom() : 18) + "/" + geoUrlData.getLat() + "/" + geoUrlData.getLon();
             Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
             startActivity(intent);
         }


### PR DESCRIPTION
Without a marker it is not easy to see which position was shared.
Feel free to close this PR if you disagree.