### PR TITLE
fix markdown-gradle-plugin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
-        classpath 'org.kordamp:markdown-gradle-plugin:2.0.0'
+        classpath 'org.kordamp:markdown-gradle-plugin:1.2.0'
         classpath 'org.jacoco:org.jacoco.core:0.8.4'
         // classpath 'com.trickyandroid:jacoco-everywhere:0.2.1'
         classpath "ch.poole:preset-utils:0.8.1"


### PR DESCRIPTION
it allows Vespucci to compile (on my computer)
it is version documented at https://github.com/aalmiray/markdown-gradle-plugin#installation
fixes #917

I have no idea at all what may be broken by this change and why it was required for me - is it possible that my computer is somehow broken and unable to fetch 2.0.0 version that is available?