### PR TITLE
Support fixed length list/array semantics for multi-selects

### DIFF
--- a/src/main/java/de/blau/android/presets/Preset.java
+++ b/src/main/java/de/blau/android/presets/Preset.java
@@ -192,6 +192,8 @@ public class Preset implements Serializable {
     private static final String COUNT                      = "count";
     private static final String REQUISITE                  = "requisite";
     private static final String MEMBER_EXPRESSION          = "member_expression";
+    private static final String REF                        = "ref";
+    private static final String VALUE_COUNT_KEY            = "value_count_key";
     /**
      * 
      */
@@ -1008,6 +1010,10 @@ public class Preset implements Serializable {
                     if (javaScript != null) {
                         ((PresetComboField) field).setScript(javaScript);
                     }
+                    String valueCountKey = attr.getValue(VALUE_COUNT_KEY);
+                    if (valueCountKey != null) {
+                        ((PresetComboField) field).setValueCountKey(valueCountKey);
+                    }
                     break;
                 case ROLES:
                     break;
@@ -1023,8 +1029,8 @@ public class Preset implements Serializable {
                     currentItem.addRole(role);
                     break;
                 case REFERENCE:
-                    PresetItem chunk = chunks.get(attr.getValue("ref")); // note this assumes that there are no
-                                                                         // forward references
+                    PresetItem chunk = chunks.get(attr.getValue(REF)); // note this assumes that there are no
+                                                                       // forward references
                     if (chunk != null) {
                         if (inOptionalSection) {
                             // fixed tags don't make sense in an optional section, and doesn't seem to happen in
@@ -1041,7 +1047,7 @@ public class Preset implements Serializable {
                                     copy.setOptional(true);
                                     currentItem.fields.put(copy.getKey(), copy);
                                 } else {
-                                    Log.e(DEBUG_TAG, "Error in PresetItem " + currentItem.getName() + " chunk " + attr.getValue("ref") + " field " + key
+                                    Log.e(DEBUG_TAG, "Error in PresetItem " + currentItem.getName() + " chunk " + attr.getValue(REF) + " field " + key
                                             + " overwrites existing field");
                                 }
                             }

--- a/src/main/java/de/blau/android/presets/PresetComboField.java
+++ b/src/main/java/de/blau/android/presets/PresetComboField.java
@@ -49,6 +49,11 @@ public class PresetComboField extends PresetField implements PresetFieldJavaScri
     private String valuesContext = null;
 
     /**
+     * Reference to key of tag holding the number of values this field should hold
+     */
+    private String valueCountKey;
+
+    /**
      * Constructor
      * 
      * @param key the key for this PresetCheckField
@@ -241,6 +246,25 @@ public class PresetComboField extends PresetField implements PresetFieldJavaScri
      */
     void setValuesSearchable(boolean valuesSearchable) {
         this.valuesSearchable = valuesSearchable;
+    }
+
+    /**
+     * Name of a key that contains the number of values this field should have
+     * 
+     * @param valueCountKey the key name
+     */
+    void setValueCountKey(@Nullable String valueCountKey) {
+        this.valueCountKey = valueCountKey;
+    }
+
+    /**
+     * Get the name of a key containing the number of values this field should have
+     * 
+     * @return the name of the key with count or null
+     */
+    @Nullable
+    public String getValueCountKey() {
+        return valueCountKey;
     }
 
     @Override

--- a/src/main/java/de/blau/android/propertyeditor/EditorUpdate.java
+++ b/src/main/java/de/blau/android/propertyeditor/EditorUpdate.java
@@ -24,7 +24,7 @@ public interface EditorUpdate {
     /**
      * Update or add multiple keys
      * 
-     * @param tags map containing the new key - value pais
+     * @param tags map containing the new key - value pairs
      * @param flush if true delete all existing tags before applying the update
      */
     void updateTags(@NonNull final Map<String, String> tags, final boolean flush);

--- a/src/main/java/de/blau/android/propertyeditor/TagChanged.java
+++ b/src/main/java/de/blau/android/propertyeditor/TagChanged.java
@@ -1,0 +1,15 @@
+package de.blau.android.propertyeditor;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public interface TagChanged {
+    
+    /**
+     * Notify that a tag has changed
+     * 
+     * @param key the key
+     * @param value the value, if null assume the tag has been deleted
+     */
+    void changed(@NonNull String key, @Nullable String value);
+}

--- a/src/main/java/de/blau/android/propertyeditor/TagEditorFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/TagEditorFragment.java
@@ -2450,7 +2450,7 @@ public class TagEditorFragment extends BaseFragment implements PropertyRows, Edi
                     // this will fill up any missing fields
                     try {
                         int valueCount = Integer.parseInt(valueCountValue);
-                        long currentCount = value.codePoints().filter(ch -> ch == delimiter).count() + 1;
+                        long currentCount = Util.countChar(value, delimiter) + 1;
                         if (currentCount < valueCount) {
                             for (long i = currentCount; i < valueCount; i++) {
                                 value += delimiter; // NOSONAR

--- a/src/main/java/de/blau/android/propertyeditor/TagEditorFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/TagEditorFragment.java
@@ -67,6 +67,7 @@ import de.blau.android.presets.Preset.UseLastAsDefault;
 import de.blau.android.presets.Preset.ValueType;
 import de.blau.android.presets.PresetCheckField;
 import de.blau.android.presets.PresetCheckGroupField;
+import de.blau.android.presets.PresetComboField;
 import de.blau.android.presets.PresetElementPath;
 import de.blau.android.presets.PresetField;
 import de.blau.android.presets.PresetFieldJavaScript;
@@ -2440,11 +2441,37 @@ public class TagEditorFragment extends BaseFragment implements PropertyRows, Edi
         if (pi != null) {
             PresetField field = pi.getField(key);
             boolean useLastAsDefault = field != null && field.getUseLastAsDefault() != UseLastAsDefault.FALSE;
-            if (pi.getKeyType(key) == PresetKeyType.MULTISELECT) {
-                // trim potential trailing separators
-                char delimter = pi.getDelimiter(key);
-                if (value.endsWith(String.valueOf(delimter))) {
-                    value = value.substring(0, value.length() - 1);
+            if (field instanceof PresetComboField && ((PresetComboField) field).isMultiSelect()) {
+                // trim potential trailing separators, or ensure that we have as many fields as we are supposed to
+                char delimiter = pi.getDelimiter(key);
+                String valueCountKey = ((PresetComboField) field).getValueCountKey();
+                String valueCountValue = valueCountKey != null ? result.get(valueCountKey) : null;
+                if (valueCountValue != null) {
+                    // this will fill up any missing fields
+                    try {
+                        int valueCount = Integer.parseInt(valueCountValue);
+                        long currentCount = value.codePoints().filter(ch -> ch == delimiter).count() + 1;
+                        if (currentCount < valueCount) {
+                            for (long i = currentCount; i < valueCount; i++) {
+                                value += delimiter; // NOSONAR
+                            }
+                        } else if (currentCount > valueCount) {
+                            // only remove trailing delimiters
+                            for (int i = valueCount; i < currentCount; i++) {
+                                if (value.endsWith(String.valueOf(delimiter))) {
+                                    value = value.substring(0, value.length() - 1);
+                                } else {
+                                    break;
+                                }
+                            }
+                        }
+                    } catch (NumberFormatException nfex) {
+                        // something is wrong, don't touch value
+                    }
+                } else {
+                    if (value.endsWith(String.valueOf(delimiter))) {
+                        value = value.substring(0, value.length() - 1);
+                    }
                 }
                 List<String> values = Preset.splitValues(Util.wrapInList(value), pi, key);
                 if (values != null) {

--- a/src/main/java/de/blau/android/propertyeditor/tagform/CheckGroupDialogRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/CheckGroupDialogRow.java
@@ -171,17 +171,17 @@ public class CheckGroupDialogRow extends MultiselectDialogRow {
                         PresetCheckField check = (PresetCheckField) checkBox.getTag();
                         String checkKey = check.getKey();
                         if (state == null) {
-                            caller.tagListener.updateSingleValue(checkKey, "");
+                            caller.updateSingleValue(checkKey, "");
                             keyValues.put(checkKey, "");
                         } else if (!checkBox.isEnabled()) {
                             // unknown stuff
                             keyValues.put(checkKey, keyValues.get(checkKey));
                         } else if (state) { // NOSONAR state can't be null here
-                            caller.tagListener.updateSingleValue(checkKey, check.getOnValue().getValue());
+                            caller.updateSingleValue(checkKey, check.getOnValue().getValue());
                             keyValues.put(checkKey, check.getOnValue().getValue());
                         } else {
                             StringWithDescription offValue = check.getOffValue();
-                            caller.tagListener.updateSingleValue(checkKey, offValue == null ? "" : offValue.getValue());
+                            caller.updateSingleValue(checkKey, offValue == null ? "" : offValue.getValue());
                             keyValues.put(checkKey, offValue == null ? "" : offValue.getValue());
                         }
                         if (rowLayout instanceof EditableLayout) {
@@ -306,7 +306,7 @@ public class CheckGroupDialogRow extends MultiselectDialogRow {
                     }
                 }
             }
-            caller.tagListener.updateTags(ourKeyValues, false); // batch update
+            caller.updateTags(ourKeyValues, false); // batch update
             row.setSelectedValues(ourKeyValues);
             row.setChanged(true);
         });

--- a/src/main/java/de/blau/android/propertyeditor/tagform/ComboDialogRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/ComboDialogRow.java
@@ -208,7 +208,7 @@ public class ComboDialogRow extends DialogRow {
         }
         final Handler handler = new Handler();
         builder.setPositiveButton(R.string.clear, (dialog, which) -> {
-            caller.tagListener.updateSingleValue((String) layout.getTag(), "");
+            caller.updateSingleValue((String) layout.getTag(), "");
             row.setValue("", "");
             row.setChanged(true);
             // allow a tiny bit of time to see that the action actually worked
@@ -223,7 +223,7 @@ public class ComboDialogRow extends DialogRow {
             if (checkedId != -1) {
                 RadioButton button = (RadioButton) group.findViewById(checkedId);
                 ourValue = (StringWithDescription) button.getTag();
-                caller.tagListener.updateSingleValue((String) layout.getTag(), ourValue.getValue());
+                caller.updateSingleValue((String) layout.getTag(), ourValue.getValue());
                 row.setValue(ourValue);
                 row.setChanged(true);
             }

--- a/src/main/java/de/blau/android/propertyeditor/tagform/ComboRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/ComboRow.java
@@ -212,7 +212,7 @@ public class ComboRow extends LinearLayout {
                         RadioButton button = (RadioButton) group.findViewById(checkedId);
                         v = (String) button.getTag();
                     }
-                    caller.tagListener.updateSingleValue(key, v);
+                    caller.updateSingleValue(key, v);
                     if (rowLayout instanceof EditableLayout) {
                         ((EditableLayout) rowLayout).putTag(key, v);
                     }

--- a/src/main/java/de/blau/android/propertyeditor/tagform/MultiselectDialogRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/MultiselectDialogRow.java
@@ -235,7 +235,7 @@ public class MultiselectDialogRow extends DialogRow {
                 }
             }
             row.setValue(valueList);
-            caller.tagListener.updateSingleValue((String) layout.getTag(), row.getValue());
+            caller.updateSingleValue((String) layout.getTag(), row.getValue());
             row.setChanged(true);
         });
         builder.setNegativeButton(R.string.cancel, null);

--- a/src/main/java/de/blau/android/propertyeditor/tagform/MultiselectRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/MultiselectRow.java
@@ -160,7 +160,7 @@ public class MultiselectRow extends LinearLayout {
         if (adapter != null) {
             row.setDelimiter(preset.getDelimiter(key));
             CompoundButton.OnCheckedChangeListener onCheckedChangeListener = (buttonView, isChecked) -> {
-                caller.tagListener.updateSingleValue(key, row.getValue());
+                caller.updateSingleValue(key, row.getValue());
                 if (rowLayout instanceof EditableLayout) {
                     ((EditableLayout) rowLayout).putTag(key, row.getValue());
                 }

--- a/src/main/java/de/blau/android/propertyeditor/tagform/OpeningHoursDialogRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/OpeningHoursDialogRow.java
@@ -152,7 +152,7 @@ public class OpeningHoursDialogRow extends MultiselectDialogRow {
             try {
                 rules = parser.rules(false);
                 value = ch.poole.openinghoursparser.Util.rulesToOpeningHoursString(rules);
-                caller.tagListener.updateSingleValue(key, value);
+                caller.updateSingleValue(key, value);
                 lenientSucceeded = true;
             } catch (Exception e1) {
                 // failed
@@ -213,7 +213,7 @@ public class OpeningHoursDialogRow extends MultiselectDialogRow {
             List<String> isoCodes = caller.propertyEditorListener.getIsoCodes();
             OpeningHoursFragment openingHoursDialog = OpeningHoursFragment.newInstance(keyWithDescription,
                     isoCodes != null && !isoCodes.isEmpty() ? isoCodes.get(0) : null,
-                    preset != null ? preset.getObjectTag(App.getCurrentPresets(caller.getContext()), caller.tagListener.getKeyValueMapSingle(false)) : null,
+                    preset != null ? preset.getObjectTag(App.getCurrentPresets(caller.getContext()), caller.getKeyValueMapSingle(false)) : null,
                     finalValue, caller.prefs.lightThemeEnabled() ? R.style.Theme_AppCompat_Light_Dialog_Alert : R.style.Theme_AppCompat_Dialog_Alert, -1, true,
                     textValues);
             openingHoursDialog.show(fm, FRAGMENT_OPENING_HOURS_TAG);

--- a/src/main/java/de/blau/android/propertyeditor/tagform/TextRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/TextRow.java
@@ -216,7 +216,7 @@ public class TextRow extends LinearLayout implements KeyValueRow {
             Log.d(DEBUG_TAG, "onFocusChange");
             String rowValue = row.getValue();
             if (!hasFocus && !rowValue.equals(value)) {
-                caller.tagListener.updateSingleValue(key, rowValue);
+                caller.updateSingleValue(key, rowValue);
                 if (rowLayout instanceof EditableLayout) {
                     ((EditableLayout) rowLayout).putTag(key, rowValue);
                 }
@@ -238,7 +238,7 @@ public class TextRow extends LinearLayout implements KeyValueRow {
             Object o = parent.getItemAtPosition(position);
             if (o instanceof Names.NameAndTags) {
                 ourValueView.setOrReplaceText(((NameAndTags) o).getName());
-                caller.tagListener.applyTagSuggestions(((NameAndTags) o).getTags(), caller::update);
+                caller.applyTagSuggestions(((NameAndTags) o).getTags(), caller::update);
                 caller.update();
                 return;
             } else if (o instanceof ValueWithCount) {
@@ -248,7 +248,7 @@ public class TextRow extends LinearLayout implements KeyValueRow {
             } else if (o instanceof String) {
                 ourValueView.setOrReplaceText((String) o);
             }
-            caller.tagListener.updateSingleValue(key, row.getValue());
+            caller.updateSingleValue(key, row.getValue());
             if (rowLayout instanceof EditableLayout) {
                 ((EditableLayout) rowLayout).putTag(key, row.getValue());
             }

--- a/src/main/java/de/blau/android/propertyeditor/tagform/UrlDialogRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/UrlDialogRow.java
@@ -105,7 +105,7 @@ public class UrlDialogRow extends DialogRow {
 
         builder.setPositiveButton(R.string.save, (dialog, which) -> {
             String ourValue = input.getText().toString();
-            caller.tagListener.updateSingleValue((String) layout.getTag(), ourValue);
+            caller.updateSingleValue((String) layout.getTag(), ourValue);
             row.setValue(ourValue);
             row.setChanged(true);
         });

--- a/src/main/java/de/blau/android/util/Util.java
+++ b/src/main/java/de/blau/android/util/Util.java
@@ -734,4 +734,21 @@ public final class Util {
         url += (url.contains("?") ? (url.endsWith("?") ? "" : "&") : "?") + query;
         return url;
     }
+
+    /**
+     * Naive counting of how many times a char is present in a string
+     * 
+     * @param string the String
+     * @param c the char
+     * @return the count
+     */
+    public static int countChar(@NonNull String string, char c) {
+        int count = 0;
+        for (int i = 0; i < string.length(); i++) {
+            if (c == string.charAt(i)) {
+                count++;
+            }
+        }
+        return count;
+    }
 }


### PR DESCRIPTION
This adds support for a "value_count_key" attribute in presets that
refers to a tag that holds the number of values that should be present.

MultiTextRow has been modified so that when such a tag is present it
will try to always show the correct number of rows and concatenate them
with array semantics.

The bulk of the file changes result from re-routing the "updateSingleValue" callback through TagFormFragment instead of directly calling PropertyEditor.