### PR TITLE
Merge and reverse operations issue reporting re-factoring

### DIFF
--- a/src/main/java/de/blau/android/Main.java
+++ b/src/main/java/de/blau/android/Main.java
@@ -4298,7 +4298,7 @@ public class Main extends FullScreenAppCompatActivity
     /**
      * Schedule automatic locking of the screen in a configurable time in the future
      */
-    void scheduleAutoLock() {
+    public void scheduleAutoLock() {
         map.removeCallbacks(autoLock);
         if (prefs != null) {
             int delay = prefs.getAutolockDelay();

--- a/src/main/java/de/blau/android/dialogs/ConfirmUpload.java
+++ b/src/main/java/de/blau/android/dialogs/ConfirmUpload.java
@@ -189,7 +189,7 @@ public class ConfirmUpload extends ImmersiveDialogFragment {
             byte elemenState = element.getState();
             boolean deleted = elemenState == OsmElement.STATE_DELETED;
             if (elemenState == OsmElement.STATE_MODIFIED || deleted) {
-                ElementInfo.showDialog(getActivity(), App.getDelegator().getUndo().getOriginal(element), element, !deleted);
+                ElementInfo.showDialog(getActivity(), 0, element, !deleted);
             } else {
                 ElementInfo.showDialog(getActivity(), element, !deleted);
             }

--- a/src/main/java/de/blau/android/dialogs/TagConflictDialog.java
+++ b/src/main/java/de/blau/android/dialogs/TagConflictDialog.java
@@ -1,0 +1,201 @@
+package de.blau.android.dialogs;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.text.SpannableString;
+import android.text.SpannableStringBuilder;
+import android.text.style.ForegroundColorSpan;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.WindowManager;
+import android.widget.ArrayAdapter;
+import android.widget.ListView;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatDialog;
+import androidx.fragment.app.FragmentManager;
+import de.blau.android.App;
+import de.blau.android.Main;
+import de.blau.android.R;
+import de.blau.android.osm.Issue;
+import de.blau.android.osm.OsmElement;
+import de.blau.android.osm.Result;
+import de.blau.android.util.ImmersiveDialogFragment;
+import de.blau.android.util.ThemeUtils;
+import de.blau.android.util.Util;
+
+public class TagConflictDialog extends ImmersiveDialogFragment {
+    private static final String DEBUG_TAG = TagConflictDialog.class.getSimpleName();
+
+    private static final String TAG = "fragment_tag_conflict";
+
+    private static final String RESULTS_KEY = "results";
+
+    private List<Result> result;
+
+    /**
+     * Show a dialog with a list of issues
+     * 
+     * @param activity the calling FragmentActivity
+     * @param result the List of Result elements
+     */
+    public static void showDialog(@NonNull AppCompatActivity activity, @NonNull List<Result> result) {
+        dismissDialog(activity);
+        try {
+            FragmentManager fm = activity.getSupportFragmentManager();
+            TagConflictDialog tagConflictFragment = newInstance(result);
+            tagConflictFragment.show(fm, TAG);
+        } catch (IllegalStateException isex) {
+            Log.e(DEBUG_TAG, "showDialog", isex);
+        }
+    }
+
+    /**
+     * Dismiss the Dialog
+     * 
+     * @param activity the calling FragmentActivity
+     */
+    private static void dismissDialog(@NonNull AppCompatActivity activity) {
+        de.blau.android.dialogs.Util.dismissDialog(activity, TAG);
+    }
+
+    /**
+     * Create new instance of this object
+     * 
+     * @param result the List of Result elements
+     * @return a TagConflictDialog instance
+     */
+    private static TagConflictDialog newInstance(@NonNull List<Result> result) {
+        TagConflictDialog f = new TagConflictDialog();
+        Bundle args = new Bundle();
+        args.putSerializable(RESULTS_KEY, (Serializable) result);
+
+        f.setArguments(args);
+        f.setShowsDialog(true);
+
+        return f;
+    }
+
+    @NonNull
+    @Override
+    @SuppressWarnings("unchecked")
+    @SuppressLint("InflateParams")
+    public AppCompatDialog onCreateDialog(Bundle savedInstanceState) {
+        if (savedInstanceState != null) {
+            result = (List<Result>) savedInstanceState.getSerializable(RESULTS_KEY);
+            // restore the elements
+            for (Result r : result) {
+                r.restoreElement(App.getDelegator());
+            }
+        } else {
+            result = (List<Result>) getArguments().getSerializable(RESULTS_KEY);
+        }
+        final LayoutInflater inflater = ThemeUtils.getLayoutInflater(getActivity());
+        View layout = inflater.inflate(R.layout.tag_conflict, null);
+        AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
+        builder.setTitle(R.string.tag_conflict_title);
+        builder.setMessage(R.string.tag_conflict_message);
+
+        ListView list = layout.findViewById(R.id.elements);
+        list.setAdapter(new ResultArrayAdapter(getContext(), R.layout.tag_conflict_item, R.id.text1, result));
+        list.setOnItemClickListener((parent, view, position, id) -> {
+            Result clicked = result.get(position);
+            OsmElement element = clicked.getElement();
+            ElementInfo.showDialog(getActivity(), App.getDelegator().getUndo().getUndoElements(element).size() - 1, element, false);
+        });
+        builder.setView(layout);
+        builder.setPositiveButton(R.string.done, null);
+        return builder.create();
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        getDialog().getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
+        Tip.showDialog(getActivity(), R.string.tip_tag_conflict_key, R.string.tip_tag_conflict);
+    }
+
+    @Override
+    public void onDismiss(DialogInterface dialog) {
+        super.onDismiss(dialog);
+        if (getActivity() instanceof Main) {
+            ((Main) getActivity()).scheduleAutoLock();
+        }
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        Log.d(DEBUG_TAG, "onSaveInstanceState");
+        // directly saving OsmElements is a bad idea
+        for (Result r : result) {
+            r.saveElement();
+        }
+        outState.putSerializable(RESULTS_KEY, new ArrayList<Result>(result));
+        Log.w(DEBUG_TAG, "onSaveInstanceState bundle size " + Util.getBundleSize(outState));
+    }
+
+    /**
+     * Highlight results that have a potential issue
+     * 
+     * @author Simon Poole
+     *
+     */
+    private class ResultArrayAdapter extends ArrayAdapter<Result> {
+        final List<Result> results;
+        final int          warningColor;
+        final int          errorColor;
+
+        /**
+         * Construct a new instance of the Adapter
+         * 
+         * @param context an Android COntext
+         * @param layout the layout id
+         * @param resource the id of the TextView in the layout
+         * @param results the List of Result
+         */
+        public ResultArrayAdapter(@NonNull Context context, int layout, int resource, @NonNull List<Result> results) {
+            super(context, layout, resource, results);
+            this.results = results;
+            errorColor = ThemeUtils.getStyleAttribColorValue(getContext(), R.color.material_red, 0xFFF44336);
+            warningColor = ThemeUtils.getStyleAttribColorValue(getContext(), R.color.material_orange, 0xFFFF9800);
+        }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup container) {
+            View v = super.getView(position, convertView, container);
+            TextView elementView = (TextView) v.findViewById(R.id.text1);
+            if (elementView != null) {
+                final Result r = results.get(position);
+                OsmElement element = r.getElement();
+                elementView.setText(element.getDescription(getContext()));
+                SpannableStringBuilder spanBuilder = new SpannableStringBuilder();
+                if (r.hasIssue()) {
+                    for (Issue issue : r.getIssues()) {
+                        SpannableString issueSpan = new SpannableString(issue.toTranslatedString(getContext()));
+                        issueSpan.setSpan(new ForegroundColorSpan(issue.isError() ? errorColor : warningColor), 0, issueSpan.length(), 0);
+                        spanBuilder.append(issueSpan);
+                        spanBuilder.append(" ");
+                    }
+                } else {
+                    Log.w(DEBUG_TAG, "Element " + element.getDescription(getContext()) + " has no issues");
+                }
+                TextView issueView = (TextView) v.findViewById(R.id.issues);
+                issueView.setText(spanBuilder);
+            } else {
+                Log.e("ResultAdapterView", "position " + position + " view is null");
+            }
+            return v;
+        }
+    }
+}

--- a/src/main/java/de/blau/android/easyedit/EasyEditActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/EasyEditActionModeCallback.java
@@ -11,7 +11,6 @@ import android.view.View;
 import android.view.ViewStub;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.view.ActionMode;
 import androidx.appcompat.widget.ActionMenuView;
 import de.blau.android.App;
@@ -21,7 +20,6 @@ import de.blau.android.Main;
 import de.blau.android.R;
 import de.blau.android.osm.Node;
 import de.blau.android.osm.OsmElement;
-import de.blau.android.osm.Result;
 import de.blau.android.osm.Tags;
 import de.blau.android.osm.Way;
 import de.blau.android.prefs.Preferences;
@@ -331,19 +329,5 @@ public abstract class EasyEditActionModeCallback implements ActionMode.Callback 
             }
         }
         return result;
-    }
-
-    /**
-     * Show an AlertDialog when we've had a merge conflict
-     * 
-     * @param result a MergeResult object from the operation
-     */
-    protected void showConflictAlert(@NonNull Result<?> result) {
-        // TODO detailed message
-        AlertDialog.Builder builder = new AlertDialog.Builder(main);
-        builder.setMessage(R.string.toast_merge_tag_conflict);
-        builder.setNegativeButton(R.string.cancel, null);
-        builder.setPositiveButton(R.string.edit, (dialog, which) -> main.performTagEdit(result.getElement(), null, false, false));
-        builder.show();
     }
 }

--- a/src/main/java/de/blau/android/easyedit/ElementSelectionActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/ElementSelectionActionModeCallback.java
@@ -26,7 +26,6 @@ import de.blau.android.osm.OsmElement;
 import de.blau.android.osm.Relation;
 import de.blau.android.osm.RelationMember;
 import de.blau.android.osm.Tags;
-import de.blau.android.osm.UndoStorage.UndoElement;
 import de.blau.android.osm.Way;
 import de.blau.android.prefs.PrefEditor;
 import de.blau.android.prefs.Preferences;
@@ -275,12 +274,7 @@ public abstract class ElementSelectionActionModeCallback extends EasyEditActionM
             main.descheduleAutoLock();
             // as we want to display relation membership changes too
             // we can't rely on the element status
-            UndoElement ue = App.getDelegator().getUndo().getOriginal(element);
-            if (ue != null) {
-                ElementInfo.showDialog(main, ue, element, false);
-            } else {
-                ElementInfo.showDialog(main, element);
-            }
+            ElementInfo.showDialog(main, 0, element, false);
             break;
         case MENUITEM_UPLOAD:
             main.descheduleAutoLock();

--- a/src/main/java/de/blau/android/easyedit/WayMergingActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/WayMergingActionModeCallback.java
@@ -1,5 +1,6 @@
 package de.blau.android.easyedit;
 
+import java.util.List;
 import java.util.Set;
 
 import android.content.res.Resources.NotFoundException;
@@ -8,8 +9,8 @@ import android.view.Menu;
 import androidx.annotation.NonNull;
 import androidx.appcompat.view.ActionMode;
 import de.blau.android.R;
+import de.blau.android.dialogs.TagConflictDialog;
 import de.blau.android.exception.OsmIllegalOperationException;
-import de.blau.android.osm.MergeIssue;
 import de.blau.android.osm.OsmElement;
 import de.blau.android.osm.Result;
 import de.blau.android.osm.Way;
@@ -56,10 +57,12 @@ public class WayMergingActionModeCallback extends NonSimpleActionModeCallback {
             return false;
         }
         try {
-            Result<MergeIssue> result = logic.performMerge(main, way, (Way) element);
-            main.startSupportActionMode(new WaySelectionActionModeCallback(manager, (Way) result.getElement()));
-            if (result.hasIssue()) {
-                showConflictAlert(result);
+            List<Result> result = logic.performMerge(main, way, (Way) element);
+            Result r = result.get(0);
+            main.startSupportActionMode(new WaySelectionActionModeCallback(manager, (Way) r.getElement()));
+            if (result.size() > 1 || r.hasIssue()) {
+                main.descheduleAutoLock();
+                TagConflictDialog.showDialog(main, result);
             }
         } catch (OsmIllegalOperationException e) {
             Snack.barError(main, e.getLocalizedMessage());

--- a/src/main/java/de/blau/android/osm/Issue.java
+++ b/src/main/java/de/blau/android/osm/Issue.java
@@ -1,0 +1,15 @@
+package de.blau.android.osm;
+
+import java.io.Serializable;
+
+import de.blau.android.util.TranslatedString;
+
+public interface Issue extends Serializable, TranslatedString {
+
+    /**
+     * Check if this is an error or just a warning
+     * 
+     * @return true if an error
+     */
+    public boolean isError();
+}

--- a/src/main/java/de/blau/android/osm/MergeIssue.java
+++ b/src/main/java/de/blau/android/osm/MergeIssue.java
@@ -1,5 +1,29 @@
 package de.blau.android.osm;
 
-public enum MergeIssue {
-    ROLECONFLICT, MERGEDTAGS, NOTREVERSABLE, SAMEOBJECT
+import android.content.Context;
+import de.blau.android.R;
+
+public enum MergeIssue implements Issue {
+    ROLECONFLICT, MERGEDTAGS, NOTREVERSABLE, SAMEOBJECT;
+
+    @Override
+    public String toTranslatedString(Context context) {
+        switch (this) {
+        case ROLECONFLICT:
+            return context.getString(R.string.issue_role_conflict);
+        case MERGEDTAGS:
+            return context.getString(R.string.issue_merged_tags);
+        case NOTREVERSABLE:
+            return context.getString(R.string.issue_not_reversable);
+        case SAMEOBJECT:
+            return context.getString(R.string.issue_same_object);
+        default:
+            return "";
+        }
+    }
+
+    @Override
+    public boolean isError() {
+        return true;
+    }
 }

--- a/src/main/java/de/blau/android/osm/Result.java
+++ b/src/main/java/de/blau/android/osm/Result.java
@@ -1,7 +1,9 @@
 package de.blau.android.osm;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import androidx.annotation.NonNull;
@@ -13,10 +15,18 @@ import androidx.annotation.Nullable;
  * @author Simon
  *
  */
-public class Result<T> {
+public class Result implements Serializable {
 
-    private OsmElement element;
-    Set<T>             issues = null;
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 2L;
+
+    private OsmElement          element;
+    private Set<Issue>          issues = null;
+    private Map<String, String> tags   = null;
+    private String              elementType;
+    private long                elementId;
 
     /**
      * Empty default constructor
@@ -38,7 +48,7 @@ public class Result<T> {
      * 
      * @param issue the MergeIssue to add
      */
-    public void addIssue(@NonNull T issue) {
+    public void addIssue(@NonNull Issue issue) {
         if (issues == null) {
             issues = new HashSet<>();
         }
@@ -50,7 +60,7 @@ public class Result<T> {
      * 
      * @param issues a Collection containing Issues
      */
-    public void addAllIssues(@NonNull Collection<T> issues) {
+    public void addAllIssues(@NonNull Collection<Issue> issues) {
         if (this.issues == null) {
             this.issues = new HashSet<>();
         }
@@ -72,7 +82,7 @@ public class Result<T> {
      * @return a Collection of Issues
      */
     @Nullable
-    public Collection<T> getIssues() {
+    public Collection<Issue> getIssues() {
         return issues;
     }
 
@@ -92,5 +102,58 @@ public class Result<T> {
      */
     public void setElement(OsmElement element) {
         this.element = element;
+    }
+
+    /**
+     * Get any relevant tags or null
+     * 
+     * @return the tags
+     */
+    @Nullable
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
+    /**
+     * Add relevant tags for the result
+     * 
+     * @param tags the tags to add
+     */
+    public void addTags(@NonNull Map<String, String> tags) {
+        if (this.tags == null) {
+            this.tags = tags;
+        } else {
+            this.tags.putAll(tags);
+        }
+    }
+
+    /**
+     * Save type and id of element, and zap element
+     */
+    public void saveElement() {
+        elementType = element.getName();
+        elementId = element.getOsmId();
+        element = null;
+    }
+
+    /**
+     * Restore the element from the saved values
+     * 
+     * @param delegator the current StorageDelegator element
+     */
+    public void restoreElement(@NonNull StorageDelegator delegator) {
+        element = delegator.getOsmElement(elementType, elementId);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder b = new StringBuilder(element.getDescription());
+        if (hasIssue()) {
+            for (Issue issue : issues) {
+                b.append(" ");
+                b.append(issue.toString());
+            }
+        }
+        return b.toString();
     }
 }

--- a/src/main/java/de/blau/android/osm/Reverse.java
+++ b/src/main/java/de/blau/android/osm/Reverse.java
@@ -121,7 +121,6 @@ final class Reverse {
                     }
                     if (rm.role != null && Tags.ROLE_BACKWARD.equals(rm.role)) {
                         rm.setRole(Tags.ROLE_FORWARD);
-                        continue;
                     }
                 }
             }

--- a/src/main/java/de/blau/android/osm/ReverseIssue.java
+++ b/src/main/java/de/blau/android/osm/ReverseIssue.java
@@ -1,0 +1,29 @@
+package de.blau.android.osm;
+
+import android.content.Context;
+import de.blau.android.R;
+
+public enum ReverseIssue implements Issue {
+    NOTREVERSABLE, SHAREDNODE, TAGSREVERSED, ROLEREVERSED;
+
+    @Override
+    public String toTranslatedString(Context context) {
+        switch (this) {
+        case NOTREVERSABLE:
+            return context.getString(R.string.issue_not_reversable);
+        case SHAREDNODE:
+            return context.getString(R.string.issue_shared_node);
+        case TAGSREVERSED:
+            return context.getString(R.string.issue_tags_reversed);
+        case ROLEREVERSED:
+            return context.getString(R.string.issue_role_reversed);
+        default:
+            return "";
+        }
+    }
+
+    @Override
+    public boolean isError() {
+        return this != TAGSREVERSED && this != ROLEREVERSED;
+    }
+}

--- a/src/main/java/de/blau/android/osm/UndoStorage.java
+++ b/src/main/java/de/blau/android/osm/UndoStorage.java
@@ -1019,15 +1019,28 @@ public class UndoStorage implements Serializable {
      */
     @Nullable
     public UndoElement getOriginal(@NonNull OsmElement element) {
-        UndoElement result = null;
+        List<UndoElement> undoElements = getUndoElements(element);
+        if (!undoElements.isEmpty()) {
+            return undoElements.get(0);
+        }
+        return null;
+    }
+
+    /**
+     * Get a list of all UndoElements for a specific element
+     * 
+     * @param element the OsmElement
+     * @return a List of UndoElement empty if nothing found
+     */
+    @NonNull
+    public List<UndoElement> getUndoElements(@NonNull OsmElement element) {
+        List<UndoElement> result = new ArrayList<>();
         String name = element.getName();
         long osmId = element.getOsmId();
-        int checkpointCount = undoCheckpoints.size();
-        // loop over most recent to oldest checkpoint
-        for (int i = checkpointCount - 1; i >= 0; i--) {
-            for (UndoElement undoElement : undoCheckpoints.get(i).elements.values()) {
+        for (Checkpoint checkpoint : undoCheckpoints) {
+            for (UndoElement undoElement : checkpoint.elements.values()) {
                 if (undoElement.element.getName().equals(name) && undoElement.osmId == osmId) {
-                    result = undoElement;
+                    result.add(undoElement);
                     break;
                 }
             }

--- a/src/main/java/de/blau/android/util/TranslatedString.java
+++ b/src/main/java/de/blau/android/util/TranslatedString.java
@@ -1,0 +1,16 @@
+package de.blau.android.util;
+
+import android.content.Context;
+import androidx.annotation.NonNull;
+
+public interface TranslatedString {
+
+    /**
+     * Return a (potentially) translated String representation of this object
+     * 
+     * @param context an Android Context
+     * @return a translated string
+     */
+    @NonNull
+    public String toTranslatedString(@NonNull Context context);
+}

--- a/src/main/res/layout/tag_conflict.xml
+++ b/src/main/res/layout/tag_conflict.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ListView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/elements"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:paddingLeft="?attr/dialogPreferredPadding"
+    android:paddingRight="?attr/dialogPreferredPadding" />

--- a/src/main/res/layout/tag_conflict_item.xml
+++ b/src/main/res/layout/tag_conflict_item.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        android:paddingTop="4dp"
+        android:paddingBottom="4dp"
+        android:gravity="center_vertical"
+        android:drawableRight="?attr/information_small"
+        android:drawableEnd="?attr/information_small" 
+        android:layout_weight="1" />
+    <TextView
+        android:id="@+id/issues"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        android:paddingTop="4dp"
+        android:paddingBottom="4dp"
+        android:gravity="center_vertical" 
+        android:layout_weight="1" />
+</LinearLayout>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -183,8 +183,10 @@
     <string name="empty_role">Empty role</string>
     <string name="last_edited">Last edited</string>
     <string name="original">Original</string>
+    <string name="previous">Previous</string>
     <string name="current">Current</string>
     <string name="goto_element">Go to element</string>
+    <string name="edit_properties">Edit Tags</string>
     <!--  GeoJSON feature display dialog -->
     <string name="feature_information">GeoJSON feature info</string>
     <string name="copy_properties">Copy properties</string>
@@ -313,6 +315,9 @@
     <string name="api_info_latest_date">Last included date</string>
     <string name="api_info_attribution">Attribution</string>
     <string name="api_info_mapsplit_source">MapSplit read only source</string>
+    <!-- Tag conflict dialog -->
+    <string name="tag_conflict_title">Tags changed</string>
+    <string name="tag_conflict_message">The operation required changing tags on the elements involved.</string>
     <!--  Undo - Redo dialog -->
     <string name="checkpoints">Checkpoints</string>
     <string name="undo_redo_title">Undo - redo</string>
@@ -342,6 +347,7 @@ avoided by using an offline data source.</string>
     <string name="tip_locked_mode">In locked mode you can\'t edit, but a long press on an object will open a display with detailed information.</string>
     <string name="tip_longpress_simple_mode">In simple mode a long press will not do anything. Turn simple mode off in the main menu if you want to use long clicks to create objects.</string>
     <string name="tip_gpx_no_elevation">Starting with version 15, GPX tracks no longer contain elevation information by default.&lt;p&gt;To enable elevation recording, install a Geoid model with &lt;i&gt;Install EGM&lt;/i&gt; from the Tools menu, or switch to NMEA input.</string>
+    <string name="tip_tag_conflict">Merging and reversing OSM elements sometimes requires changing attributes on the elements, if there is a potential error or conflict you are alerted to this and are offered an opportunity to review the objects in question.</string>
     <!--  NumberPicker -->
     <string name="plus_sign">+</string>
     <string name="minus_sign">-</string>
@@ -371,7 +377,6 @@ avoided by using an offline data source.</string>
     <string name="toast_merge_overwrote_tags">Note - operation overwrote tag(s)</string>
     <string name="toast_cant_autoapply_preset">This preset can\'t be auto-applied</string>
     <string name="toast_oneway_reversed">You reversed a oneway street or a way with directionally dependent tags. Please check the tags and correct them if needed.</string>
-    <string name="toast_merge_tag_conflict">You merged elements with conflicting tag values, direction dependent semantics or different roles in the same relation. Please check the tags and roles and correct them if needed.</string>
     <string name="toast_potential_merge_tag_conflict">You are trying to merge elements with conflicting tag values.\n\nPlease check the tags and correct them before trying again.</string>
     <string name="toast_state_file_failed">Unreadable or corrupt state file</string>
     <string name="toast_way_nodes_moved">%1$d nodes in moved way</string>
@@ -1173,6 +1178,14 @@ avoided by using an offline data source.</string>
     <string name="bridge">Bridge</string>
     <string name="tunnel">Tunnel</string>
     <string name="culvert">Culvert</string>
+    <!-- Tag issues -->
+    <string name="issue_not_reversable">Tags not reversable</string>
+    <string name="issue_shared_node">Shared with other way</string>
+    <string name="issue_tags_reversed">Tags reversed</string>
+    <string name="issue_role_reversed">Role reversed</string>
+    <string name="issue_role_conflict">Role conflict</string>
+    <string name="issue_merged_tags">Merged tags</string>
+    <string name="issue_same_object">Same object</string>
     <!-- time and distance -->
     <plurals name="days">
         <item quantity="one">1 day</item>

--- a/src/main/res/values/tipkeys.xml
+++ b/src/main/res/values/tipkeys.xml
@@ -8,4 +8,5 @@
     <string name="tip_locked_mode_key">lockedMode</string>
     <string name="tip_longpress_simple_mode_key">longPressSimpleMode</string>
     <string name="tip_gpx_no_elevation_key">gpxNoElevation</string>
+    <string name="tip_tag_conflict_key">tagConflict</string>
 </resources>


### PR DESCRIPTION
This improves on the previous implementation

- by reporting issues for all affected objects (that is including nodes)

- making it easier to see the individual changes and if necessary edit
the tags

As a side effect the ElementInfo dialog now supports comparing with any
undo checkpoint version of the element in question.