### PR TITLE
Adjust GPX coordinate precision

### DIFF
--- a/src/main/java/de/blau/android/gpx/TrackPoint.java
+++ b/src/main/java/de/blau/android/gpx/TrackPoint.java
@@ -225,10 +225,10 @@ public class TrackPoint implements InterruptibleGeoPoint, Serializable {
      */
     public synchronized void toXml(@NonNull XmlSerializer serializer, @NonNull GpxTimeFormater gtf) throws IOException {
         serializer.startTag(null, TRKPT_ELEMENT);
-        serializer.attribute(null, "lat", String.format(Locale.US, "%f", latitude));
-        serializer.attribute(null, "lon", String.format(Locale.US, "%f", longitude));
+        serializer.attribute(null, "lat", String.format(Locale.US, "%.8f", latitude));
+        serializer.attribute(null, "lon", String.format(Locale.US, "%.8f", longitude));
         if (hasAltitude()) {
-            serializer.startTag(null, ELE_ELEMENT).text(String.format(Locale.US, "%f", altitude)).endTag(null, ELE_ELEMENT);
+            serializer.startTag(null, ELE_ELEMENT).text(String.format(Locale.US, "%.3f", altitude)).endTag(null, ELE_ELEMENT);
         }
         serializer.startTag(null, TIME_ELEMENT).text(gtf.format(time)).endTag(null, TIME_ELEMENT);
         serializer.endTag(null, TRKPT_ELEMENT);


### PR DESCRIPTION
Use 8 digits for latitude and longitude.  This is about 1 mm, which is
silly for internal GPS of today's phones, but not for dual-frequwency
RTK.

Use 3 digits for altitude, which is 1 mm.  That's even better than the
best current equipment.

These values are chosen on the theory that one should be able to see
GPS errors in the recorded data, that the data format should never be
the limiting factor, and that recorded precision should not be vastly
more than is necessary.