### PR TITLE
PathCreationActionModeCallback refactoring

### DIFF
--- a/src/androidTest/java/de/blau/android/easyedit/LongClickTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/LongClickTest.java
@@ -153,7 +153,7 @@ public class LongClickTest {
         TestUtils.clickAtCoordinates(device, map, 8.3895763, 47.3901374, true);
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_createpath)));
         TestUtils.clickAtCoordinates(device, map, 8.3896274, 47.3902424, true);
-        TestUtils.clickUp(device);
+        TestUtils.clickButton(device, device.getCurrentPackageName() + ":id/simpleButton", true);
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.tag_form_untagged_element)));
         TestUtils.clickHome(device, true);
         Way way = App.getLogic().getSelectedWay();

--- a/src/androidTest/java/de/blau/android/easyedit/RelationTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/RelationTest.java
@@ -190,7 +190,7 @@ public class RelationTest {
         TestUtils.clickAtCoordinates(device, map, 8.3895763, 47.3901374, true);
         TestUtils.sleep();
         TestUtils.clickAtCoordinates(device, map, 8.3896274, 47.3902424, true);
-        TestUtils.clickUp(device);
+        TestUtils.clickButton(device, device.getCurrentPackageName() + ":id/simpleButton", true);
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.tag_form_untagged_element)));
         TestUtils.clickHome(device, true);
         Way way = App.getLogic().getSelectedWay();

--- a/src/androidTest/java/de/blau/android/easyedit/SimpleActionsTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/SimpleActionsTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.fail;
 import java.util.List;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -129,6 +130,12 @@ public class SimpleActionsTest {
         TestUtils.clickAtCoordinates(device, map, 8.3895763, 47.3901374, true);
         TestUtils.sleep();
         TestUtils.clickAtCoordinates(device, map, 8.3896274, 47.3902424, true);
+        TestUtils.sleep();
+        TestUtils.clickAtCoordinates(device, map, 8.3897000, 47.3903500, true);
+        TestUtils.sleep();
+        // undo last addition
+        Assert.assertTrue(TestUtils.clickMenuButton(device, context.getString(R.string.undo), false, false));
+        TestUtils.sleep();
         TestUtils.clickButton(device, device.getCurrentPackageName() + ":id/simpleButton", true);
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.tag_form_untagged_element)));
         TestUtils.clickHome(device, true);

--- a/src/androidTest/java/de/blau/android/easyedit/SimpleActionsTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/SimpleActionsTest.java
@@ -61,7 +61,7 @@ public class SimpleActionsTest {
         Preferences prefs = new Preferences(context);
         TestUtils.removeImageryLayers(context);
         prefs.enableSimpleActions(true);
-        main.runOnUiThread(()->main.showSimpleActionsButton());
+        main.runOnUiThread(() -> main.showSimpleActionsButton());
         map = main.getMap();
         map.setPrefs(main, prefs);
         TestUtils.grantPermissons(device);
@@ -129,7 +129,7 @@ public class SimpleActionsTest {
         TestUtils.clickAtCoordinates(device, map, 8.3895763, 47.3901374, true);
         TestUtils.sleep();
         TestUtils.clickAtCoordinates(device, map, 8.3896274, 47.3902424, true);
-        TestUtils.clickUp(device);
+        TestUtils.clickButton(device, device.getCurrentPackageName() + ":id/simpleButton", true);
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.tag_form_untagged_element)));
         TestUtils.clickHome(device, true);
         Way way = App.getLogic().getSelectedWay();

--- a/src/androidTest/java/de/blau/android/easyedit/WayActionsTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/WayActionsTest.java
@@ -118,7 +118,7 @@ public class WayActionsTest {
         } catch (InterruptedException e) {
         }
         TestUtils.clickAtCoordinates(device, map, 8.38877, 47.389202, true);
-        TestUtils.clickUp(device);
+        TestUtils.clickButton(device, device.getCurrentPackageName() + ":id/simpleButton", true);
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.tag_form_untagged_element)));
         TestUtils.clickHome(device, true);
         Way way = App.getLogic().getSelectedWay();

--- a/src/main/java/de/blau/android/easyedit/EasyEditActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/EasyEditActionModeCallback.java
@@ -259,33 +259,6 @@ public abstract class EasyEditActionModeCallback implements ActionMode.Callback 
     }
 
     /**
-     * Takes a parameter for a node and one for a way. If the way is not null, opens a tag editor for the way.
-     * Otherwise, opens a tag editor for the node (unless the node is also null, then nothing happens).
-     * 
-     * @param possibleNode a node that was edited, or null
-     * @param possibleWay a way that was edited, or null
-     * @param select select the element before starting the PropertyEditor
-     */
-    void tagApplicable(@Nullable final Node possibleNode, @Nullable final Way possibleWay, final boolean select) {
-        if (possibleWay == null) {
-            // Single node was added
-            if (possibleNode != null) { // null-check to be sure
-                if (select) {
-                    main.startSupportActionMode(new NodeSelectionActionModeCallback(manager, possibleNode));
-                }
-                main.performTagEdit(possibleNode, null, false, false);
-            } else {
-                Log.e(DEBUG_TAG, "tagApplicable called with null arguments");
-            }
-        } else { // way was added
-            if (select) {
-                main.startSupportActionMode(new WaySelectionActionModeCallback(manager, possibleWay));
-            }
-            main.performTagEdit(possibleWay, null, false, false);
-        }
-    }
-
-    /**
      * Finds which ways can be merged with a way. For this, the ways must not be equal, need to share at least one end
      * node, and either at least one of them must not have tags, or the tags on both ways must be equal.
      * 

--- a/src/main/java/de/blau/android/easyedit/EasyEditManager.java
+++ b/src/main/java/de/blau/android/easyedit/EasyEditManager.java
@@ -63,8 +63,9 @@ public class EasyEditManager {
 
     private boolean contextMenuEnabled;
 
-    private static final List<String> restartable = Collections.unmodifiableList(Arrays.asList(RouteSegmentActionModeCallback.class.getCanonicalName(),
-            RestartRouteSegmentActionModeCallback.class.getCanonicalName(), EditRelationMembersActionModeCallback.class.getCanonicalName()));
+    private static final List<String> restartable = Collections.unmodifiableList(
+            Arrays.asList(RouteSegmentActionModeCallback.class.getCanonicalName(), RestartRouteSegmentActionModeCallback.class.getCanonicalName(),
+                    EditRelationMembersActionModeCallback.class.getCanonicalName(), PathCreationActionModeCallback.class.getCanonicalName()));
 
     public static final String              FILENAME     = "easyeditmanager.res";
     private SavingHelper<SerializableState> savingHelper = new SavingHelper<>();
@@ -282,7 +283,7 @@ public class EasyEditManager {
                                         }
                                     } catch (ClassNotFoundException | NoSuchMethodException | SecurityException | InstantiationException
                                             | IllegalAccessException | IllegalArgumentException | InvocationTargetException exception) {
-                                        Log.e(DEBUG_TAG, "Restarting " + restartActionModeCallbackName + " received " + exception.getMessage());
+                                        Log.e(DEBUG_TAG, "Restarting " + restartActionModeCallbackName + " received " + exception.getClass().getCanonicalName() + " "+ exception.getMessage());
                                     }
                                 }
                                 Log.e(DEBUG_TAG, "restart, saved state is null");

--- a/src/main/java/de/blau/android/osm/Way.java
+++ b/src/main/java/de/blau/android/osm/Way.java
@@ -37,8 +37,10 @@ public class Way extends OsmElement implements BoundedObject, StyleableFeature {
     private int top;
 
     public static final String NAME = "way";
-
     public static final String NODE = "nd";
+
+    public static final int MINIMUM_NODES_IN_WAY        = 2;
+    public static final int MINIMUM_NODES_IN_CLOSED_WAY = 3;
 
     private transient FeatureStyle style = null; // FeatureProfile is currently not serializable
 
@@ -216,7 +218,7 @@ public class Way extends OsmElement implements BoundedObject, StyleableFeature {
             Log.i(DEBUG_TAG, "removeNode removed " + (count - 1) + " duplicate node(s)");
         }
     }
-    
+
     /**
      * Remove all nodes from the Way
      * 
@@ -491,6 +493,22 @@ public class Way extends OsmElement implements BoundedObject, StyleableFeature {
      */
     public int nodeCount() {
         return nodes == null ? 0 : nodes.size();
+    }
+
+    /**
+     * Count the occurrences of node
+     * 
+     * @param node the Node
+     * @return the number of times node is present
+     */
+    public int count(@NonNull Node node) {
+        int result = 0;
+        for (Node n : nodes) {
+            if (node.equals(n)) {
+                result++;
+            }
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/de/blau/android/util/SerializableState.java
+++ b/src/main/java/de/blau/android/util/SerializableState.java
@@ -52,6 +52,16 @@ public class SerializableState implements Serializable {
     }
 
     /**
+     * Store a String
+     * 
+     * @param key the key
+     * @param s the String
+     */
+    public void putString(@NonNull String key, @Nullable String s) {
+        state.put(key, s);
+    }
+    
+    /**
      * Get a serializable object
      * 
      * @param key the key
@@ -72,6 +82,21 @@ public class SerializableState implements Serializable {
     public Long getLong(@NonNull String key) {
         try {
             return (Long) state.get(key);
+        } catch (ClassCastException e) {
+            return null;
+        }
+    }
+    
+    /**
+     * Get a String
+     * 
+     * @param key the key
+     * @return a String or null if not found or not a String
+     */
+    @Nullable
+    public String getString(@NonNull String key) {
+        try {
+            return (String) state.get(key);
         } catch (ClassCastException e) {
             return null;
         }

--- a/src/test/java/de/blau/android/osm/StorageDelegatorTest.java
+++ b/src/test/java/de/blau/android/osm/StorageDelegatorTest.java
@@ -569,6 +569,54 @@ public class StorageDelegatorTest {
     }
 
     /**
+     * Test removeNodeFromWay closes Way is closing Node is removed
+     */
+    @Test
+    public void removeNodeFromWay() {
+        StorageDelegator d = new StorageDelegator();
+        Way w = addWayToStorage(d, true);
+        Way temp = (Way) d.getOsmElement(Way.NAME, w.getOsmId());
+        assertNotNull(temp);
+        assertTrue(w.isClosed());
+        Node lastNode = w.getLastNode();
+        assertEquals(2, w.count(lastNode));
+        d.removeNodeFromWay(w, lastNode);
+        assertFalse(w.hasNode(lastNode));
+        assertTrue(w.isClosed());
+    }
+    
+    /**
+     * Test removeLastNodeFromWay method
+     */
+    @Test
+    public void removeLastNodeFromWay() {
+        StorageDelegator d = new StorageDelegator();
+        Way w = addWayToStorage(d, false);
+        Way temp = (Way) d.getOsmElement(Way.NAME, w.getOsmId());
+        assertNotNull(temp);
+        Node tempNode = temp.getNodes().get(2);
+        Map<String, String> tags = new TreeMap<>();
+        tags.put("test","test");
+        tempNode.setTags(tags);
+        
+        int count = temp.nodeCount();
+        assertEquals(4, count);
+        for (int i = 0; i < 2; i++) {
+            Node n = temp.getLastNode();
+            d.removeLastNodeFromWay(temp);
+            assertFalse(temp.hasNode(n));
+            assertEquals(count - (i + 1), temp.nodeCount());
+        }
+        // removing the 2nd last node should delete the way
+        d.removeLastNodeFromWay(temp);
+        assertEquals(OsmElement.STATE_DELETED, temp.getState());
+        assertNull(d.getApiStorage().getOsmElement(Way.NAME, temp.getOsmId()));
+        
+        // check that the tagged node is still here
+        assertEquals(OsmElement.STATE_CREATED, tempNode.getState());
+    }
+
+    /**
      * Split way at node
      */
     @Test


### PR DESCRIPTION
Re-factor PathCreationActionModeCallback

This changes the mode to use the same UI as the other "Builder" modes and makes it restartable.

Further we now encapsulate all actions in one undo checkpoint.
