### PR TITLE
Multi-polygon creation and extension

### DIFF
--- a/src/androidTest/java/de/blau/android/easyedit/RelationTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/RelationTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.List;
-import java.util.TreeMap;
 
 import org.junit.After;
 import org.junit.Before;
@@ -182,6 +181,17 @@ public class RelationTest {
         map.getDataLayer().setVisible(true);
         TestUtils.zoomToLevel(device, main, 22);
         TestUtils.unlock(device);
+        // split building first
+        TestUtils.clickAtCoordinates(device, map, 8.3882060, 47.3885768, true);
+        assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_wayselect)));
+        assertTrue(TestUtils.clickMenuButton(device, "Split", false, true));
+        assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_closed_way_split_1)));
+        TestUtils.clickAtCoordinates(device, map, 8.3881251, 47.3885077, true);
+        assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_closed_way_split_2)));
+        TestUtils.clickAtCoordinates(device, map, 8.3881577, 47.3886924, true);
+        assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_multiselect)));
+        TestUtils.clickUp(device);
+        //
         TestUtils.clickButton(device, device.getCurrentPackageName() + ":id/simpleButton", true);
         assertTrue(TestUtils.clickText(device, false, context.getString(R.string.menu_add_way), true, false));
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.simple_add_way)));
@@ -206,6 +216,9 @@ public class RelationTest {
         assertTrue(TestUtils.clickText(device, false, "Multipolygon", true, false));
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.menu_add_relation_member)));
         TestUtils.clickAtCoordinates(device, map, 8.3882060, 47.3885768, true);
+        TestUtils.sleep();
+        TestUtils.clickAtCoordinates(device, map, 8.3880720, 47.3886182, true);
+        TestUtils.sleep();
         // finish
         TestUtils.clickButton(device, device.getCurrentPackageName() + ":id/simpleButton", true);
         ActivityMonitor monitor = instrumentation.addMonitor(PropertyEditor.class.getName(), null, false);
@@ -225,11 +238,11 @@ public class RelationTest {
         assertTrue(relation.hasTag(Tags.KEY_BUILDING, "residential"));
         List<RelationMember> members = relation.getMembers();
         assertNotNull(members);
-        assertEquals(2, members.size());
+        assertEquals(3, members.size());
         RelationMember innerMember = relation.getMember(inner);
         assertEquals(Tags.ROLE_INNER, innerMember.getRole());
         List<RelationMember> outerMembers = relation.getMembersWithRole(Tags.ROLE_OUTER);
-        assertEquals(1, outerMembers.size());
+        assertEquals(2, outerMembers.size());
         RelationMember outer = outerMembers.get(0);
         assertTrue(outer.getElement().getTags().isEmpty()); // tags have been moved
         // select another building add add it to the MP
@@ -249,8 +262,8 @@ public class RelationTest {
         TestUtils.sleep(2000);
         TestUtils.clickHome(device, true); // exit property editor
         outerMembers = relation.getMembersWithRole(Tags.ROLE_OUTER);
-        assertEquals(2, outerMembers.size());
-        outer = outerMembers.get(1);
+        assertEquals(3, outerMembers.size());
+        outer = outerMembers.get(2);
         assertEquals(1, outer.getElement().getTags().size());
         assertTrue(outer.getElement().hasTagWithValue(Tags.KEY_ADDR_HOUSENUMBER, "38"));
     }

--- a/src/androidTest/java/de/blau/android/propertyeditor/AddressTest.java
+++ b/src/androidTest/java/de/blau/android/propertyeditor/AddressTest.java
@@ -76,6 +76,7 @@ public class AddressTest {
         logic.deselectAll();
         TestUtils.loadTestData(main, "test2.osm");
         App.getTaskStorage().reset();
+        Address.resetLastAddresses(main);
         TestUtils.stopEasyEdit(main);
     }
 

--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -622,7 +622,7 @@ public class Logic {
      * 
      * @param activity activity we were called from
      * @param e element to change the tags on
-     * @param tags Tag-List to be set.
+     * @param tags Tags to be set
      * @throws OsmIllegalOperationException if the e isn't in storage
      */
     public synchronized void setTags(@Nullable Activity activity, @NonNull final OsmElement e, @Nullable final java.util.Map<String, String> tags)
@@ -634,19 +634,36 @@ public class Logic {
      * Delegates the setting of the Tag-list to {@link StorageDelegator}. All existing tags will be replaced.
      * 
      * @param activity activity we were called from
-     * @param type type of the element for the Tag-list.
-     * @param osmId OSM-ID of the element.
-     * @param tags Tag-List to be set.
+     * @param type type of the element
+     * @param osmId OSM-ID of the element
+     * @param tags Tags to be set
      * @throws OsmIllegalOperationException if the e isn't in storage
      */
     public synchronized void setTags(@Nullable Activity activity, final String type, final long osmId, @Nullable final java.util.Map<String, String> tags)
             throws OsmIllegalOperationException {
+        setTags(activity, type, osmId, tags, true);
+    }
+
+    /**
+     * Delegates the setting of the Tag-list to {@link StorageDelegator}. All existing tags will be replaced.
+     * 
+     * @param activity activity we were called from
+     * @param type type of the element
+     * @param osmId OSM-ID of the element
+     * @param tags Tags to be set
+     * @param createCheckpoint create a checkpoint, except in composite operations this should always be true
+     * @throws OsmIllegalOperationException if the e isn't in storage
+     */
+    public synchronized void setTags(@Nullable Activity activity, final String type, final long osmId, @Nullable final java.util.Map<String, String> tags,
+            boolean createCheckpoint) throws OsmIllegalOperationException {
         OsmElement osmElement = getDelegator().getOsmElement(type, osmId);
         if (osmElement == null) {
             Log.e(DEBUG_TAG, "Attempted to setTags on a non-existing element " + type + " #" + osmId);
             throw new OsmIllegalOperationException(type + " #" + osmId + " not in storage");
         } else {
-            createCheckpoint(activity, R.string.undo_action_set_tags);
+            if (createCheckpoint) {
+                createCheckpoint(activity, R.string.undo_action_set_tags);
+            }
             getDelegator().setTags(osmElement, tags);
         }
     }

--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -4770,6 +4770,7 @@ public class Logic {
      * @param members the osm elements to include in the relation
      * @return the new relation
      */
+    @NonNull
     public Relation createRelation(@Nullable Activity activity, String type, List<OsmElement> members) {
         createCheckpoint(activity, R.string.undo_action_create_relation);
         Relation relation = getDelegator().createAndInsertRelation(members);
@@ -4785,6 +4786,7 @@ public class Logic {
      * @param members the osm elements to include in the relation
      * @return the new relation
      */
+    @NonNull
     public Relation createRelationFromMembers(@Nullable Activity activity, String type, List<RelationMember> members) {
         createCheckpoint(activity, R.string.undo_action_create_relation);
         Relation relation = getDelegator().createAndInsertRelationFromMembers(members);

--- a/src/main/java/de/blau/android/easyedit/BuilderActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/BuilderActionModeCallback.java
@@ -50,6 +50,7 @@ public abstract class BuilderActionModeCallback extends EasyEditActionModeCallba
         if (!prefs.areSimpleActionsEnabled()) {
             main.showSimpleActionsButton();
         }
+        main.descheduleAutoLock();
         return true;
     }
 

--- a/src/main/java/de/blau/android/easyedit/EditRelationMembersActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/EditRelationMembersActionModeCallback.java
@@ -1,8 +1,11 @@
 package de.blau.android.easyedit;
 
+import static de.blau.android.util.Geometry.isInside;
+
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -28,6 +31,7 @@ import de.blau.android.osm.Relation;
 import de.blau.android.osm.RelationMember;
 import de.blau.android.osm.Storage;
 import de.blau.android.osm.StorageDelegator;
+import de.blau.android.osm.Tags;
 import de.blau.android.osm.Way;
 import de.blau.android.presets.Preset;
 import de.blau.android.presets.Preset.PresetItem;
@@ -37,6 +41,7 @@ import de.blau.android.search.Wrapper;
 import de.blau.android.util.SerializableState;
 import de.blau.android.util.Snack;
 import de.blau.android.util.ThemeUtils;
+import de.blau.android.util.Util;
 import de.blau.android.util.collections.MultiHashMap;
 
 /**
@@ -179,7 +184,7 @@ public class EditRelationMembersActionModeCallback extends BuilderActionModeCall
                     // exactly one match
                     member.setRole(roles.get(0).getRole());
                 } else {
-                    // TODO ask user
+                    // TODO maybe ask user
                 }
             }
         }
@@ -476,6 +481,18 @@ public class EditRelationMembersActionModeCallback extends BuilderActionModeCall
     public void finishBuilding() {
         if (!newMembers.isEmpty() || !removeMembers.isEmpty()) { // something was actually added
             if (relation == null) {
+                if (relationPreset != null && (relationPreset.hasKeyValue(Tags.KEY_TYPE, Tags.VALUE_MULTIPOLYGON)
+                        || relationPreset.hasKeyValue(Tags.KEY_TYPE, Tags.VALUE_BOUNDARY))) {
+                    List<RelationMember> multipolygonMembers = setMultipolygonRoles(newMembers);
+                    newMembers.clear();
+                    newMembers.addAll(multipolygonMembers);
+                    if (outersHaveSameTags(newMembers)) {
+                        moveOuterTags();
+                        return;
+                    } else {
+                        Snack.toastTopWarning(main, R.string.toast_outer_rings_differing_tags);
+                    }
+                }
                 relation = logic.createRelationFromMembers(main, null, newMembers);
                 main.performTagEdit(relation, presetPath, null, false);
             } else {
@@ -497,6 +514,212 @@ public class EditRelationMembersActionModeCallback extends BuilderActionModeCall
         } else {
             manager.finish();
         }
+    }
+
+    /**
+     * Move tags from the outer members to the multi-polygon relation, asking for confirmation first
+     */
+    private void moveOuterTags() {
+        // create relation first, roles have been set now
+        relation = logic.createRelationFromMembers(main, null, newMembers);
+        AlertDialog alertDialog = new AlertDialog.Builder(main).setTitle(R.string.move_outer_tags_title).setMessage(R.string.move_outer_tags_message)
+                .setPositiveButton(R.string.move, (dialog, which) -> {
+                    List<RelationMember> outers = relation.getMembersWithRole(Tags.ROLE_OUTER);
+                    HashMap<String, String> outerTags = null;
+                    Map<String, String> emptyTags = new HashMap<>();
+                    for (RelationMember outer : outers) {
+                        if (outer.downloaded()) {
+                            if (outerTags == null) {
+                                outerTags = new HashMap<>(outer.getElement().getTags());
+                            }
+                            App.getLogic().setTags(main, outer.getType(), outer.getRef(), emptyTags, false);
+                        }
+                    }
+                    if (outerTags != null) {
+                        // add MP type to tags
+                        outerTags.put(Tags.KEY_TYPE, Tags.VALUE_MULTIPOLYGON);
+                    }
+                    App.getLogic().setTags(main, Relation.NAME, relation.getOsmId(), outerTags, false);
+                }).setNeutralButton(R.string.leave_as_is, null).create();
+        alertDialog.setOnDismissListener(dialog -> {
+            main.performTagEdit(relation, presetPath, null, false);
+            main.startSupportActionMode(new RelationSelectionActionModeCallback(manager, relation));
+        });
+        alertDialog.show();
+    }
+
+    /**
+     * Check if all outer members of a multi-polygon have the same tags
+     * 
+     * @param members a List of the members
+     * @return true if all outer members have the same tags
+     */
+    private boolean outersHaveSameTags(List<RelationMember> members) {
+        Map<String, String> tags = null;
+        for (RelationMember member : members) {
+            if (Tags.ROLE_OUTER.equals(member.getRole())) {
+                if (tags == null) {
+                    tags = member.downloaded() ? member.getElement().getTags() : null;
+                } else if (member.downloaded() && !tags.equals(member.getElement().getTags())) {
+                    return false;
+                }
+            }
+        }
+        return tags != null;
+    }
+
+    /**
+     * Try to determine if rings are outer or inner rings
+     * 
+     * This simply tests one node from a ring if it is inside an other ring, this can go wrong in multiple ways.
+     * 
+     * @param origMembers List of RelationMembers
+     * @return a List of RelationMembers with inner / outer role set as far as could be determined
+     */
+    List<RelationMember> setMultipolygonRoles(@NonNull List<RelationMember> origMembers) {
+        List<RelationMember> sortedMembers = Util.sortRelationMembers(origMembers);
+        List<RelationMember> other = new ArrayList<>();
+        List<List<RelationMember>> rings = new ArrayList<>();
+        List<List<RelationMember>> partialRings = new ArrayList<>();
+        List<RelationMember> currentRing = null;
+        Way previousRingSegment = null;
+        for (RelationMember rm : sortedMembers) {
+            if (rm.downloaded() && Way.NAME.equals(rm.getType())) {
+                Way currentRingSegment = ((Way) rm.getElement());
+                boolean closed = currentRingSegment.isClosed();
+                if (currentRing == null) { // start ring
+                    currentRing = new ArrayList<>();
+                    currentRing.add(rm);
+                    if (closed) {
+                        rings.add(currentRing);
+                        currentRing = null;
+                    }
+                } else if (closed) {
+                    // incomplete ring
+                    partialRings.add(currentRing);
+                    currentRing = new ArrayList<>();
+                    currentRing.add(rm);
+                    rings.add(currentRing);
+                    currentRing = null;
+                } else {
+                    final Node currentFirstNode = currentRingSegment.getFirstNode();
+                    final Node currentLastNode = currentRingSegment.getLastNode();
+                    final Node previousFirstNode = previousRingSegment.getFirstNode();
+                    final Node previousLastNode = previousRingSegment.getLastNode();
+                    if (currentFirstNode.equals(previousFirstNode) || currentFirstNode.equals(previousLastNode) || currentLastNode.equals(previousFirstNode)
+                            || currentLastNode.equals(previousLastNode)) {
+                        currentRing.add(rm);
+                        final Way firstSegment = (Way) currentRing.get(0).getElement();
+                        final Node firstFirstNode = firstSegment.getFirstNode();
+                        final Node firstLastNode = firstSegment.getLastNode();
+                        if (firstFirstNode.equals(currentFirstNode) || firstFirstNode.equals(currentLastNode) || firstLastNode.equals(currentFirstNode)
+                                || firstLastNode.equals(currentLastNode)) {
+                            rings.add(currentRing);
+                            currentRing = null;
+                        }
+                    } else { // incomplete ring, restart
+                        partialRings.add(currentRing);
+                        currentRing = new ArrayList<>();
+                        currentRing.add(rm);
+                    }
+                }
+                previousRingSegment = currentRingSegment;
+            } else {
+                other.add(rm);
+            }
+        }
+        final int ringCount = rings.size();
+        List<List<RelationMember>> rings2 = new ArrayList<>(rings);
+        for (int i = 0; i < ringCount; i++) {
+            List<RelationMember> ring = rings.get(i);
+            // this avoids iterating over rings we have already processed at the price of creating a shallow copy of
+            // rings2
+            for (List<RelationMember> ring2 : new ArrayList<>(rings2)) {
+                if (ring2.equals(ring)) {
+                    continue;
+                }
+                Node ring2Node = ((Way) ring2.get(0).getElement()).getFirstNode();
+                try {
+                    if (isInside(getNodesForRing(ring).toArray(new Node[ring.size()]), ring2Node)) {
+                        setRole(Tags.ROLE_OUTER, ring);
+                        setRole(Tags.ROLE_INNER, ring2);
+                        rings2.remove(ring);
+                        rings2.remove(ring2);
+                    } else {
+                        Node ringNode = ((Way) ring.get(0).getElement()).getFirstNode();
+                        if (isInside(getNodesForRing(ring2).toArray(new Node[ring2.size()]), ringNode)) {
+                            setRole(Tags.ROLE_INNER, ring);
+                            setRole(Tags.ROLE_OUTER, ring2);
+                            rings2.remove(ring);
+                            rings2.remove(ring2);
+                        }
+                    }
+                } catch (IllegalArgumentException iae) {
+                    Log.e(DEBUG_TAG, "Ring not well formed");
+                }
+            }
+            final String role = ring.get(0).getRole();
+            if (role == null || "".equals(role)) {
+                setRole(Tags.ROLE_OUTER, ring);
+                rings2.remove(ring);
+            }
+        }
+        List<RelationMember> result = new ArrayList<>();
+        for (List<RelationMember> ring : rings) {
+            result.addAll(ring);
+        }
+        for (List<RelationMember> ring : partialRings) {
+            result.addAll(ring);
+        }
+        if (!partialRings.isEmpty()) {
+            Snack.toastTopWarning(main, R.string.toast_multipolygon_has_incomplete_rings);
+        }
+        result.addAll(other);
+        return result;
+    }
+
+    /**
+     * Set a role value for all members in a List
+     * 
+     * @param role the role value to set
+     * @param members the
+     */
+    private void setRole(@NonNull String role, @NonNull List<RelationMember> members) {
+        for (RelationMember member : members) {
+            String current = member.getRole();
+            if (current != null && !"".equals(current) && !role.equals(current)) {
+                Log.w(DEBUG_TAG, "Changing role from " + current + " to " + role);
+            }
+            member.setRole(role);
+        }
+    }
+
+    /**
+     * Create a list of Nodes for the ring ordered correctly
+     * 
+     * @param ring the input ring
+     * @return a List of Nodes
+     */
+    private List<Node> getNodesForRing(@NonNull List<RelationMember> ring) {
+        final Way firstRingWay = (Way) ring.get(0).getElement();
+        if (firstRingWay.isClosed()) {
+            List<Node> nodes = firstRingWay.getNodes();
+            return nodes.subList(0, nodes.size() - 1); // de-dup last node
+        }
+        List<Node> result = new ArrayList<>();
+        List<Node> nodes = new ArrayList<>(firstRingWay.getNodes());
+        final int ringNodeCount = ring.size();
+        for (int i = 0; i < ringNodeCount; i++) {
+            List<Node> nextNodes = new ArrayList<>(((Way) ring.get((i + 1) % ringNodeCount).getElement()).getNodes());
+            // order of nodes is important
+            Node firstNode = nodes.get(0);
+            if (firstNode.equals(nextNodes.get(0)) || firstNode.equals(nextNodes.get(nextNodes.size() - 1))) {
+                Collections.reverse(nodes);
+            }
+            result.addAll(nodes.subList(0, nodes.size() - 1)); // de-dup last node
+            nodes = nextNodes;
+        }
+        return result;
     }
 
     @Override

--- a/src/main/java/de/blau/android/easyedit/route/RestartRouteSegmentActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/route/RestartRouteSegmentActionModeCallback.java
@@ -72,6 +72,7 @@ public class RestartRouteSegmentActionModeCallback extends NonSimpleActionModeCa
         logic.setSelectedNode(null);
         logic.setSelectedWay(null);
         super.onCreateActionMode(mode, menu);
+        main.descheduleAutoLock();
         return true;
     }
 

--- a/src/main/java/de/blau/android/layer/data/MapOverlay.java
+++ b/src/main/java/de/blau/android/layer/data/MapOverlay.java
@@ -1,5 +1,9 @@
 package de.blau.android.layer.data;
 
+import static de.blau.android.util.Winding.CLOCKWISE;
+import static de.blau.android.util.Winding.COUNTERCLOCKWISE;
+import static de.blau.android.util.Winding.winding;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -717,13 +721,13 @@ public class MapOverlay extends MapViewLayer implements ExtentInterface, Configu
     private void addRing(@NonNull String role, @NonNull List<Node> ring) {
         switch (role) {
         case Tags.ROLE_OUTER:
-            if (!clockwise(ring)) {
+            if (winding(ring) == COUNTERCLOCKWISE) {
                 Collections.reverse(ring);
             }
             outerRings.add(ring);
             break;
         case Tags.ROLE_INNER:
-            if (clockwise(ring)) {
+            if (winding(ring) == CLOCKWISE) {
                 Collections.reverse(ring);
             }
             innerRings.add(ring);
@@ -731,30 +735,6 @@ public class MapOverlay extends MapViewLayer implements ExtentInterface, Configu
         default:
             unknownRings.add(ring);
         }
-    }
-
-    /**
-     * Determine winding of a List of Nodes
-     * 
-     * @param nodes the List of Nodes
-     * @return true if the winding is clockwise
-     */
-    private boolean clockwise(@NonNull List<Node> nodes) {
-        long area = 0;
-        int s = nodes.size();
-        Node n1 = nodes.get(0);
-        int lat1 = n1.getLat();
-        int lon1 = n1.getLon();
-        int size = nodes.size();
-        for (int i = 0; i < size; i++) {
-            Node n2 = nodes.get((i + 1) % s);
-            int lat2 = n2.getLat();
-            int lon2 = n2.getLon();
-            area = area + (long) (lat2 - lat1) * (long) (lon2 + lon1);
-            lat1 = lat2;
-            lon1 = lon2;
-        }
-        return area < 0;
     }
 
     /**
@@ -1196,7 +1176,7 @@ public class MapOverlay extends MapViewLayer implements ExtentInterface, Configu
 
         List<Node> nodes = way.getNodes();
         boolean reversed = false; // way arrows need to be drawn reversed if we reverse the direction of the way
-        if (style.isArea() && !clockwise(nodes)) {
+        if (style.isArea() && winding(nodes) == COUNTERCLOCKWISE) {
             areaNodes.clear();
             areaNodes.addAll(nodes);
             Collections.reverse(areaNodes);

--- a/src/main/java/de/blau/android/layer/data/MapOverlay.java
+++ b/src/main/java/de/blau/android/layer/data/MapOverlay.java
@@ -719,15 +719,16 @@ public class MapOverlay extends MapViewLayer implements ExtentInterface, Configu
      * @param ring the ring
      */
     private void addRing(@NonNull String role, @NonNull List<Node> ring) {
+        final int winding = winding(ring);
         switch (role) {
         case Tags.ROLE_OUTER:
-            if (winding(ring) == COUNTERCLOCKWISE) {
+            if (winding == COUNTERCLOCKWISE) {
                 Collections.reverse(ring);
             }
             outerRings.add(ring);
             break;
         case Tags.ROLE_INNER:
-            if (winding(ring) == CLOCKWISE) {
+            if (winding == CLOCKWISE) {
                 Collections.reverse(ring);
             }
             innerRings.add(ring);

--- a/src/main/java/de/blau/android/layer/data/MapOverlay.java
+++ b/src/main/java/de/blau/android/layer/data/MapOverlay.java
@@ -81,9 +81,6 @@ public class MapOverlay extends MapViewLayer implements ExtentInterface, Configu
     private static final String DEBUG_TAG = MapOverlay.class.getName();
 
     private static final int THREAD_POOL_SIZE = 2;
-    
-    private static final String OUTER = "outer";
-    private static final String INNER = "inner";
 
     public static final int ICON_SIZE_DP = 20;
 
@@ -719,13 +716,13 @@ public class MapOverlay extends MapViewLayer implements ExtentInterface, Configu
      */
     private void addRing(@NonNull String role, @NonNull List<Node> ring) {
         switch (role) {
-        case OUTER:
+        case Tags.ROLE_OUTER:
             if (!clockwise(ring)) {
                 Collections.reverse(ring);
             }
             outerRings.add(ring);
             break;
-        case INNER:
+        case Tags.ROLE_INNER:
             if (clockwise(ring)) {
                 Collections.reverse(ring);
             }

--- a/src/main/java/de/blau/android/osm/Tags.java
+++ b/src/main/java/de/blau/android/osm/Tags.java
@@ -22,7 +22,7 @@ import androidx.annotation.Nullable;
  */
 public final class Tags {
     public static final String OSM_VALUE_SEPARATOR = ";";
-    
+
     // Karlsruher schema
     public static final String KEY_ADDR_BASE        = "addr:";
     public static final String KEY_ADDR_HOUSENUMBER = "addr:housenumber";
@@ -158,6 +158,8 @@ public final class Tags {
     public static final String VALUE_MULTIPOLYGON     = "multipolygon";
     public static final String VALUE_BOUNDARY         = "boundary";
     public static final String KEY_BOUNDARY           = "boundary";
+    public static final String ROLE_OUTER             = "outer";
+    public static final String ROLE_INNER             = "inner";
 
     /**
      * Check if a relation member element should be treated as a via element

--- a/src/main/java/de/blau/android/util/Geometry.java
+++ b/src/main/java/de/blau/android/util/Geometry.java
@@ -288,14 +288,13 @@ public final class Geometry {
         do {
             int next = (i + 1) % n;
             if (intersect(polygon[i], polygon[next], node, extreme)) {
-                if (winding(polygon[i], node, polygon[next]) == 0) {
+                if (winding(polygon[i], node, polygon[next]) == COLINEAR) {
                     return onSegment(polygon[i], node, polygon[next]);
                 }
                 intersections++;
             }
             i = next;
         } while (i != 0);
-
         return (intersections % 2 == 1);
     }
 }

--- a/src/main/java/de/blau/android/util/Winding.java
+++ b/src/main/java/de/blau/android/util/Winding.java
@@ -24,7 +24,7 @@ public final class Winding {
      * @return an int indicating winding direction
      */
     public static int winding(@NonNull List<Node> nodes) {
-        long area = 0;
+        double area = 0;
         int s = nodes.size();
         Node n1 = nodes.get(0);
         int lat1 = n1.getLat();
@@ -34,7 +34,7 @@ public final class Winding {
             Node n2 = nodes.get((i + 1) % s);
             int lat2 = n2.getLat();
             int lon2 = n2.getLon();
-            area = area + (long) (lat2 - lat1) * (long) (lon2 + lon1);
+            area = area + (double) (lat2 - lat1) * (double) (lon2 + lon1);
             lat1 = lat2;
             lon1 = lon2;
         }

--- a/src/main/java/de/blau/android/util/Winding.java
+++ b/src/main/java/de/blau/android/util/Winding.java
@@ -1,0 +1,43 @@
+package de.blau.android.util;
+
+import java.util.List;
+
+import androidx.annotation.NonNull;
+import de.blau.android.osm.Node;
+
+public final class Winding {
+    public static final int COLINEAR         = 0;
+    public static final int CLOCKWISE        = -1;
+    public static final int COUNTERCLOCKWISE = 1;
+
+    /**
+     * Private constructor to stop instantation
+     */
+    private Winding() {
+        // private
+    }
+
+    /**
+     * Determine winding of a List of Nodes
+     * 
+     * @param nodes the List of Nodes
+     * @return an int indicating winding direction
+     */
+    public static int winding(@NonNull List<Node> nodes) {
+        long area = 0;
+        int s = nodes.size();
+        Node n1 = nodes.get(0);
+        int lat1 = n1.getLat();
+        int lon1 = n1.getLon();
+        int size = nodes.size();
+        for (int i = 0; i < size; i++) {
+            Node n2 = nodes.get((i + 1) % s);
+            int lat2 = n2.getLat();
+            int lon2 = n2.getLon();
+            area = area + (long) (lat2 - lat1) * (long) (lon2 + lon1);
+            lat1 = lat2;
+            lon1 = lon2;
+        }
+        return area < 0 ? CLOCKWISE : area > 0 ? COUNTERCLOCKWISE : COLINEAR;
+    }
+}

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -212,6 +212,11 @@
     <string name="duplicate_relation_member_title">Add relation member</string>
     <string name="duplicate_relation_member_message">This element is already a member of the relation.</string>
     <string name="duplicate_relation_member_remove_button">Remove member</string>
+    <!-- Mode multi-polygon outer element tags to relation -->
+    <string name="move_outer_tags_title">Move tags from outer rings to multi-polygon</string>
+    <string name="move_outer_tags_message">Object defining tags should only be present on the multi-polygon</string>
+    <string name="move">Move</string>
+    <string name="leave_as_is">Leave as is</string>
     <!-- Abort action mode dialog -->
     <string name="abort_action_title">Abort action</string>
     <!--  -->
@@ -526,6 +531,8 @@ avoided by using an offline data source.</string>
     <string name="toast_split_next_segment">Split next segment</string>
     <string name="toast_nothing_changed">Nothing changed</string>
     <string name="toast_preset_failed">Failed to create preset %1$s\nError %2$s</string>
+    <string name="toast_outer_rings_differing_tags">Outer rings have differing tags</string>
+    <string name="toast_multipolygon_has_incomplete_rings">Multi-polygon has incomplete rings</string>
     <!-- Error messages -->
     <string name="error_mapsplit_missing_zoom">MapSplit sources must have min and max zoom set</string>
     <string name="error_pbf_no_version">Version information missing in PBF file</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -212,11 +212,15 @@
     <string name="duplicate_relation_member_title">Add relation member</string>
     <string name="duplicate_relation_member_message">This element is already a member of the relation.</string>
     <string name="duplicate_relation_member_remove_button">Remove member</string>
-    <!-- Mode multi-polygon outer element tags to relation -->
+    <!-- Move multi-polygon outer element tags to relation -->
     <string name="move_outer_tags_title">Move tags from outer rings to multi-polygon</string>
     <string name="move_outer_tags_message">Object defining tags should only be present on the multi-polygon</string>
     <string name="move">Move</string>
     <string name="leave_as_is">Leave as is</string>
+    <!-- Remove duplicate tags from multi-polygon outer element -->
+    <string name="remove_duplicate_outer_tags_title">Remove duplicate tags on outer rings</string>
+    <string name="remove_duplicate_outer_tags_message">Remove tags from outer rings that are set on the multi-polygon</string>
+    <string name="remove">Remove</string>
     <!-- Abort action mode dialog -->
     <string name="abort_action_title">Abort action</string>
     <!--  -->

--- a/src/test/java/de/blau/android/osm/StorageDelegatorTest.java
+++ b/src/test/java/de/blau/android/osm/StorageDelegatorTest.java
@@ -758,7 +758,7 @@ public class StorageDelegatorTest {
      * @param d double coordinate value
      * @return a scaled int
      */
-    static int toE7(double d) {
+    public static int toE7(double d) {
         return (int) (d * 1E7);
     }
 }

--- a/src/test/java/de/blau/android/util/GeometryTest.java
+++ b/src/test/java/de/blau/android/util/GeometryTest.java
@@ -1,0 +1,42 @@
+package de.blau.android.util;
+
+import static de.blau.android.osm.StorageDelegatorTest.toE7;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import de.blau.android.App;
+import de.blau.android.osm.Node;
+import de.blau.android.osm.OsmElementFactory;
+
+public class GeometryTest {
+
+    /**
+     * Is node in polygon or not
+     */
+    @Test
+    public void isInsideTest() {
+        OsmElementFactory factory = App.getDelegator().getFactory();
+        Node[] nodes = new Node[4];
+        Node n0 = factory.createNodeWithNewId(toE7(51.5019094D), toE7(-0.1417412D));
+        nodes[0] = n0;
+        Node n1 = factory.createNodeWithNewId(toE7(51.5016867D), toE7(-0.1410033D));
+        nodes[1] = n1;
+        Node n2 = factory.createNodeWithNewId(toE7(51.5011566D), toE7(-0.1413721D));
+        nodes[2] = n2;
+        Node n3 = factory.createNodeWithNewId(toE7(51.5013694D), toE7(-0.1421482D));
+        nodes[3] = n3;
+
+        Node inside1 = factory.createNodeWithNewId(toE7(51.50166452D), toE7(-0.1416078D));
+        assertTrue(Geometry.isInside(nodes, inside1));
+        
+        assertTrue(Geometry.isInside(nodes, n2));
+
+        Node outside1 = factory.createNodeWithNewId(toE7(51.5020192D), toE7(-0.1422925D));
+        assertFalse(Geometry.isInside(nodes, outside1));
+
+        Node outside2 = factory.createNodeWithNewId(toE7(51.5017543D), toE7(-0.1422112D));
+        assertFalse(Geometry.isInside(nodes, outside2));
+    }
+}

--- a/src/test/java/de/blau/android/util/WindingTest.java
+++ b/src/test/java/de/blau/android/util/WindingTest.java
@@ -1,0 +1,88 @@
+package de.blau.android.util;
+
+import static de.blau.android.osm.StorageDelegatorTest.toE7;
+import static de.blau.android.util.Winding.winding;
+import static de.blau.android.util.Winding.COLINEAR;
+import static de.blau.android.util.Winding.CLOCKWISE;
+import static de.blau.android.util.Winding.COUNTERCLOCKWISE;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import de.blau.android.App;
+import de.blau.android.osm.Node;
+import de.blau.android.osm.OsmElementFactory;
+
+public class WindingTest {
+
+    /**
+     * Check 3 nodes in a row
+     */
+    @Test
+    public void colinear() {
+        OsmElementFactory factory = App.getDelegator().getFactory();
+        List<Node> nodes = new ArrayList<>();
+        Node n0 = factory.createNodeWithNewId(toE7(51.478D), toE7(0D));
+        nodes.add(n0);
+        Node n1 = factory.createNodeWithNewId(toE7(51.578D), toE7(0D));
+        nodes.add(n1);
+        Node n2 = factory.createNodeWithNewId(toE7(51.678D), toE7(0D));
+        nodes.add(n2);
+        assertEquals(COLINEAR, winding(nodes));
+
+        nodes.clear();
+        n0 = factory.createNodeWithNewId(toE7(0D), toE7(51.478D));
+        nodes.add(n0);
+        n1 = factory.createNodeWithNewId(toE7(0D), toE7(51.578D));
+        nodes.add(n1);
+        n2 = factory.createNodeWithNewId(toE7(0D), toE7(51.678D));
+        nodes.add(n2);
+        assertEquals(COLINEAR, winding(nodes));
+
+        nodes.clear();
+        n0 = factory.createNodeWithNewId(toE7(51.478D), toE7(51.478D));
+        nodes.add(n0);
+        n1 = factory.createNodeWithNewId(toE7(51.578D), toE7(51.578D));
+        nodes.add(n1);
+        n2 = factory.createNodeWithNewId(toE7(51.678D), toE7(51.678D));
+        nodes.add(n2);
+        assertEquals(COLINEAR, winding(nodes));
+    }
+
+    /**
+     * Check 3 nodes clockwise
+     */
+    @Test
+    public void clockwise() {
+        OsmElementFactory factory = App.getDelegator().getFactory();
+        List<Node> nodes = new ArrayList<>();
+        Node n0 = factory.createNodeWithNewId(toE7(51.5019433D), toE7(-0.1423007D));
+        nodes.add(n0);
+        Node n1 = factory.createNodeWithNewId(toE7(51.5019019D), toE7(-0.1421827D));
+        nodes.add(n1);
+        Node n2 = factory.createNodeWithNewId(toE7(51.5018651D), toE7(-0.1423209D));
+        nodes.add(n2);
+        assertEquals(CLOCKWISE, winding(nodes));
+    }
+    
+    /**
+     * Check 3 nodes counterclockwise
+     */
+    @Test
+    public void counterclockwise() {
+        OsmElementFactory factory = App.getDelegator().getFactory();
+        List<Node> nodes = new ArrayList<>();
+        Node n0 = factory.createNodeWithNewId(toE7(51.5018651D), toE7(-0.1423209D));
+        nodes.add(n0);
+        Node n1 = factory.createNodeWithNewId(toE7(51.5019019D), toE7(-0.1421827D));
+        nodes.add(n1);
+        Node n2 = factory.createNodeWithNewId(toE7(51.5019433D), toE7(-0.1423007D));
+        nodes.add(n2);
+        assertEquals(COUNTERCLOCKWISE, winding(nodes));
+    }
+}

--- a/src/test/java/de/blau/android/util/WindingTest.java
+++ b/src/test/java/de/blau/android/util/WindingTest.java
@@ -1,13 +1,11 @@
 package de.blau.android.util;
 
 import static de.blau.android.osm.StorageDelegatorTest.toE7;
-import static de.blau.android.util.Winding.winding;
-import static de.blau.android.util.Winding.COLINEAR;
 import static de.blau.android.util.Winding.CLOCKWISE;
+import static de.blau.android.util.Winding.COLINEAR;
 import static de.blau.android.util.Winding.COUNTERCLOCKWISE;
-
+import static de.blau.android.util.Winding.winding;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
This adds code to the relation creation and extension action mode to specifically cater for multi-polygons. In particular it supports automatically determining roles and moving tags from relation members with "outer" role to the relation. 