### PR TITLE
Flexible label and icon styling

### DIFF
--- a/documentation/docs/tutorials/data_styling.md
+++ b/documentation/docs/tutorials/data_styling.md
@@ -1,15 +1,17 @@
 ## Vespucci Data Styling
-_Documentation for Vespucci 14.1_
+_Documentation for Vespucci 15.2_
 
 The data styling configuration is not a work of art, it was created ad hoc (in other words it is an awful hack) to allow slightly more flexible configuration of the rendering.
 
 ### Using custom style files in Vespucci
 
-Files need to have an unique _name_ attribute and a filename in the format _name_-profile.xml and be stored in the _Vespucci_ directory. 
+Files need to need have an unique _name_ attribute and the _.xml_ extension and reside in a _styles_ directory in an app specific files directory (for example _Android/data/de.blau.android/files/styles/test.xml_ ). Currently the legacy storage format and location continues to work: unique _name_ attribute and a filename in the format _name_-profile.xml and stored in the _Vespucci_ directory. 
 
 ### Style Elements and Attributes
 
 The styles are for a major part not much more than an external representation of the [Android Paint](https://developer.android.com/reference/android/graphics/Paint) objects. In particular color, style, cap, join and strokeWidth attributes map directly to the Paint fields.
+
+Node styling is limited to the __labelKey__ and __iconPath__ attributes.
 
 
 |Element                    | Attributes     | Description
@@ -25,7 +27,7 @@ The styles are for a major part not much more than an external representation of
 |                           | length         | User with min_handle_len, defines the minimum length a way segment must have on screen so that the geometry improvement handles are shown
 |                           | zoom           | Used with icon_zoom_limit, minimum zoom level at which POI icons are still displayed
 |__&lt;feature&gt;__        |                | Feature elements can be nested and each feature can contain one or more other feature elements. Nested elements inherit attributes from their parents. 
-|                           | type           | "way" or "relation" to match the corresponding OSM elements, or a name
+|                           | type           | "way", "node" or "relation" to match the corresponding OSM elements, or a name
 |                           | tags           | Tags to use for matching, ignored for named styles, in the format _key_=_value_ or _key_=_*_ for any value. Multiple tags can be added using __&vert;__ as a separator.
 |                           | closed         | If not present will match all ways, if present will match closed ways if true, or if false open ways, ignored for relations
 |                           | area           | Use area semantics for rendering if true
@@ -45,6 +47,8 @@ The styles are for a major part not much more than an external representation of
 |                           | casingStyle    | Reference to a style to use for casing
 |                           | arrowStyle     | Reference to a style to use for way arrows                          
 |                           | oneway         | Set this on the referenced arrowStyle if it should have oneway semantics
+|                           | labelKey       | Tag key to use as label if present, magic value "preset" will use the preset name.
+|                           | iconPath       | Path, relative to the directory in which the style file resides, to a PNG format icon, magic value "preset" will use the preset icon.
 |__&lt;dash&gt;__           |                | feature sub-element used to define a dash pattern
 |                           | phase          | Phase of the dash
 |__&lt;interval&gt;__       |                | dash sub-element used to define the length of the dash/no-dash phases

--- a/documentation/docs/tutorials/data_styling.md
+++ b/documentation/docs/tutorials/data_styling.md
@@ -5,7 +5,7 @@ The data styling configuration is not a work of art, it was created ad hoc (in o
 
 ### Using custom style files in Vespucci
 
-Files need to need have an unique _name_ attribute and the _.xml_ extension and reside in a _styles_ directory in an app specific files directory (for example _Android/data/de.blau.android/files/styles/test.xml_ ). Currently the legacy storage format and location continues to work: unique _name_ attribute and a filename in the format _name_-profile.xml and stored in the _Vespucci_ directory. 
+Files need to need have an unique _name_ attribute and the _.xml_ extension and reside in a _styles_ directory in an app specific files directory (for example _Android/data/de.blau.android/files/styles/test.xml_ ). Currently the legacy storage format and location continues to work: unique _name_ attribute and a filename in the format _name_-profile.xml and stored in the _Vespucci_ directory, this is the only location that will work for devices with Android version older than 4.4. 
 
 ### Style Elements and Attributes
 

--- a/src/main/assets/styles/Color-round-no-mp.xml
+++ b/src/main/assets/styles/Color-round-no-mp.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' ?>
-<profile name="Color Round Nodes" format="0.2.0">
+<profile name="Color Round Nodes No Multipolygons" format="0.2.0">
     <!-- Assorted config -->
     <config type="min_handle_length" length="200.0" />
     <config type="icon_zoom_limit" zoom="15" />
@@ -54,6 +54,10 @@
     <feature type="oneway_direction" updateWidth="true" widthFactor="0.5" color="ffb9121b" style="STROKE" cap="SQUARE" join="MITER" oneway="true" />
     <feature type="waterway_direction" updateWidth="true" widthFactor="0.5" color="ff0000bb" style="STROKE" cap="SQUARE" join="MITER" />
     
+    <!-- OSM node based features -->
+    <feature type="node" tags="name" labelKey="name"/>
+    <feature type="node" tags="entrance|addr:housenumber" labelKey="addr:housenumber" />
+    
     <!-- OSM way based features -->
     <feature type="way" updateWidth="true" widthFactor="1.0" color="80000000" style="STROKE" cap="BUTT" join="MITER" />
     <feature type="way" tags="boundary" updateWidth="true" widthFactor="0.6" color="ff000000" style="STROKE" cap="BUTT" join="MITER">
@@ -101,7 +105,9 @@
         <feature type="way" tags="man_made=embankment" color="ff996633" pathPattern="triangle_right" />
         <feature type="way" tags="man_made=bridge" color="aa585c63" closed="true" area="true" pathPattern="border_right" />
     </feature>
-    <feature type="way" tags="building" updateWidth="true" widthFactor="1.0" color="ffcc9999" style="STROKE" cap="BUTT" join="MITER" />
+    <feature type="way" tags="building" updateWidth="true" widthFactor="1.0" color="ffcc9999" style="STROKE" cap="BUTT" join="MITER" >
+        <feature type="way" tags="building|addr:housenumber" closed="true" labelKey="addr:housenumber"/>
+    </feature>
     <feature type="way" tags="building:part" updateWidth="true" widthFactor="0.8" color="ffcc9999" style="STROKE" cap="BUTT" join="MITER" >
     	<dash phase="1.0">
     		<interval length="2.0" />
@@ -333,30 +339,6 @@
         <feature type="way" tags="indoor=corridor" updateWidth="true" widthFactor="0.7" color="99f2c791" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
     </feature>
     
-    <!-- relations (only multipolygons currently -->
-    <feature type="relation" updateWidth="true" widthFactor="1.0" color="ff222222" style="STROKE" cap="BUTT" join="MITER" />
-    <feature type="relation" tags="type=multipolygon" updateWidth="true" widthFactor="0.8" color="88222222" style="STROKE" cap="BUTT" join="MITER" pathPattern="border_right">
-        <feature type="relation" tags="building" widthFactor="1.0" color="ffcc9999"/>
-        <feature type="relation" tags="leisure=playground" widthFactor="0.8" color="88f4a460" style="FILL_AND_STROKE" />
-        <feature type="relation" tags="leisure=pitch" updateWidth="true" widthFactor="1.0" color="8839AC39" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
-        <feature type="relation" tags="leisure=swimming_pool" updateWidth="true" widthFactor="1.0" color="880000ff" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
-        <feature type="relation" tags="leisure=garden" updateWidth="true" widthFactor="1.0" color="882d6e3a" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />    
-        
-        <feature type="relation" tags="natural" color="ff71BE80" >
-            <feature type="relation" tags="natural=water" widthFactor="1.0" minVisibleZoom="10" color="ff0000ff" />
-            <feature type="relation" tags="natural=cliff" widthFactor="2.0" color="ff555555" pathPattern="triangle_right" />
-            <feature type="relation" tags="natural=coastline" widthFactor="2.0" minVisibleZoom="10" color="ff71BE80" pathPattern="triangle_left" />
-            <feature type="relation" tags="natural=tree_row" widthFactor="2.0" color="ff4b7a54" cap="ROUND" />
-        </feature>
-        <feature type="relation" tags="landuse" updateWidth="true" widthFactor="2.0" color="8871BE80" style="STROKE" cap="BUTT" join="BEVEL" pathPattern="border_right" >
-            <feature type="relation" tags="landuse=construction" color="88996633" />
-            <feature type="relation" tags="landuse=residential" minVisibleZoom="10" color="88888888" />
-            <feature type="relation" tags="landuse=quarry" color="88d8a2a2" />
-            <feature type="relation" tags="landuse=military" color="88af2626" />
-            <feature type="relation" tags="landuse=forest" minVisibleZoom="10" color="8800BE00" />
-            <feature type="relation" tags="landuse=industrial" minVisibleZoom="10" color="88A3709A" />
-            <feature type="relation" tags="landuse=commercial" minVisibleZoom="10" color="88A3709A" />
-            <feature type="relation" tags="landuse=railway" minVisibleZoom="10" color="88A3709A" />
-        </feature>
-    </feature>
+    <!-- relations  -->
+    <feature type="relation" dontrender="true" updateWidth="true" widthFactor="1.0" color="ff222222" style="STROKE" cap="BUTT" join="MITER" />
 </profile>

--- a/src/main/assets/styles/Color-round.xml
+++ b/src/main/assets/styles/Color-round.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' ?>
-<profile name="Color Round Nodes No Multipolygons" format="0.2.0">
+<profile name="Color Round Nodes" format="0.2.0">
     <!-- Assorted config -->
     <config type="min_handle_length" length="200.0" />
     <config type="icon_zoom_limit" zoom="15" />
@@ -54,6 +54,10 @@
     <feature type="oneway_direction" updateWidth="true" widthFactor="0.5" color="ffb9121b" style="STROKE" cap="SQUARE" join="MITER" oneway="true" />
     <feature type="waterway_direction" updateWidth="true" widthFactor="0.5" color="ff0000bb" style="STROKE" cap="SQUARE" join="MITER" />
     
+    <!-- OSM node based features -->
+    <feature type="node" tags="name" labelKey="name"/>
+    <feature type="node" tags="entrance|addr:housenumber" labelKey="addr:housenumber" />
+    
     <!-- OSM way based features -->
     <feature type="way" updateWidth="true" widthFactor="1.0" color="80000000" style="STROKE" cap="BUTT" join="MITER" />
     <feature type="way" tags="boundary" updateWidth="true" widthFactor="0.6" color="ff000000" style="STROKE" cap="BUTT" join="MITER">
@@ -101,7 +105,9 @@
         <feature type="way" tags="man_made=embankment" color="ff996633" pathPattern="triangle_right" />
         <feature type="way" tags="man_made=bridge" color="aa585c63" closed="true" area="true" pathPattern="border_right" />
     </feature>
-    <feature type="way" tags="building" updateWidth="true" widthFactor="1.0" color="ffcc9999" style="STROKE" cap="BUTT" join="MITER" />
+    <feature type="way" tags="building" updateWidth="true" widthFactor="1.0" color="ffcc9999" style="STROKE" cap="BUTT" join="MITER" >
+        <feature type="way" tags="building|addr:housenumber" closed="true" labelKey="addr:housenumber"/>
+    </feature>
     <feature type="way" tags="building:part" updateWidth="true" widthFactor="0.8" color="ffcc9999" style="STROKE" cap="BUTT" join="MITER" >
     	<dash phase="1.0">
     		<interval length="2.0" />
@@ -333,6 +339,30 @@
         <feature type="way" tags="indoor=corridor" updateWidth="true" widthFactor="0.7" color="99f2c791" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
     </feature>
     
-    <!-- relations  -->
-    <feature type="relation" dontrender="true" updateWidth="true" widthFactor="1.0" color="ff222222" style="STROKE" cap="BUTT" join="MITER" />
+    <!-- relations (only multipolygons currently -->
+    <feature type="relation" updateWidth="true" widthFactor="1.0" color="ff222222" style="STROKE" cap="BUTT" join="MITER" />
+    <feature type="relation" tags="type=multipolygon" updateWidth="true" widthFactor="0.8" color="88222222" style="STROKE" cap="BUTT" join="MITER" pathPattern="border_right">
+        <feature type="relation" tags="building" widthFactor="1.0" color="ffcc9999"/>
+        <feature type="relation" tags="leisure=playground" widthFactor="0.8" color="88f4a460" style="FILL_AND_STROKE" />
+        <feature type="relation" tags="leisure=pitch" updateWidth="true" widthFactor="1.0" color="8839AC39" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
+        <feature type="relation" tags="leisure=swimming_pool" updateWidth="true" widthFactor="1.0" color="880000ff" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
+        <feature type="relation" tags="leisure=garden" updateWidth="true" widthFactor="1.0" color="882d6e3a" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />    
+        
+        <feature type="relation" tags="natural" color="ff71BE80" >
+            <feature type="relation" tags="natural=water" widthFactor="1.0" minVisibleZoom="10" color="ff0000ff" />
+            <feature type="relation" tags="natural=cliff" widthFactor="2.0" color="ff555555" pathPattern="triangle_right" />
+            <feature type="relation" tags="natural=coastline" widthFactor="2.0" minVisibleZoom="10" color="ff71BE80" pathPattern="triangle_left" />
+            <feature type="relation" tags="natural=tree_row" widthFactor="2.0" color="ff4b7a54" cap="ROUND" />
+        </feature>
+        <feature type="relation" tags="landuse" updateWidth="true" widthFactor="2.0" color="8871BE80" style="STROKE" cap="BUTT" join="BEVEL" pathPattern="border_right" >
+            <feature type="relation" tags="landuse=construction" color="88996633" />
+            <feature type="relation" tags="landuse=residential" minVisibleZoom="10" color="88888888" />
+            <feature type="relation" tags="landuse=quarry" color="88d8a2a2" />
+            <feature type="relation" tags="landuse=military" color="88af2626" />
+            <feature type="relation" tags="landuse=forest" minVisibleZoom="10" color="8800BE00" />
+            <feature type="relation" tags="landuse=industrial" minVisibleZoom="10" color="88A3709A" />
+            <feature type="relation" tags="landuse=commercial" minVisibleZoom="10" color="88A3709A" />
+            <feature type="relation" tags="landuse=railway" minVisibleZoom="10" color="88A3709A" />
+        </feature>
+    </feature>
 </profile>

--- a/src/main/assets/styles/Pen-round.xml
+++ b/src/main/assets/styles/Pen-round.xml
@@ -54,6 +54,10 @@
     <feature type="oneway_direction" updateWidth="true" widthFactor="0.5" color="ffb9121b" style="STROKE" cap="SQUARE" join="MITER" oneway="true" />
     <feature type="waterway_direction" updateWidth="true" widthFactor="0.5" color="ff0000bb" style="STROKE" cap="SQUARE" join="MITER" />
     
+    <!-- OSM node based features -->
+    <feature type="node" tags="name" labelKey="name"/>
+    <feature type="node" tags="entrance|addr:housenumber" labelKey="addr:housenumber" />
+    
     <!-- OSM way based features -->
     <feature type="way" updateWidth="true" widthFactor="1.0" color="80000000" style="STROKE" cap="BUTT" join="MITER" />
     <feature type="way" tags="boundary" updateWidth="true" widthFactor="0.6" color="ff000000" style="STROKE" cap="BUTT" join="MITER">
@@ -101,7 +105,9 @@
         <feature type="way" tags="man_made=embankment" color="ff996633" pathPattern="triangle_right" />
         <feature type="way" tags="man_made=bridge" color="aa585c63" closed="true" area="true" pathPattern="border_right" />
     </feature>
-    <feature type="way" tags="building" updateWidth="true" widthFactor="1.0" color="ffcc9999" style="STROKE" cap="BUTT" join="MITER" />
+    <feature type="way" tags="building" updateWidth="true" widthFactor="1.0" color="ffcc9999" style="STROKE" cap="BUTT" join="MITER" >
+        <feature type="way" tags="building|addr:housenumber" closed="true" labelKey="addr:housenumber"/>
+    </feature>
     <feature type="way" tags="building:part" updateWidth="true" widthFactor="0.8" color="ffcc9999" style="STROKE" cap="BUTT" join="MITER" >
     	<dash phase="1.0">
     		<interval length="2.0" />

--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -92,6 +92,7 @@ import de.blau.android.osm.ViewBox;
 import de.blau.android.osm.Way;
 import de.blau.android.prefs.Preferences;
 import de.blau.android.resources.DataStyle;
+import de.blau.android.resources.DataStyle.FeatureStyle;
 import de.blau.android.resources.TileLayerSource;
 import de.blau.android.tasks.Note;
 import de.blau.android.tasks.Task;
@@ -884,13 +885,12 @@ public class Logic {
     /**
      * Determine if the way should have an icon shown and should respond to a touch event on the icon
      * 
-     * Note this should be made configurable in the long run
-     * 
      * @param way the way in question
      * @return true if we should have an icon
      */
-    public static boolean areaHasIcon(Way way) {
-        return way.isClosed() && (way.hasTagKey(Tags.KEY_BUILDING) || way.hasTag(Tags.KEY_INDOOR, Tags.VALUE_ROOM));
+    private static boolean areaHasIcon(@NonNull Way way) {
+        final FeatureStyle style = DataStyle.matchStyle(way);
+        return style.getIconPath() != null || style.getLabelKey() != null;
     }
 
     /**

--- a/src/main/java/de/blau/android/contract/Paths.java
+++ b/src/main/java/de/blau/android/contract/Paths.java
@@ -14,10 +14,13 @@ public final class Paths {
     public static final String DIRECTORY_PATH_EXTERNAL_SD_CARD   = "/external_sd";   // NOSONAR
     public static final String DIRECTORY_PATH_PICTURES           = "Pictures";
     public static final String DIRECTORY_PATH_SCRIPTS            = "Scripts";
+    public static final String DIRECTORY_PATH_STYLES             = "styles";
     public static final String DIRECTORY_PATH_STORAGE            = "/storage";       // NOSONAR
     public static final String DIRECTORY_PATH_VESPUCCI           = "Vespucci";
     public static final String DIRECTORY_PATH_AUTOPRESET         = "autopreset";
     public static final String DIRECTORY_PATH_TILE_CACHE         = "/tiles/";        // NOSONAR
     public static final String DIRECTORY_PATH_TILE_CACHE_CLASSIC = "/andnav2/tiles/";// NOSONAR
     public static final String FILE_EXTENSION_IMAGE              = ".jpg";
+    public static final String FILE_EXTENSION_XML                = ".xml";
+    public static final String DELIMITER                         = "/";
 }

--- a/src/main/java/de/blau/android/osm/OsmElement.java
+++ b/src/main/java/de/blau/android/osm/OsmElement.java
@@ -290,7 +290,7 @@ public abstract class OsmElement implements Serializable, XmlSerializable, JosmX
      * @param value the value that we are checking
      * @return true if the key - value combination is present
      */
-    public boolean hasTagWithValue(String tagKey, String value) {
+    public boolean hasTagWithValue(@NonNull String tagKey, @NonNull String value) {
         String tagValue = getTagWithKey(tagKey);
         return tagValue != null && tagValue.equalsIgnoreCase(value);
     }
@@ -299,7 +299,8 @@ public abstract class OsmElement implements Serializable, XmlSerializable, JosmX
      * @param key the key to search for (case sensitive)
      * @return the value of this key.
      */
-    public String getTagWithKey(final String key) {
+    @Nullable
+    public String getTagWithKey(@NonNull final String key) {
         if (tags == null) {
             return null;
         }
@@ -310,7 +311,7 @@ public abstract class OsmElement implements Serializable, XmlSerializable, JosmX
      * @param key the key to search for (case sensitive)
      * @return true if the element has a tag with this key.
      */
-    public boolean hasTagKey(final String key) {
+    public boolean hasTagKey(@NonNull final String key) {
         return getTagWithKey(key) != null;
     }
 

--- a/src/main/java/de/blau/android/osm/StyleableFeature.java
+++ b/src/main/java/de/blau/android/osm/StyleableFeature.java
@@ -7,7 +7,7 @@ public interface StyleableFeature {
     /**
      * Get the rendering style for this way
      * 
-     * @return the style of null if not set
+     * @return the style or null if not set
      */
     public FeatureStyle getStyle();
 

--- a/src/main/java/de/blau/android/presets/PresetIconManager.java
+++ b/src/main/java/de/blau/android/presets/PresetIconManager.java
@@ -120,24 +120,33 @@ public class PresetIconManager {
             } else {
                 Log.e(DEBUG_TAG, "unknown icon URL type for " + url);
             }
-
             if (pngStream == null) {
                 return null;
             }
-
-            // resources used only for density
-            BitmapDrawable drawable = new BitmapDrawable(context.getResources(), BitmapFactory.decodeStream(pngStream));
-            drawable.getBitmap().setDensity(Bitmap.DENSITY_NONE);
-            int pxsize = Density.dpToPx(context, size);
-            Log.d(DEBUG_TAG, "icon " + url + " size " + size + " pxsize " + pxsize);
-            drawable.setBounds(0, 0, pxsize, pxsize);
-            return drawable;
+            return bitmapDrawableFromStream(context, size, pngStream);
         } catch (Exception e) {
             Log.e(DEBUG_TAG, "Failed to load preset icon " + url, e);
             return null;
         } finally {
             SavingHelper.close(pngStream);
         }
+    }
+
+    /**
+     * Decode a BitmapDrawable from an InputStream
+     * 
+     * @param context an Android Context
+     * @param size size of the Drawable
+     * @param pngStream the InputStream
+     * @return a BitmapDrawable
+     */
+    public static BitmapDrawable bitmapDrawableFromStream(@NonNull Context context, int size, @NonNull InputStream pngStream) {
+        // resources used only for density
+        BitmapDrawable drawable = new BitmapDrawable(context.getResources(), BitmapFactory.decodeStream(pngStream));
+        drawable.getBitmap().setDensity(Bitmap.DENSITY_NONE);
+        int pxsize = Density.dpToPx(context, size);
+        drawable.setBounds(0, 0, pxsize, pxsize);
+        return drawable;
     }
 
     /**

--- a/src/main/java/de/blau/android/resources/DataStyle.java
+++ b/src/main/java/de/blau/android/resources/DataStyle.java
@@ -63,7 +63,6 @@ import de.blau.android.util.Snack;
 import de.blau.android.util.Version;
 
 public final class DataStyle extends DefaultHandler {
-
     private static final String I18N_DATASTYLE = "i18n/datastyle_";
 
     private static final String DEBUG_TAG = "DataStyle";
@@ -153,6 +152,14 @@ public final class DataStyle extends DefaultHandler {
     private static final String ARROW_STYLE_ATTR      = "arrowStyle";
     private static final String CASING_STYLE_ATTR     = "casingStyle";
     private static final String VALIDATION            = "validation";
+    private static final String CODE_ATTR             = "code";
+    private static final String SCALE_ATTR            = "scale";
+    private static final String TOUCH_RADIUS_ATTR     = "touchRadius";
+    private static final String ZOOM_ATTR             = "zoom";
+    private static final String TYPE_ATTR             = "type";
+    private static final String FORMAT_ATTR           = "format";
+    private static final String NAME_ATTR             = "name";
+    private static final String TAGS_ATTR             = "tags";
 
     private static final int DEFAULT_MIN_VISIBLE_ZOOM = 15;
 
@@ -1314,8 +1321,8 @@ public final class DataStyle extends DefaultHandler {
     public void startElement(final String uri, final String element, final String qName, final Attributes atts) {
         try {
             if (element.equals(PROFILE_ELEMENT)) {
-                name = atts.getValue("name");
-                String format = atts.getValue("format");
+                name = atts.getValue(NAME_ATTR);
+                String format = atts.getValue(FORMAT_ATTR);
                 if (format != null) {
                     Version v = new Version(format);
                     if (v.getMajor() == CURRENT_VERSION.getMajor() && v.getMinor() == CURRENT_VERSION.getMinor()) {
@@ -1326,15 +1333,15 @@ public final class DataStyle extends DefaultHandler {
                 Log.e(DEBUG_TAG, "format attribute missing or wrong for " + name);
                 throw new SAXException("format attribute missing or wrong for " + name);
             } else if (element.equals(CONFIG_ELEMENT)) {
-                type = atts.getValue("type");
+                type = atts.getValue(TYPE_ATTR);
                 if (type != null) {
                     switch (type) {
                     case LARGE_DRAG_AREA:
                         // special handling
-                        largDragToleranceRadius = Density.dpToPx(ctx, Float.parseFloat(atts.getValue("touchRadius")));
+                        largDragToleranceRadius = Density.dpToPx(ctx, Float.parseFloat(atts.getValue(TOUCH_RADIUS_ATTR)));
                         return;
                     case MARKER_SCALE:
-                        float scale = Float.parseFloat(atts.getValue("scale"));
+                        float scale = Float.parseFloat(atts.getValue(SCALE_ATTR));
                         createOrientationPath(scale);
                         createWayPointPath(scale);
                         createCrosshairsPath(scale);
@@ -1348,7 +1355,7 @@ public final class DataStyle extends DefaultHandler {
                         }
                         return;
                     case ICON_ZOOM_LIMIT:
-                        String zoomStr = atts.getValue("zoom");
+                        String zoomStr = atts.getValue(ZOOM_ATTR);
                         if (zoomStr != null) {
                             iconZoomLimit = Integer.parseInt(zoomStr);
                         }
@@ -1358,13 +1365,13 @@ public final class DataStyle extends DefaultHandler {
                     }
                 }
             } else if (element.equals(FEATURE_ELEMENT)) {
-                type = atts.getValue("type");
+                type = atts.getValue(TYPE_ATTR);
                 if (tempFeatureStyle != null) { // we already have a style, save it
                     styleStack.push(tempFeatureStyle);
                     parent = tempFeatureStyle;
                 }
 
-                tags = atts.getValue("tags");
+                tags = atts.getValue(TAGS_ATTR);
                 if (Way.NAME.equals(type) || Relation.NAME.equals(type)) {
                     if (parent != null) {
                         tempFeatureStyle = new FeatureStyle(tags == null ? "" : tags, parent); // inherit
@@ -1465,7 +1472,7 @@ public final class DataStyle extends DefaultHandler {
                 }
 
                 validationCode = 0; // reset
-                String codeString = atts.getValue("code");
+                String codeString = atts.getValue(CODE_ATTR);
                 if (codeString != null) {
                     validationCode = Integer.parseInt(codeString);
                 }

--- a/src/main/java/de/blau/android/resources/DataStyle.java
+++ b/src/main/java/de/blau/android/resources/DataStyle.java
@@ -30,7 +30,6 @@ import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlPullParserFactory;
 import org.xmlpull.v1.XmlSerializer;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.res.AssetManager;
 import android.graphics.Color;
@@ -52,6 +51,7 @@ import ch.poole.poparser.Po;
 import de.blau.android.R;
 import de.blau.android.contract.FileExtensions;
 import de.blau.android.contract.Paths;
+import de.blau.android.osm.Node;
 import de.blau.android.osm.OsmElement;
 import de.blau.android.osm.OsmXml;
 import de.blau.android.osm.Relation;
@@ -61,6 +61,7 @@ import de.blau.android.util.Density;
 import de.blau.android.util.SavingHelper;
 import de.blau.android.util.Snack;
 import de.blau.android.util.Version;
+import de.blau.android.util.XmlFileFilter;
 
 public final class DataStyle extends DefaultHandler {
     private static final String I18N_DATASTYLE = "i18n/datastyle_";
@@ -160,6 +161,9 @@ public final class DataStyle extends DefaultHandler {
     private static final String FORMAT_ATTR           = "format";
     private static final String NAME_ATTR             = "name";
     private static final String TAGS_ATTR             = "tags";
+    private static final String LABEL_KEY_ATTR        = "labelKey";
+    private static final String ICON_PATH_ATTR        = "iconPath";
+    private static final String PRESET                = "preset";
 
     private static final int DEFAULT_MIN_VISIBLE_ZOOM = 15;
 
@@ -179,6 +183,8 @@ public final class DataStyle extends DefaultHandler {
         private FeatureStyle      casingStyle    = null;
         private boolean           oneway         = false;
         private Boolean           closed         = null;
+        private String            labelKey       = null;
+        private String            iconPath       = null;
 
         List<FeatureStyle> cascadedStyles = null;
 
@@ -249,6 +255,9 @@ public final class DataStyle extends DefaultHandler {
             arrowStyle = fp.arrowStyle;
             casingStyle = fp.casingStyle;
             oneway = fp.oneway;
+            closed = fp.closed;
+            labelKey = fp.labelKey;
+            iconPath = fp.iconPath;
             cascadedStyles = null;
         }
 
@@ -527,6 +536,62 @@ public final class DataStyle extends DefaultHandler {
         }
 
         /**
+         * Set the label key
+         * 
+         * @param key the key
+         */
+        public void setLabelKey(@Nullable String key) {
+            labelKey = key;
+        }
+
+        /**
+         * Get the label key
+         * 
+         * @return the key or null if not set
+         */
+        @Nullable
+        public String getLabelKey() {
+            return labelKey;
+        }
+
+        /**
+         * Check if labelkey is set to "preset"
+         * 
+         * @return true if the magic value is set
+         */
+        public boolean usePresetLabel() {
+            return PRESET.equals(labelKey);
+        }
+
+        /**
+         * Check if the iconPath is set to "preset"
+         * 
+         * @return true if the magic value is set
+         */
+        public boolean usePresetIcon() {
+            return PRESET.equals(iconPath);
+        }
+
+        /**
+         * Set the icon path
+         * 
+         * @param path the path
+         */
+        public void setIconPath(@Nullable String path) {
+            iconPath = iconDirPath != null && path != null && !PRESET.equals(path) ? iconDirPath + Paths.DELIMITER + path : path;
+        }
+
+        /**
+         * Get the icon path
+         * 
+         * @return the path or null if not set
+         */
+        @Nullable
+        public String getIconPath() {
+            return iconPath;
+        }
+
+        /**
          * Dump this Style in XML format, not very abstracted and closely tied to the implementation
          * 
          * @param s an XmlSerialzer instance
@@ -545,6 +610,12 @@ public final class DataStyle extends DefaultHandler {
                 s.attribute("", CLOSED_ATTR, Boolean.toString(closed));
             }
             s.attribute("", ONEWAY_ATTR, Boolean.toString(oneway));
+            if (labelKey != null) {
+                s.attribute("", LABEL_KEY_ATTR, labelKey);
+            }
+            if (iconPath != null) {
+                s.attribute("", ICON_PATH_ATTR, iconPath);
+            }
             //
             s.attribute("", COLOR_ATTR, Integer.toHexString(getPaint().getColor()));
             // alpha should be contained in color
@@ -595,6 +666,7 @@ public final class DataStyle extends DefaultHandler {
     private String                     name;
     private Map<String, FeatureStyle>  internalStyles;
     private Map<Integer, FeatureStyle> validationStyles;
+    private FeatureStyle               nodeStyles;
     private FeatureStyle               wayStyles;
     private FeatureStyle               relationStyles;
 
@@ -645,6 +717,7 @@ public final class DataStyle extends DefaultHandler {
     private int   iconZoomLimit;
 
     private final Context ctx;
+    private String        iconDirPath;
 
     /**
      * Create minimum default style
@@ -661,9 +734,11 @@ public final class DataStyle extends DefaultHandler {
      * 
      * @param ctx Android Context
      * @param is the InputStream
+     * @param iconDirPath dir to use for icons
      */
-    private DataStyle(@NonNull Context ctx, @NonNull InputStream is) {
+    private DataStyle(@NonNull Context ctx, @NonNull InputStream is, @Nullable String iconDirPath) {
         this.ctx = ctx;
+        this.iconDirPath = iconDirPath;
         init(); // defaults for internal styles
         try {
             read(is);
@@ -701,7 +776,6 @@ public final class DataStyle extends DefaultHandler {
 
         FeatureStyle baseWayStyle = new FeatureStyle(WAY, standardPath);
         baseWayStyle.setColor(Color.BLACK);
-        wayStyles = baseWayStyle;
 
         FeatureStyle fp = new FeatureStyle(PROBLEM_WAY, standardPath);
         int problemColor = ContextCompat.getColor(ctx, R.color.problem);
@@ -1031,6 +1105,11 @@ public final class DataStyle extends DefaultHandler {
         fp = new FeatureStyle("", standardPath);
         fp.setColor(Color.BLACK);
         fp.setWidthFactor(1f);
+        nodeStyles = fp;
+
+        fp = new FeatureStyle("", standardPath);
+        fp.setColor(Color.BLACK);
+        fp.setWidthFactor(1f);
         relationStyles = fp;
 
         Log.i(DEBUG_TAG, "... done");
@@ -1213,14 +1292,14 @@ public final class DataStyle extends DefaultHandler {
     /**
      * Get the list of available Styles
      * 
-     * @param activity the calling Activity
+     * @param context an Android Context
      * @return list of available Styles (Default entry first, rest sorted)
      */
     @NonNull
-    public static String[] getStyleList(@NonNull Activity activity) {
+    public static String[] getStyleList(@NonNull Context context) {
         if (availableStyles.size() == 0) { // shouldn't happen
             Log.e(DEBUG_TAG, "getStyleList called before initialized");
-            addDefaultStye(activity);
+            addDefaultStyle(context);
         }
         // creating the default style object will set availableStyles
         String[] res = new String[availableStyles.size()];
@@ -1240,16 +1319,17 @@ public final class DataStyle extends DefaultHandler {
     /**
      * Get the list of available Styles translated
      * 
-     * @param activity the calling Activity
+     * @param context an Android Context
+     * @param the list of style names to translate
      * @return list of available Styles translated (or untranslated if no translation is avilable)
      */
     @NonNull
-    public static String[] getStyleListTranslated(@NonNull Activity activity, String[] styleNames) {
+    public static String[] getStyleListTranslated(@NonNull Context context, @NonNull String[] styleNames) {
         Locale locale = Locale.getDefault();
         String language = locale.getLanguage();
         InputStream poFileStream = null;
         try {
-            AssetManager assetManager = activity.getAssets();
+            AssetManager assetManager = context.getAssets();
             try {
                 poFileStream = assetManager.open(I18N_DATASTYLE + locale + "." + FileExtensions.PO);
             } catch (IOException ioex) {
@@ -1301,6 +1381,7 @@ public final class DataStyle extends DefaultHandler {
      */
     private void start(@NonNull final InputStream in) throws SAXException, IOException, ParserConfigurationException {
         SAXParserFactory factory = SAXParserFactory.newInstance(); // NOSONAR
+        factory.setNamespaceAware(true);
         SAXParser saxParser = factory.newSAXParser();
         saxParser.parse(in, this);
     }
@@ -1329,9 +1410,9 @@ public final class DataStyle extends DefaultHandler {
                         return; // everything OK
                     }
                 }
-                Snack.toastTopError(ctx, ctx.getString(R.string.toast_invalid_style_file, name));
-                Log.e(DEBUG_TAG, "format attribute missing or wrong for " + name);
-                throw new SAXException("format attribute missing or wrong for " + name);
+                Snack.toastTopError(ctx, ctx.getString(R.string.toast_invalid_style_file, getName()));
+                Log.e(DEBUG_TAG, "format attribute missing or wrong for " + getName());
+                throw new SAXException("format attribute missing or wrong for " + getName());
             } else if (element.equals(CONFIG_ELEMENT)) {
                 type = atts.getValue(TYPE_ATTR);
                 if (type != null) {
@@ -1372,7 +1453,7 @@ public final class DataStyle extends DefaultHandler {
                 }
 
                 tags = atts.getValue(TAGS_ATTR);
-                if (Way.NAME.equals(type) || Relation.NAME.equals(type)) {
+                if (Way.NAME.equals(type) || Relation.NAME.equals(type) || Node.NAME.equals(type)) {
                     if (parent != null) {
                         tempFeatureStyle = new FeatureStyle(tags == null ? "" : tags, parent); // inherit
                     } else {
@@ -1470,6 +1551,10 @@ public final class DataStyle extends DefaultHandler {
                 if (closedString != null) {
                     tempFeatureStyle.setClosed(Boolean.parseBoolean(closedString));
                 }
+
+                tempFeatureStyle.setLabelKey(atts.getValue(LABEL_KEY_ATTR));
+
+                tempFeatureStyle.setIconPath(atts.getValue(ICON_PATH_ATTR));
 
                 validationCode = 0; // reset
                 String codeString = atts.getValue(CODE_ATTR);
@@ -1578,6 +1663,14 @@ public final class DataStyle extends DefaultHandler {
                     parent.addStyle(tempFeatureStyle);
                 }
                 break;
+            case Node.NAME:
+                if (tags == null) {
+                    nodeStyles = tempFeatureStyle;
+                    parent = nodeStyles;
+                } else {
+                    parent.addStyle(tempFeatureStyle);
+                }
+                break;
             case Relation.NAME:
                 if (tags == null) {
                     relationStyles = tempFeatureStyle;
@@ -1604,6 +1697,9 @@ public final class DataStyle extends DefaultHandler {
                     switch (type) {
                     case Way.NAME:
                         parent = wayStyles;
+                        break;
+                    case Node.NAME:
+                        parent = nodeStyles;
                         break;
                     case Relation.NAME:
                         parent = relationStyles;
@@ -1646,20 +1742,21 @@ public final class DataStyle extends DefaultHandler {
         if (availableStyles.size() == 0) {
             Log.i(DEBUG_TAG, "No style files found");
             // no files, need to install a default
-            addDefaultStye(ctx);
+            addDefaultStyle(ctx);
         }
         // assets directory
         AssetManager assetManager = ctx.getAssets();
         //
         try {
-            String[] fileList = assetManager.list("");
+            String[] fileList = assetManager.list(Paths.DIRECTORY_PATH_STYLES);
             if (fileList != null) {
                 for (String fn : fileList) {
-                    if (fn.endsWith(FILE_PATH_STYLE_SUFFIX)) {
-                        Log.i(DEBUG_TAG, "Creating profile from file in assets directory " + fn);
-                        InputStream is = assetManager.open(fn);
-                        DataStyle p = new DataStyle(ctx, is);
-                        availableStyles.put(p.name, p);
+                    if (fn.endsWith(Paths.FILE_EXTENSION_XML)) {
+                        Log.i(DEBUG_TAG, "Creating style from file in assets directory " + fn);
+                        try (InputStream is = assetManager.open(Paths.DIRECTORY_PATH_STYLES + Paths.DELIMITER + fn)) {
+                            DataStyle p = new DataStyle(ctx, is, null);
+                            availableStyles.put(p.getName(), p);
+                        }
                     }
                 }
             }
@@ -1667,31 +1764,54 @@ public final class DataStyle extends DefaultHandler {
             Log.i(DEBUG_TAG, ex.toString());
         }
 
-        // from sdcard
+        // from "sdcard" this will stop working with android 11 or so
         File sdcard = Environment.getExternalStorageDirectory();
         File indir = new File(sdcard, Paths.DIRECTORY_PATH_VESPUCCI);
-        if (indir != null) {
-            class StyleFilter implements FilenameFilter {
-                @Override
-                public boolean accept(File dir, String name) {
-                    return name.endsWith(FILE_PATH_STYLE_SUFFIX);
-                }
+        class StyleFilter implements FilenameFilter {
+            @Override
+            public boolean accept(File dir, String name) {
+                return name.endsWith(FILE_PATH_STYLE_SUFFIX);
             }
+        }
+        try {
             File[] list = indir.listFiles(new StyleFilter());
-            if (list != null) {
-                for (File f : list) {
-                    Log.i(DEBUG_TAG, "Creating profile from " + f.getName());
-                    try {
-                        InputStream is = new FileInputStream(f);
-                        DataStyle p = new DataStyle(ctx, is);
-                        // overwrites profile with same name
-                        availableStyles.put(p.name, p);
-                    } catch (Exception ex) {
-                        Log.i(DEBUG_TAG, ex.toString());
-                    }
-                }
-            }
+            readStylesFromFileList(ctx, list);
+        } catch (Exception ex) {
+            Log.e(DEBUG_TAG, "Unable to access directory " + indir.getAbsolutePath() + " " + ex.getMessage());
+        }
 
+        // from app specific directories
+        for (File fileDir : ctx.getExternalFilesDirs(null)) {
+            indir = new File(fileDir, Paths.DIRECTORY_PATH_STYLES);
+            try {
+                File[] list = indir.listFiles(new XmlFileFilter());
+                readStylesFromFileList(ctx, list);
+            } catch (Exception ex) {
+                Log.e(DEBUG_TAG, "Unable to access directory " + indir.getAbsolutePath() + " " + ex.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Read styles provided as a list of Files, adding them to the available styles
+     * 
+     * @param ctx an Android Context
+     * @param list the list
+     */
+    private static void readStylesFromFileList(@NonNull Context ctx, @Nullable File[] list) {
+        if (list == null) {
+            Log.w(DEBUG_TAG, "Null file list");
+            return;
+        }
+        for (File f : list) {
+            Log.i(DEBUG_TAG, "Creating profile from " + f.getName());
+            try (InputStream is = new FileInputStream(f)) {
+                DataStyle p = new DataStyle(ctx, is, f.getParent());
+                // overwrites profile with same name
+                availableStyles.put(p.getName(), p);
+            } catch (Exception ex) { // never crash
+                Log.i(DEBUG_TAG, ex.toString());
+            }
         }
     }
 
@@ -1700,11 +1820,19 @@ public final class DataStyle extends DefaultHandler {
      * 
      * @param ctx an Android Context
      */
-    private static void addDefaultStye(@NonNull Context ctx) {
+    private static void addDefaultStyle(@NonNull Context ctx) {
         DataStyle p = new DataStyle(ctx);
         p.name = BUILTIN_STYLE_NAME;
         currentStyle = p;
-        availableStyles.put(p.name, p);
+        availableStyles.put(p.getName(), p);
+    }
+
+    /**
+     * Reset contents used for testing only
+     */
+    public static void reset() {
+        availableStyles.clear();
+        currentStyle = null;
     }
 
     /**
@@ -1757,22 +1885,34 @@ public final class DataStyle extends DefaultHandler {
     }
 
     /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
      * Return the cached style for the element, or determine the style to use and cache it in the object
      * 
      * @param element the OsmElement we need the style for
-     * @param <T> an OsmElement that implements StyleableFeature
+     * @param <T> an OsmElement
      * @return the style
      */
     @NonNull
-    public static <T extends OsmElement & StyleableFeature> FeatureStyle matchStyle(@NonNull final T element) {
-        FeatureStyle style = element.getStyle();
+    public static <T extends OsmElement> FeatureStyle matchStyle(@NonNull final T element) {
+        final boolean styleable = element instanceof StyleableFeature;
+        FeatureStyle style = styleable ? ((StyleableFeature) element).getStyle() : null;
         if (style == null) {
             if (element instanceof Way) {
                 style = matchRecursive(currentStyle.wayStyles, element.getTags(), ((Way) element).isClosed());
+            } else if (element instanceof Node) {
+                style = matchRecursive(currentStyle.nodeStyles, element.getTags(), false);
             } else {
                 style = matchRecursive(currentStyle.relationStyles, element.getTags(), false);
             }
-            element.setStyle(style);
+            if (styleable) {
+                ((StyleableFeature) element).setStyle(style);
+            }
         }
         return style;
     }

--- a/src/main/java/de/blau/android/resources/DataStyle.java
+++ b/src/main/java/de/blau/android/resources/DataStyle.java
@@ -30,6 +30,7 @@ import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlPullParserFactory;
 import org.xmlpull.v1.XmlSerializer;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.AssetManager;
 import android.graphics.Color;
@@ -42,6 +43,7 @@ import android.graphics.Paint.Style;
 import android.graphics.Path;
 import android.graphics.PathDashPathEffect;
 import android.graphics.Typeface;
+import android.os.Build;
 import android.os.Environment;
 import android.util.Log;
 import androidx.annotation.NonNull;
@@ -1738,6 +1740,7 @@ public final class DataStyle extends DefaultHandler {
      * 
      * @param ctx Android Context
      */
+    @SuppressLint("NewApi")
     public static void getStylesFromFiles(@NonNull Context ctx) {
         if (availableStyles.size() == 0) {
             Log.i(DEBUG_TAG, "No style files found");
@@ -1765,6 +1768,7 @@ public final class DataStyle extends DefaultHandler {
         }
 
         // from "sdcard" this will stop working with android 11 or so
+        @SuppressWarnings("deprecation")
         File sdcard = Environment.getExternalStorageDirectory();
         File indir = new File(sdcard, Paths.DIRECTORY_PATH_VESPUCCI);
         class StyleFilter implements FilenameFilter {
@@ -1781,13 +1785,15 @@ public final class DataStyle extends DefaultHandler {
         }
 
         // from app specific directories
-        for (File fileDir : ctx.getExternalFilesDirs(null)) {
-            indir = new File(fileDir, Paths.DIRECTORY_PATH_STYLES);
-            try {
-                File[] list = indir.listFiles(new XmlFileFilter());
-                readStylesFromFileList(ctx, list);
-            } catch (Exception ex) {
-                Log.e(DEBUG_TAG, "Unable to access directory " + indir.getAbsolutePath() + " " + ex.getMessage());
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            for (File fileDir : ctx.getExternalFilesDirs(null)) {
+                indir = new File(fileDir, Paths.DIRECTORY_PATH_STYLES);
+                try {
+                    File[] list = indir.listFiles(new XmlFileFilter());
+                    readStylesFromFileList(ctx, list);
+                } catch (Exception ex) {
+                    Log.e(DEBUG_TAG, "Unable to access directory " + indir.getAbsolutePath() + " " + ex.getMessage());
+                }
             }
         }
     }

--- a/src/main/java/de/blau/android/util/XmlFileFilter.java
+++ b/src/main/java/de/blau/android/util/XmlFileFilter.java
@@ -1,0 +1,19 @@
+package de.blau.android.util;
+
+import java.io.File;
+import java.io.FilenameFilter;
+
+import de.blau.android.contract.Paths;
+
+/**
+ * Filter for .xml ending file names
+ * 
+ * @author Simon Poole
+ *
+ */
+public class XmlFileFilter implements FilenameFilter {
+    @Override
+    public boolean accept(File dir, String name) {
+        return name.endsWith(Paths.FILE_EXTENSION_XML);
+    }
+}

--- a/src/test/java/de/blau/android/osm/StorageDelegatorTest.java
+++ b/src/test/java/de/blau/android/osm/StorageDelegatorTest.java
@@ -99,7 +99,7 @@ public class StorageDelegatorTest {
      * @param close if true close the way
      * @return the way
      */
-    static Way addWayToStorage(@NonNull StorageDelegator d, boolean close) {
+    public static Way addWayToStorage(@NonNull StorageDelegator d, boolean close) {
         d.getUndo().createCheckpoint("add test way");
         OsmElementFactory factory = d.getFactory();
         Way w = factory.createWayWithNewId();

--- a/src/test/java/de/blau/android/resources/DataStyleTest.java
+++ b/src/test/java/de/blau/android/resources/DataStyleTest.java
@@ -1,0 +1,106 @@
+package de.blau.android.resources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.filters.LargeTest;
+import de.blau.android.App;
+import de.blau.android.JavaResources;
+import de.blau.android.contract.Paths;
+import de.blau.android.osm.Node;
+import de.blau.android.osm.StorageDelegator;
+import de.blau.android.osm.StorageDelegatorTest;
+import de.blau.android.osm.Tags;
+import de.blau.android.osm.Way;
+import de.blau.android.resources.DataStyle.FeatureStyle;
+
+@RunWith(RobolectricTestRunner.class)
+@LargeTest
+public class DataStyleTest {
+
+    /**
+     * Pre-test setup
+     */
+    @Before
+    public void setup() {
+        DataStyle.reset();
+    }
+
+    /**
+     * Test matching for a building with and without a house number
+     */
+    @Test
+    public void buildingTest() {
+        DataStyle.getStylesFromFiles(ApplicationProvider.getApplicationContext());
+        final StorageDelegator delegator = App.getDelegator();
+        Way w = StorageDelegatorTest.addWayToStorage(delegator, true);
+        Map<String, String> tags = new TreeMap<>();
+        tags.put(Tags.KEY_BUILDING, Tags.VALUE_YES);
+        delegator.setTags(w, tags);
+        assertEquals(4, DataStyle.getStyleList(ApplicationProvider.getApplicationContext()).length);
+        assertEquals(DataStyle.getBuiltinStyleName(), DataStyle.getCurrent().getName());
+        DataStyle.getStyle(DataStyle.getBuiltinStyleName());
+        DataStyle.switchTo("Color Round Nodes");
+        assertEquals("Color Round Nodes", DataStyle.getCurrent().getName());
+        FeatureStyle style = DataStyle.matchStyle(w);
+        assertEquals(((int) Long.parseLong("ffcc9999", 16)), style.getPaint().getColor());
+        assertNull(style.getLabelKey());
+        assertFalse(style.usePresetIcon());
+        assertFalse(style.isArea());
+        tags.put(Tags.KEY_ADDR_HOUSENUMBER, "111");
+        delegator.setTags(w, tags);
+        style = DataStyle.matchStyle(w);
+        assertEquals(Tags.KEY_ADDR_HOUSENUMBER, style.getLabelKey());
+    }
+
+    /**
+     * Load a custom style besides the standard ones
+     */
+    @Test
+    public void customStyle() {
+        try {
+            JavaResources.copyFileFromResources(ApplicationProvider.getApplicationContext(), "test-style.xml", "/" + Paths.DIRECTORY_PATH_STYLES, false);
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+        DataStyle.getStylesFromFiles(ApplicationProvider.getApplicationContext());
+        assertEquals(5, DataStyle.getStyleList(ApplicationProvider.getApplicationContext()).length);
+        // matching test
+        
+        final StorageDelegator delegator = App.getDelegator();
+        Node tree = delegator.getFactory().createNodeWithNewId(0, 0);
+        delegator.insertElementSafe(tree);
+        Map<String, String> tags = new TreeMap<>();
+        tags.put(Tags.KEY_NATURAL, "tree");
+        delegator.setTags(tree, tags);
+        DataStyle.switchTo("Test Style");
+        assertEquals("Test Style", DataStyle.getCurrent().getName());
+        FeatureStyle style = DataStyle.matchStyle(tree);
+        assertTrue(style.usePresetIcon());
+        tags.put("height", "1");
+        delegator.setTags(tree, tags);
+        style = DataStyle.matchStyle(tree);
+        assertTrue(style.getIconPath().endsWith("tree_height.png"));
+        tags.put("circumference", "2");
+        delegator.setTags(tree, tags);
+        style = DataStyle.matchStyle(tree);
+        assertTrue(style.getIconPath().endsWith("tree_height_circumference.png"));
+        tags.put("diameter_crown", "3");
+        delegator.setTags(tree, tags);
+        style = DataStyle.matchStyle(tree);
+        assertTrue(style.getIconPath().endsWith("tree_all.png"));
+    }
+}

--- a/src/test/resources/test-style.xml
+++ b/src/test/resources/test-style.xml
@@ -1,0 +1,377 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<profile name="Test Style" format="0.2.0">
+    <!-- Assorted config -->
+    <config type="min_handle_length" length="200.0" />
+    <config type="icon_zoom_limit" zoom="15" />
+    <!-- Vespucci internal styles -->
+    <feature type="gps_accuracy" updateWidth="false" widthFactor="2.0" color="280000ff" style="FILL_AND_STROKE" cap="ROUND" join="ROUND" strokeWidth="0.0" />
+    <feature type="way_direction" updateWidth="true" widthFactor="0.8" color="ffb9121b" style="STROKE" cap="SQUARE" join="MITER" />
+    <feature type="handle" updateWidth="true" widthFactor="0.8" color="ffb9121b" style="STROKE" cap="SQUARE" join="MITER" />
+    <feature type="selected_way" updateWidth="true" widthFactor="2.0" color="fffcfa74" style="STROKE" cap="ROUND" join="ROUND" />
+    <feature type="way_tolerance" updateWidth="false" widthFactor="1.0" color="28bd8d46" style="STROKE" cap="BUTT" join="MITER" strokeWidth="40.0" />
+    <feature type="way_tolerance_2" updateWidth="false" widthFactor="1.0" color="7fbd8d46" style="STROKE" cap="BUTT" join="MITER" strokeWidth="40.0" />
+    <feature type="gps_track" updateWidth="false" widthFactor="1.0" color="ff0000ff" style="STROKE" cap="ROUND" join="ROUND" strokeWidth="2.0" />
+    <feature type="node_tolerance" updateWidth="false" widthFactor="1.0" color="28bd8d46" style="FILL" cap="BUTT" join="MITER" strokeWidth="40.0" />
+    <feature type="node_tolerance_2" updateWidth="false" widthFactor="1.0" color="7fbd8d46" style="FILL" cap="BUTT" join="MITER" strokeWidth="40.0" />
+    <feature type="infotext" updateWidth="false" widthFactor="1.0" color="ff000000" style="FILL" cap="BUTT" join="MITER" strokeWidth="0.0" typefacestyle="0" textsize="12.0" />
+    <feature type="viewbox" updateWidth="false" widthFactor="1.0" color="7d0f0f0f" style="FILL" cap="BUTT" join="MITER" strokeWidth="0.0" />
+    <feature type="gps_pos" updateWidth="false" widthFactor="2.0" color="ff0000ff" style="FILL" cap="ROUND" join="ROUND" strokeWidth="2.0" />
+    <feature type="gps_pos_follow" updateWidth="false" widthFactor="2.0" color="ff0000ff" style="STROKE" cap="ROUND" join="ROUND" strokeWidth="2.0"/>
+    <feature type="dontrender_way" dontrender="true" updateWidth="true" widthFactor="1.0" color="00ffffff" style="STROKE" cap="ROUND" join="ROUND" />
+    <!-- OSM node based features currently internal features -->
+    <feature type="node" updateWidth="true" widthFactor="1.0" color="ffb9121b" style="FILL" cap="ROUND" join="MITER" />
+    <feature type="node_tagged" updateWidth="true" widthFactor="1.5" color="ffb9121b" style="FILL" cap="ROUND" join="MITER" />
+    <feature type="node_thin" updateWidth="false" widthFactor="1.0" color="ffb9121b" style="STROKE" cap="BUTT" join="MITER" strokeWidth="1.0" typefacestyle="0" textsize="12.0" />
+    <feature type="selected_node" updateWidth="true" widthFactor="1.5" color="fff6e497" style="FILL" cap="ROUND" join="MITER" />
+    <feature type="selected_node_tagged" updateWidth="true" widthFactor="2.0" color="fff6e497" style="FILL" cap="ROUND" join="MITER" />
+    <feature type="selected_node_thin" updateWidth="false" widthFactor="1.0" color="fff6e497" style="STROKE" cap="BUTT" join="MITER" strokeWidth="1.0" typefacestyle="0" textsize="12.0" />
+    <feature type="node_drag_radius" updateWidth="false" widthFactor="1.0" strokeWidth="10.0" color="80f6e497" style="STROKE" cap="BUTT" join="MITER">
+        <dash phase="1.0">
+            <interval length="40.0" />
+            <interval length="20.0" />
+        </dash>
+    </feature>
+    <!-- Validation -->
+    <feature type="problem_node" updateWidth="true" widthFactor="2.0" color="ffff00ff" style="STROKE" cap="ROUND" join="MITER" />
+    <feature type="problem_node_tagged" updateWidth="true" widthFactor="1.5" color="ffff00ff" style="FILL" cap="BUTT" join="MITER" />
+    <feature type="problem_node_thin" updateWidth="false" widthFactor="1.0" color="ffff00ff" style="STROKE" cap="BUTT" join="MITER" strokeWidth="1.0" typefacestyle="0" textsize="12.0" />
+    <feature type="problem_way" updateWidth="true" widthFactor="1.5" color="ffff00ff" style="STROKE" cap="BUTT" join="MITER" />
+    <!--  Code based validation styles -->
+    <!--  AGE                  = 0x00000002 -->
+    <!--  FIXME                = 0x00000004 -->
+    <!--  MISSING_TAG          = 0x00000008 -->
+    <!--  HIGHWAY_NAME         = 0x00000010 -->
+    <!--  HIGHWAY_ROAD         = 0x00000020 -->
+    <!--  NO_TYPE              = 0x00000040 -->
+    <!--  IMPERIAL_UNITS       = 0x00000080 -->
+    <!--  INVALID_OBJECT       = 0x00000100 -->
+    <!--  UNTAGGED             = 0x00000200 -->
+    <!--  UNCONNECTED_END_NODE = 0x00000400 -->
+    <!--  DEGENERATE_WAY       = 0x00000800 -->
+    <feature type="validation" code="2" updateWidth="true" widthFactor="1.5" color="ffffe000" style="STROKE" cap="BUTT" join="MITER" />
+    
+    <!-- Arrow styles -->
+    <feature type="oneway_direction" updateWidth="true" widthFactor="0.5" color="ffb9121b" style="STROKE" cap="SQUARE" join="MITER" oneway="true" />
+    <feature type="waterway_direction" updateWidth="true" widthFactor="0.5" color="ff0000bb" style="STROKE" cap="SQUARE" join="MITER" />
+    
+    <!-- OSM node based features -->
+    <feature type="node" tags="name" labelKey="name"/>
+    <feature type="node" tags="entrance|addr:housenumber" labelKey="addr:housenumber" />
+    <feature type="node" tags="natural=tree" iconPath="preset">
+        <feature type="node" tags="circumference|height|diameter_crown" iconPath="icons/tree_all.png" />
+        <feature type="node" tags="diameter_crown|circumference" iconPath="icons/tree_crown_diameter_circumference.png" />
+        <feature type="node" tags="height|diameter_crown" iconPath="icons/tree_height_crown_diameter.png" />
+        <feature type="node" tags="height|circumference" iconPath="icons/tree_height_circumference.png" />
+        <feature type="node" tags="circumference" iconPath="icons/tree_circumference.png" />
+        <feature type="node" tags="height" iconPath="icons/tree_height.png" />
+        <feature type="node" tags="diameter_crown" iconPath="icons/tree_crown_diameter.png" />
+    </feature>
+    
+    <!-- OSM way based features -->
+    <feature type="way" updateWidth="true" widthFactor="1.0" color="80000000" style="STROKE" cap="BUTT" join="MITER" />
+    <feature type="way" tags="boundary" updateWidth="true" widthFactor="0.6" color="ff000000" style="STROKE" cap="BUTT" join="MITER">
+    	<dash phase="1.0">
+    		<interval length="6.0" />
+    		<interval length="2.0" />
+    	</dash>
+    </feature>
+    <feature type="way" tags="route" updateWidth="true" widthFactor="0.6" color="880000AA" style="STROKE" cap="BUTT" join="MITER">
+    	<dash phase="1.0">
+    		<interval length="3.0" />
+    		<interval length="3.0" />
+    	</dash>
+    </feature>
+    <feature type="way" tags="landuse" area="true" updateWidth="true" widthFactor="2.0" color="8871BE80" style="STROKE" cap="BUTT" join="MITER" pathPattern="border_right">
+        <feature type="way" tags="landuse=construction" color="88996633" style="FILL_AND_STROKE" pathPattern="" />
+        <feature type="way" tags="landuse=residential" minVisibleZoom="10" color="88888888" />
+        <feature type="way" tags="landuse=quarry" color="88d8a2a2" />
+        <feature type="way" tags="landuse=military" color="88af2626" />
+        <feature type="way" tags="landuse=forest" minVisibleZoom="10" color="8800BE00" />
+        <feature type="way" tags="landuse=industrial" minVisibleZoom="10" color="88A3709A" />
+        <feature type="way" tags="landuse=commercial" minVisibleZoom="10" color="88A3709A" />
+        <feature type="way" tags="landuse=railway" minVisibleZoom="10" color="88A3709A" />
+    </feature>
+    
+    <feature type="way" tags="leisure=pitch" updateWidth="true" widthFactor="1.0" color="8839AC39" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
+    <feature type="way" tags="leisure=swimming_pool" updateWidth="true" widthFactor="1.0" color="880000ff" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />    
+    <feature type="way" tags="leisure=playground" area="true" updateWidth="true" widthFactor="0.8" color="88f4a460" style="STROKE" cap="BUTT" join="MITER" pathPattern="border_right" />
+    <feature type="way" tags="leisure=garden" updateWidth="true" widthFactor="1.0" color="882d6e3a" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
+    
+    <feature type="way" tags="natural" updateWidth="true" widthFactor="0.5" color="ff71BE80" style="STROKE" cap="BUTT" join="MITER"> 
+        <feature type="way" tags="natural" closed="true" area="true" pathPattern="border_right" >
+            <feature type="way" tags="natural=water" widthFactor="1.0" minVisibleZoom="10" color="ff0000ff" />
+        </feature>
+        <feature type="way" tags="natural=water" widthFactor="1.0" minVisibleZoom="10" color="ff0000ff" />
+        <feature type="way" tags="natural=cliff" widthFactor="2.0" color="ff555555" pathPattern="triangle_right" />
+        <feature type="way" tags="natural=coastline" widthFactor="2.0" minVisibleZoom="10" color="ff71BE80" pathPattern="triangle_left" />
+        <feature type="way" tags="natural=tree_row" widthFactor="2.0" color="ff4b7a54" cap="ROUND" />
+    </feature>
+    <feature type="way" tags="waterway" updateWidth="true" widthFactor="1.0" color="ff0000ff" style="STROKE" cap="BUTT" join="MITER" arrowStyle="waterway_direction" >
+        <feature type="way" tags="waterway=riverbank" updateWidth="true" widthFactor="1.0" color="ff0000ff" style="STROKE" cap="BUTT" join="MITER" arrowStyle="" />
+        <feature type="way" tags="waterway=weir" widthFactor="2.0" color="ff0000ff" pathPattern="triangle_right" />
+    </feature>
+    <feature type="way" tags="man_made" color="ff585c63" style="STROKE" cap="BUTT" join="MITER" >
+        <feature type="way" tags="man_made=embankment" color="ff996633" pathPattern="triangle_right" />
+        <feature type="way" tags="man_made=bridge" color="aa585c63" closed="true" area="true" pathPattern="border_right" />
+    </feature>
+    <feature type="way" tags="building" updateWidth="true" widthFactor="1.0" color="ffcc9999" style="STROKE" cap="BUTT" join="MITER" >
+        <feature type="way" tags="building|addr:housenumber" closed="true" labelKey="addr:housenumber"/>
+    </feature>
+    <feature type="way" tags="building:part" updateWidth="true" widthFactor="0.8" color="ffcc9999" style="STROKE" cap="BUTT" join="MITER" >
+    	<dash phase="1.0">
+    		<interval length="2.0" />
+    		<interval length="2.0" />
+    	</dash>
+    </feature>
+    <feature type="motorway_casing" updateWidth="true" widthFactor="2.4" color="FFFFFFFF" style="STROKE" cap="BUTT" join="MITER" />
+    <feature type="motorway_bridge_casing" updateWidth="true" widthFactor="2.4" color="FFFFFFFF" style="STROKE" cap="BUTT" join="MITER">
+        <dash phase="1.0">
+            <interval length="2.0" />
+            <interval length="2.0" />
+        </dash>
+    </feature>
+    <feature type="primary_casing" updateWidth="true" widthFactor="1.8" color="FFFFFFFF" style="STROKE" cap="BUTT" join="MITER" />
+    <feature type="primary_bridge_casing" updateWidth="true" widthFactor="1.8" color="FFFFFFFF" style="STROKE" cap="BUTT" join="MITER">
+        <dash phase="1.0">
+            <interval length="2.0" />
+            <interval length="2.0" />
+        </dash>
+    </feature>
+    <feature type="secondary_casing" updateWidth="true" widthFactor="1.5" color="FFFFFFFF" style="STROKE" cap="BUTT" join="MITER" />
+    <feature type="secondary_bridge_casing" updateWidth="true" widthFactor="1.5" color="FFFFFFFF" style="STROKE" cap="BUTT" join="MITER">
+        <dash phase="1.0">
+            <interval length="2.0" />
+            <interval length="2.0" />
+        </dash>
+    </feature>
+    <feature type="teritary_casing" updateWidth="true" widthFactor="1.3" color="FFFFFFFF" style="STROKE" cap="BUTT" join="MITER" />
+    <feature type="tertiary_bridge_casing" updateWidth="true" widthFactor="1.3" color="FFFFFFFF" style="STROKE" cap="BUTT" join="MITER">
+        <dash phase="1.0">
+            <interval length="2.0" />
+            <interval length="2.0" />
+        </dash>
+    </feature>
+    <feature type="unclassified_casing" updateWidth="true" widthFactor="1.2" color="FFFFFFFF" style="STROKE" cap="BUTT" join="MITER" />
+    <feature type="unclassified_bridge_casing" updateWidth="true" widthFactor="1.2" color="FFFFFFFF" style="STROKE" cap="BUTT" join="MITER">
+        <dash phase="1.0">
+            <interval length="2.0" />
+            <interval length="2.0" />
+        </dash>
+    </feature>
+    <feature type="residential_casing" updateWidth="true" widthFactor="1.1" color="FFFFFFFF" style="STROKE" cap="BUTT" join="MITER" />
+    <feature type="residential_bridge_casing" updateWidth="true" widthFactor="1.1" color="FFFFFFFF" style="STROKE" cap="BUTT" join="MITER">
+        <dash phase="1.0">
+            <interval length="2.0" />
+            <interval length="2.0" />
+        </dash>
+    </feature>
+    <feature type="way" tags="highway" updateWidth="true" widthFactor="1.0" color="88888888" style="STROKE" cap="BUTT" join="MITER" arrowStyle="oneway_direction">
+        <feature type="way" tags="highway=construction" widthFactor="1.0" color="88888888" />
+        <feature type="way" tags="highway=proposed" widthFactor="1.0" color="88888888" />
+        <feature type="way" tags="highway=pedestrian" widthFactor="0.8" color="ff888888" />
+        <feature type="way" tags="highway=path|surface=asphalt" widthFactor="0.6" color="ffc69c49" />
+        <feature type="way" tags="highway=path|surface=paved" widthFactor="0.6" color="ffc69c49" />
+        <feature type="way" tags="highway=path" widthFactor="0.6" color="ffc69c49" >
+            <dash phase="1.0">
+                <interval length="5.0" />
+                <interval length="1.0" />
+                <interval length="1.0" />
+                <interval length="1.0" />
+            </dash>
+        </feature>
+        <feature type="way" tags="highway=cycleway" widthFactor="0.6" color="fff48f42" />
+        <feature type="way" tags="highway=footway" widthFactor="0.6" color="ffff4500" />
+        <feature type="way" tags="highway=steps"  widthFactor="0.6" color="ffff4500" >
+            <dash phase="1.0">
+    	       <interval length="1.0" />
+    	       <interval length="1.0" />
+            </dash>
+        </feature>
+        <feature type="way" tags="highway=track" widthFactor="1.0" color="ffc69c49">
+            <feature type="way" tags="tracktype=grade3">
+                <dash phase="1.0">
+                    <interval length="5.0" />
+                    <interval length="1.0" />
+                    <interval length="1.0" />
+                    <interval length="1.0" />
+                </dash>
+            </feature>
+            <feature type="way" tags="tracktype=grade4">
+                <dash phase="1.0">
+                    <interval length="2.0" />
+                    <interval length="1.0" />
+                    <interval length="1.0" />
+                    <interval length="1.0" />
+                </dash>
+            </feature>
+            <feature type="way" tags="tracktype=grade5">
+                <dash phase="1.0">
+                    <interval length="1.0" />
+                    <interval length="1.0" />
+                </dash>
+            </feature>
+        </feature>
+        <feature type="way" tags="highway=motorway" widthFactor="2.0" minVisibleZoom="10" color="ff809BC0" casingStyle="motorway_casing" >
+            <feature type="way" tags="bridge=yes" casingStyle="motorway_bridge_casing" />
+            <feature type="way" tags="tunnel=yes" casingStyle="">
+                <dash phase="1.0">
+                    <interval length="1.0" />
+                    <interval length="1.0" />
+                </dash>
+            </feature>
+        </feature>
+        <feature type="way" tags="highway=motorway_link" widthFactor="2.0" minVisibleZoom="10" color="ff809BC0" >
+            <feature type="way" tags="tunnel=yes" casingStyle="">
+                <dash phase="1.0">
+                    <interval length="1.0" />
+                    <interval length="1.0" />
+                </dash>
+            </feature>
+        </feature>
+        <feature type="way" tags="highway=trunk" widthFactor="1.5" minVisibleZoom="10" color="ff7FC97F" casingStyle="trunk_casing" >
+            <feature type="way" tags="bridge=yes" casingStyle="trunk_bridge_casing" />
+            <feature type="way" tags="tunnel=yes" casingStyle="">
+                <dash phase="1.0">
+                    <interval length="1.0" />
+                    <interval length="1.0" />
+                </dash>
+            </feature>
+        </feature>
+        <feature type="way" tags="highway=trunk_link" widthFactor="1.5" minVisibleZoom="10" color="ff7FC97F" >
+            <feature type="way" tags="tunnel=yes" casingStyle="">
+                <dash phase="1.0">
+                    <interval length="1.0" />
+                    <interval length="1.0" />
+                </dash>
+            </feature>
+        </feature>
+        <feature type="way" tags="highway=primary" widthFactor="1.5" color="ffE46D71" casingStyle="primary_casing" >
+            <feature type="way" tags="bridge=yes" casingStyle="primary_bridge_casing" />
+            <feature type="way" tags="tunnel=yes" casingStyle="">
+                <dash phase="1.0">
+                    <interval length="1.0" />
+                    <interval length="1.0" />
+                </dash>
+            </feature>
+        </feature>
+        <feature type="way" tags="highway=primary_link" widthFactor="1.5" color="ffE46D71" >
+            <feature type="way" tags="tunnel=yes" casingStyle="">
+                <dash phase="1.0">
+                    <interval length="1.0" />
+                    <interval length="1.0" />
+                </dash>
+            </feature>
+        </feature>
+        <feature type="way" tags="highway=secondary" widthFactor="1.2" color="ffFDBF6F" casingStyle="secondary_casing" >
+            <feature type="way" tags="bridge=yes" casingStyle="secondary_bridge_casing" />
+            <feature type="way" tags="tunnel=yes" casingStyle="">
+                <dash phase="1.0">
+                    <interval length="1.0" />
+                    <interval length="1.0" />
+                </dash>
+            </feature>
+        </feature>
+        <feature type="way" tags="highway=secondary_link" widthFactor="1.2" color="ffFDBF6F" >
+            <feature type="way" tags="tunnel=yes" casingStyle="">
+                <dash phase="1.0">
+                    <interval length="1.0" />
+                    <interval length="1.0" />
+                </dash>
+            </feature>
+        </feature>
+        <feature type="way" tags="highway=tertiary" widthFactor="1.0" color="ffFCFA74" casingStyle="tertiary_casing" >
+            <feature type="way" tags="bridge=yes" casingStyle="tertiary_bridge_casing" />
+            <feature type="way" tags="tunnel=yes" casingStyle="">
+                <dash phase="1.0">
+                    <interval length="1.0" />
+                    <interval length="1.0" />
+                </dash>
+            </feature>
+        </feature>
+        <feature type="way" tags="highway=tertiary_link" widthFactor="1.0" color="ffFCFA74" >
+            <feature type="way" tags="tunnel=yes" casingStyle="">
+                <dash phase="1.0">
+                    <interval length="1.0" />
+                    <interval length="1.0" />
+                </dash>
+            </feature>
+        </feature>
+        <feature type="way" tags="highway=unclassified" widthFactor="1.0" color="ffCCCCCC" casingStyle="unclassified_casing" >
+            <feature type="way" tags="bridge=yes" casingStyle="unclassifies_bridge_casing" />
+            <feature type="way" tags="tunnel=yes" casingStyle="">
+                <dash phase="1.0">
+                    <interval length="1.0" />
+                    <interval length="1.0" />
+                </dash>
+            </feature>
+        </feature>
+        <feature type="way" tags="highway=residential" widthFactor="0.9" color="ffCCCCCC" casingStyle="residential_casing" >
+            <feature type="way" tags="bridge=yes" casingStyle="residential_bridge_casing" />
+        </feature>
+        <feature type="way" tags="highway=living_street" widthFactor="0.9" color="ffff4500" />
+        <feature type="way" tags="highway=service" widthFactor="0.7" color="ffCCCCCC" />
+    </feature>
+    <feature type="way" tags="power" updateWidth="true" widthFactor="0.6" color="ffaa0000" style="STROKE" cap="BUTT" join="MITER">
+    	<dash phase="1.0">
+    		<interval length="2.0" />
+    		<interval length="2.0" />
+    	</dash>
+    </feature>
+    <feature type="way" tags="railway" updateWidth="true" widthFactor="0.7" color="ff999999" style="STROKE" cap="BUTT" join="MITER">
+    	<dash phase="1.0">
+    		<interval length="4.0" />
+    		<interval length="4.0" />
+    	</dash>
+    </feature>
+    <feature type="way" tags="addr:interpolation" updateWidth="true" widthFactor="0.6" color="ff000000" style="STROKE" cap="BUTT" join="MITER">
+    	<dash phase="1.0">
+    		<interval length="2.0" />
+    		<interval length="2.0" />
+    	</dash>
+    </feature>
+    <feature type="way" tags="amenity" updateWidth="true" widthFactor="0.8" color="ffCCCC00" style="STROKE" cap="BUTT" join="MITER">
+    	<dash phase="1.0">
+    		<interval length="2.0" />
+    		<interval length="2.0" />
+    	</dash>
+        <feature type="way" tags="amenity=parking" color="ff99CCFF"  />
+        <feature type="way" tags="amenity=bicycle_parking"  color="ff99CCFF" />
+        <feature type="way" tags="amenity=motorcycle_parking" color="ff99CCFF" />
+    </feature>
+    
+    <feature type="way" tags="military" color="88af2626" updateWidth="true" style="STROKE" cap="BUTT" join="MITER" />
+    
+    <!-- Indoor features -->
+    <feature type="way" tags="indoor" updateWidth="true" widthFactor="0.7" color="99f4a442" style="STROKE" cap="BUTT" join="MITER" >
+        <feature type="way" tags="indoor=level" updateWidth="true" widthFactor="0.7" color="99f2c791" style="STROKE" cap="BUTT" join="MITER" />
+        <feature type="way" tags="indoor=room" updateWidth="true" widthFactor="0.7" color="99f2c791" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
+        <feature type="way" tags="indoor=corridor" updateWidth="true" widthFactor="0.7" color="99f2c791" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
+    </feature>
+    
+    <!-- relations (only multipolygons currently -->
+    <feature type="relation" updateWidth="true" widthFactor="1.0" color="ff222222" style="STROKE" cap="BUTT" join="MITER" />
+    <feature type="relation" tags="type=multipolygon" updateWidth="true" widthFactor="0.8" color="88222222" style="STROKE" cap="BUTT" join="MITER" pathPattern="border_right">
+        <feature type="relation" tags="building" widthFactor="1.0" color="ffcc9999"/>
+        <feature type="relation" tags="leisure=playground" widthFactor="0.8" color="88f4a460" style="FILL_AND_STROKE" />
+        <feature type="relation" tags="leisure=pitch" updateWidth="true" widthFactor="1.0" color="8839AC39" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
+        <feature type="relation" tags="leisure=swimming_pool" updateWidth="true" widthFactor="1.0" color="880000ff" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
+        <feature type="relation" tags="leisure=garden" updateWidth="true" widthFactor="1.0" color="882d6e3a" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />    
+        
+        <feature type="relation" tags="natural" color="ff71BE80" >
+            <feature type="relation" tags="natural=water" widthFactor="1.0" minVisibleZoom="10" color="ff0000ff" />
+            <feature type="relation" tags="natural=cliff" widthFactor="2.0" color="ff555555" pathPattern="triangle_right" />
+            <feature type="relation" tags="natural=coastline" widthFactor="2.0" minVisibleZoom="10" color="ff71BE80" pathPattern="triangle_left" />
+            <feature type="relation" tags="natural=tree_row" widthFactor="2.0" color="ff4b7a54" cap="ROUND" />
+        </feature>
+        <feature type="relation" tags="landuse" updateWidth="true" widthFactor="2.0" color="8871BE80" style="STROKE" cap="BUTT" join="BEVEL" pathPattern="border_right" >
+            <feature type="relation" tags="landuse=construction" color="88996633" />
+            <feature type="relation" tags="landuse=residential" minVisibleZoom="10" color="88888888" />
+            <feature type="relation" tags="landuse=quarry" color="88d8a2a2" />
+            <feature type="relation" tags="landuse=military" color="88af2626" />
+            <feature type="relation" tags="landuse=forest" minVisibleZoom="10" color="8800BE00" />
+            <feature type="relation" tags="landuse=industrial" minVisibleZoom="10" color="88A3709A" />
+            <feature type="relation" tags="landuse=commercial" minVisibleZoom="10" color="88A3709A" />
+            <feature type="relation" tags="landuse=railway" minVisibleZoom="10" color="88A3709A" />
+        </feature>
+    </feature>
+</profile>


### PR DESCRIPTION
Re-factor data styling to support (node) icons and flexible labelling

- moves predefined styles to a subdirectory of assets
- support attributes iconPath and labelKey
- support limited styling for nodes (label and icon)
- use a thread from the thread pool to load icons from storage instead of doing this on the drawing thread