### PR TITLE
No <link> in <chunk>

### DIFF
--- a/documentation/docs/tutorials/presets.md
+++ b/documentation/docs/tutorials/presets.md
@@ -131,7 +131,7 @@ Note: this is loosely based on what [JOSM claims](https://josm.openstreetmap.de/
 |                   | text                          | ignored   | not displayed
 |__&lt;separator/&gt;__ |                           | supported | starts a new row in the preset selection display
 |__&lt;item_separator/&gt;__ |                      | ignored   |
-|__&lt;link&gt;__   |                               | supported |
+|__&lt;link&gt;__   |                               | supported | not legal inside &lt;chunk&gt; elements
 |                   | href                          | supported | including language specific variants
 |                   | wiki                          | supported | this will be used with lower preference than href entries
 |__&lt;roles&gt;__  |                               | ignored   | but not the included <role> elements

--- a/documentation/docs/tutorials/presets.md
+++ b/documentation/docs/tutorials/presets.md
@@ -134,7 +134,7 @@ Note: this is loosely based on what [JOSM claims](https://josm.openstreetmap.de/
 |__&lt;link&gt;__   |                               | supported | not legal inside &lt;chunk&gt; elements
 |                   | href                          | supported | including language specific variants
 |                   | wiki                          | supported | this will be used with lower preference than href entries
-|__&lt;roles&gt;__  |                               | ignored   | but not the included <role> elements
+|__&lt;roles&gt;__  |                               | ignored   | but not the included &lt;role&gt; elements
 |__&lt;role&gt;__   |                               | supported |
 |                   | key                           | supported | required
 |                   | text                          | supported |


### PR DESCRIPTION
This PR refers to your comment at https://github.com/simonpoole/beautified-JOSM-preset/pull/243#issuecomment-798933349 . I'm not sure if it concerns both `wiki` and `href`, or only `wiki`.

Further, some lines down, the angle brackets of an XML tag were not escaped.