### PR TITLE
GPX layer: squash short adjacent lines

### DIFF
--- a/src/main/java/de/blau/android/Map.java
+++ b/src/main/java/de/blau/android/Map.java
@@ -586,7 +586,7 @@ public class Map extends View implements IMapView {
 
         if (prefs.isStatsVisible()) {
             time = System.currentTimeMillis() - time;
-            paintStats(canvas, (int) (1 / (time / 1000f)));
+            paintStats(canvas, 1 / (time / 1000f));
         }
     }
 
@@ -787,7 +787,7 @@ public class Map extends View implements IMapView {
      * @param canvas canvas to draw on
      * @param fps frames per second
      */
-    private void paintStats(@NonNull final Canvas canvas, final int fps) {
+    private void paintStats(@NonNull final Canvas canvas, final float fps) {
         int pos = 1;
         String text = "";
         Paint infotextPaint = DataStyle.getInternal(DataStyle.INFOTEXT).getPaint();
@@ -804,7 +804,11 @@ public class Map extends View implements IMapView {
         text = "Nodes (current/Waynodes/API) :" + delegator.getCurrentStorage().getNodes().size() + "/" + delegator.getCurrentStorage().getWayNodes().size()
                 + "/" + delegator.getApiNodeCount();
         canvas.drawText(text, 5, getHeight() - textSize * pos++, infotextPaint);
-        text = "fps: " + fps;
+        if (fps < 10) {
+            text = "fps: " + String.format(Locale.US, "%.1f", fps);
+        } else {
+            text = "fps: " + (int)(fps);
+        }
         canvas.drawText(text, 5, getHeight() - textSize * pos++, infotextPaint);
         text = "hardware acceleration: " + (myIsHardwareAccelerated(canvas) ? "on" : "off");
         canvas.drawText(text, 5, getHeight() - textSize * pos++, infotextPaint);

--- a/src/main/java/de/blau/android/layer/gpx/MapOverlay.java
+++ b/src/main/java/de/blau/android/layer/gpx/MapOverlay.java
@@ -78,6 +78,7 @@ public class MapOverlay extends StyleableLayer implements Serializable, ExtentIn
         List<TrackPoint> trackPoints = tracker.getTrackPoints();
         if (!trackPoints.isEmpty()) {
             map.pointListToLinePointsArray(linePoints, trackPoints);
+            GeoMath.squashPointsArray(linePoints, getStrokeWidth() * 2);
             canvas.drawLines(linePoints.getArray(), 0, linePoints.size(), paint);
         }
         WayPoint[] wayPoints = tracker.getTrack().getWayPoints();

--- a/src/main/java/de/blau/android/util/GeoMath.java
+++ b/src/main/java/de/blau/android/util/GeoMath.java
@@ -2,7 +2,6 @@ package de.blau.android.util;
 
 import android.graphics.Canvas;
 import android.graphics.Paint;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 
@@ -592,8 +591,9 @@ public final class GeoMath {
      * @param maxLen maximal length of adjacent lines to be squashed
      */
     public static void squashPointsArray(@NonNull final FloatPrimitiveList points, float maxLen) {
-        if (points.size() <= 4)
+        if (points.size() <= 4) {
             return;
+        }
         int i; // current input line index
         int i0; // first squashable input line index
         int o; // current output line index
@@ -625,8 +625,9 @@ public final class GeoMath {
                     dx = Math.abs(points.get(i0) - points.get(i + 2));
                     dy = Math.abs(points.get(i0 + 1) - points.get(i + 3));
                     len = (dx > dy) ? (dx + dy / 2) : (dy + dx / 2);
-                    if (len > maxLen) // multi line length
+                    if (len > maxLen) { // multi line length
                         squash = false;
+                    }
                 }
                 if (!squash) {
                     points.set(o, points.get(i0));

--- a/src/main/java/de/blau/android/util/collections/FloatPrimitiveList.java
+++ b/src/main/java/de/blau/android/util/collections/FloatPrimitiveList.java
@@ -74,6 +74,32 @@ public class FloatPrimitiveList implements Serializable {
     }
 
     /**
+     * Set the float at position i
+     *
+     * @param i position we want the value for
+     * @param f the value to be set
+     */
+    public void set(int i, float f) {
+        if (i > size - 1) {
+            throw new IndexOutOfBoundsException(Integer.toString(i) + " is larger than " + Integer.toString(size));
+        }
+        array[i] = f;
+    }
+
+    /**
+     * Truncate the list
+     *
+     * @param s new size to be set
+     */
+    public void truncate(int s) {
+        if (s > size) {
+            throw new IndexOutOfBoundsException(Integer.toString(s) + " is larger than " + Integer.toString(size));
+        }
+        size = s;
+    }
+
+
+    /**
      * Reset the contents
      * 
      * Note this doesn't shrink the backing array

--- a/src/test/java/de/blau/android/util/GeoMathTest.java
+++ b/src/test/java/de/blau/android/util/GeoMathTest.java
@@ -1,0 +1,147 @@
+package de.blau.android.util;
+
+import org.junit.Test;
+
+import de.blau.android.util.collections.FloatPrimitiveList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class GeoMathTest {
+
+    @Test
+    public void squashPointsArray() {
+        FloatPrimitiveList points = new FloatPrimitiveList();
+
+        // short list
+        GeoMath.squashPointsArray(points, 0.1f);
+        assertEquals(0, points.size());
+        for(int i=0; i<4; i++)
+            points.add(i);
+        GeoMath.squashPointsArray(points, 0.1f);
+        assertEquals(4, points.size());
+
+        // all to long
+        points.clear();
+        for(int i=0; i<12; i++)
+            points.add(i);
+        GeoMath.squashPointsArray(points, 0.1f);
+        assertEquals(12, points.size());
+        for(int i=0; i<12; i++)
+            assertEquals(i, points.get(i), 0.01);
+
+        // none adjacent
+        GeoMath.squashPointsArray(points, 100);
+        assertEquals(12, points.size());
+        for(int i=0; i<12; i++)
+            assertEquals(i, points.get(i), 0.01);
+
+        // all adjacent
+        points.clear();
+        points.add(0); points.add(1); points.add(2); points.add(3);
+        points.add(2); points.add(3); points.add(4); points.add(5);
+        points.add(4); points.add(5); points.add(6); points.add(7);
+        GeoMath.squashPointsArray(points, 100);
+        assertEquals(4, points.size());
+        assertEquals(0, points.get(0), 0.01);
+        assertEquals(1, points.get(1), 0.01);
+        assertEquals(6, points.get(2), 0.01);
+        assertEquals(7, points.get(3), 0.01);
+
+        // head+tail not adjacent
+        points.clear();
+        points.add(0); points.add(1); points.add(2); points.add(3);
+        points.add(1); points.add(2); points.add(3); points.add(4);
+        points.add(3); points.add(4); points.add(5); points.add(6);
+        points.add(5); points.add(6); points.add(7); points.add(8);
+        points.add(6); points.add(7); points.add(8); points.add(9);
+        GeoMath.squashPointsArray(points, 100);
+        assertEquals(12, points.size());
+        assertEquals(0, points.get(0), 0.01);
+        assertEquals(1, points.get(1), 0.01);
+        assertEquals(2, points.get(2), 0.01);
+        assertEquals(3, points.get(3), 0.01);
+        assertEquals(1, points.get(4), 0.01);
+        assertEquals(2, points.get(5), 0.01);
+        assertEquals(7, points.get(6), 0.01);
+        assertEquals(8, points.get(7), 0.01);
+        assertEquals(6, points.get(8), 0.01);
+        assertEquals(7, points.get(9), 0.01);
+        assertEquals(8, points.get(10), 0.01);
+        assertEquals(9, points.get(11), 0.01);
+
+        // multiple segments
+        points.clear();
+        points.add(0); points.add(1); points.add(2); points.add(3);
+        points.add(2); points.add(3); points.add(4); points.add(5);
+        points.add(1); points.add(2); points.add(3); points.add(4);
+        points.add(3); points.add(4); points.add(5); points.add(6);
+        GeoMath.squashPointsArray(points, 100);
+        assertEquals(8, points.size());
+        assertEquals(0, points.get(0), 0.01);
+        assertEquals(1, points.get(1), 0.01);
+        assertEquals(4, points.get(2), 0.01);
+        assertEquals(5, points.get(3), 0.01);
+        assertEquals(1, points.get(4), 0.01);
+        assertEquals(2, points.get(5), 0.01);
+        assertEquals(5, points.get(6), 0.01);
+        assertEquals(6, points.get(7), 0.01);
+
+        // single line to long
+        points.clear();
+        points.add(0); points.add(1); points.add(2); points.add(3);
+        points.add(2); points.add(3); points.add(0); points.add(1);
+        points.add(0); points.add(1); points.add(7); points.add(8);
+        GeoMath.squashPointsArray(points, 5);
+        assertEquals(8, points.size());
+        assertEquals(0, points.get(0), 0.01);
+        assertEquals(1, points.get(1), 0.01);
+        assertEquals(0, points.get(2), 0.01);
+        assertEquals(1, points.get(3), 0.01);
+        assertEquals(0, points.get(4), 0.01);
+        assertEquals(1, points.get(5), 0.01);
+        assertEquals(7, points.get(6), 0.01);
+        assertEquals(8, points.get(7), 0.01);
+
+        // sum to long
+        points.clear();
+        points.add(0); points.add(1); points.add(2); points.add(3);
+        points.add(2); points.add(3); points.add(4); points.add(5);
+        points.add(4); points.add(5); points.add(6); points.add(7);
+        GeoMath.squashPointsArray(points, 6);
+        assertEquals(8, points.size());
+        assertEquals(0, points.get(0), 0.01);
+        assertEquals(1, points.get(1), 0.01);
+        assertEquals(4, points.get(2), 0.01);
+        assertEquals(5, points.get(3), 0.01);
+        assertEquals(4, points.get(4), 0.01);
+        assertEquals(5, points.get(5), 0.01);
+        assertEquals(6, points.get(6), 0.01);
+        assertEquals(7, points.get(7), 0.01);
+
+        // none squashed. hits all 'i != i0' conditions
+        points.clear();
+        points.add(0); points.add(1); points.add(2); points.add(3);
+        points.add(1); points.add(2); points.add(3); points.add(4);
+        points.add(2); points.add(3); points.add(16); points.add(17);
+        points.add(4); points.add(5); points.add(6); points.add(7);
+        GeoMath.squashPointsArray(points, 6);
+        assertEquals(16, points.size());
+        assertEquals(0, points.get(0), 0.01);
+        assertEquals(1, points.get(1), 0.01);
+        assertEquals(2, points.get(2), 0.01);
+        assertEquals(3, points.get(3), 0.01);
+        assertEquals(1, points.get(4), 0.01);
+        assertEquals(2, points.get(5), 0.01);
+        assertEquals(3, points.get(6), 0.01);
+        assertEquals(4, points.get(7), 0.01);
+        assertEquals(2, points.get(8), 0.01);
+        assertEquals(3, points.get(9), 0.01);
+        assertEquals(16, points.get(10), 0.01);
+        assertEquals(17, points.get(11), 0.01);
+        assertEquals(4, points.get(12), 0.01);
+        assertEquals(5, points.get(13), 0.01);
+        assertEquals(6, points.get(14), 0.01);
+        assertEquals(7, points.get(15), 0.01);
+   }
+}

--- a/src/test/java/de/blau/android/util/GeoMathTest.java
+++ b/src/test/java/de/blau/android/util/GeoMathTest.java
@@ -16,25 +16,29 @@ public class GeoMathTest {
         // short list
         GeoMath.squashPointsArray(points, 0.1f);
         assertEquals(0, points.size());
-        for(int i=0; i<4; i++)
+        for(int i=0; i<4; i++) {
             points.add(i);
+        }
         GeoMath.squashPointsArray(points, 0.1f);
         assertEquals(4, points.size());
 
         // all to long
         points.clear();
-        for(int i=0; i<12; i++)
+        for(int i=0; i<12; i++) {
             points.add(i);
+        }
         GeoMath.squashPointsArray(points, 0.1f);
         assertEquals(12, points.size());
-        for(int i=0; i<12; i++)
+        for(int i=0; i<12; i++) {
             assertEquals(i, points.get(i), 0.01);
+        }
 
         // none adjacent
         GeoMath.squashPointsArray(points, 100);
         assertEquals(12, points.size());
-        for(int i=0; i<12; i++)
+        for(int i=0; i<12; i++) {
             assertEquals(i, points.get(i), 0.01);
+        }
 
         // all adjacent
         points.clear();


### PR DESCRIPTION
Improves Canvas.drawLines() speed by drawing significantly less lines at low zoom level.
Short lines would anyway be hardly visible.

Test results with ~500k GPX track lines:
zoom 10: lines -> 0.3%, fps 0.5 -> 2.7
zoom 12: lines -> 2%, fps 0.5 -> 2.6
zoom 14: lines -> 10%, fps 0.7 to 3 -> 2.4 to 7
zoom 16: lines -> 50%, fps 2.5 to 6 -> 4 to 8
zoom 18: lines -> 98%, fps 4.7 to 9.3 -> 4.5 to 9
