### PR TITLE
Support  deprecated on preset fields and roles

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:4.1.0'
         classpath 'ch.poole.gradle:markdown-gradle-plugin:0.2.3'
         classpath 'org.jacoco:org.jacoco.core:0.8.5'
-        classpath "ch.poole:preset-utils:0.25.0"
+        classpath "ch.poole:preset-utils:0.26.0"
         classpath 'com.github.ksoichiro:gradle-eclipse-aar-plugin:0.3.1'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:2.0.0'
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.16'

--- a/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
+++ b/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
@@ -262,7 +262,7 @@ public class PropertyEditorTest {
         // Node n = App.getLogic().getSelectedNode();
         // assertNotNull(n);
 
-        assertTrue(TestUtils.clickMenuButton(device, "Properties", false, true));
+        assertTrue(TestUtils.clickMenuButton(device, main.getString(R.string.menu_tags), false, true));
         Activity propertyEditor = instrumentation.waitForMonitorWithTimeout(monitor, 30000);
         assertTrue(propertyEditor instanceof PropertyEditor);
 
@@ -287,7 +287,7 @@ public class PropertyEditorTest {
         assertTrue(TestUtils.clickText(device, true, "Asian", false, false));
         TestUtils.scrollTo("German");
         assertTrue(TestUtils.clickText(device, true, "German", false, false));
-        assertTrue(TestUtils.clickText(device, true, "SAVE", true, false));
+        assertTrue(TestUtils.clickText(device, true, main.getString(R.string.save), true, false));
         UiObject2 openingHours = null;
         try {
             openingHours = getField(device, "Opening Hours", 1);
@@ -356,7 +356,11 @@ public class PropertyEditorTest {
         } catch (UiObjectNotFoundException e) {
             fail();
         }
-
+        // apply optional tags and check that diaper tag isn't present
+        assertTrue(TestUtils.clickMenuButton(device, main.getString(R.string.tag_menu_apply_preset_with_optional), false, false));
+        TestUtils.scrollTo("Diaper changing (deprecated)");
+        assertFalse(TestUtils.findText(device, false, "Diaper changing (deprecated)"));
+        
         TestUtils.clickHome(device, true);
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_nodeselect)));
         device.waitForIdle();

--- a/src/main/assets/preset.xml
+++ b/src/main/assets/preset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<presets version="2.14.0" xmlns="http://josm.openstreetmap.de/tagging-preset-1.0" shortdescription="Default OpenStreetMap Preset for Vespucci and JOSM" 
+<presets version="3.0.0" xmlns="http://josm.openstreetmap.de/tagging-preset-1.0" shortdescription="Default OpenStreetMap Preset for Vespucci and JOSM" 
     description="General purpose OpenStreetMap preset for Vespucci and JOSM, based on the original JOSM version" 
     object_keys="advertising,attraction,building:part,cemetery,club,disused:amenity,disused:leisure,disused:man_made,golf,hazard,noexit,disused:shop,ford,indoor,playground,police,public_transport,traffic_calming,traffic_sign,traffic_sign:backward,traffic_sign:forward">
 <!--
@@ -257,7 +257,7 @@
             <list_entry value="traffic_signals" short_description="Traffic signals" icon="presets/vehicle/crossing_traffic_signals.svg"/>
             <list_entry value="unmarked" short_description="Unmarked" icon="presets/vehicle/crossing_unmarked.svg"/>
             <list_entry value="no" short_description="No crossing"/>
-            <list_entry value="island" short_description="Island (deprecated)" icon="presets/vehicle/crossing_island.svg"/>
+            <list_entry value="island" short_description="Island (deprecated)" icon="presets/vehicle/crossing_island.svg" deprecated="true" />
         </multiselect>
         <check key="crossing:island" text="With island" />
         <optional>
@@ -335,7 +335,7 @@
         </optional>
     </chunk>
     <chunk id="changing_table">
-        <combo key="diaper" text="Diaper changing (deprecated)" values_sort="false">
+        <combo key="diaper" text="Diaper changing (deprecated)" values_sort="false" deprecated="true">
             <list_entry value="yes" short_description="Available"/>
             <list_entry value="no" short_description="Not available"/>
             <list_entry value="room" short_description="Dedicated room"/>
@@ -6316,13 +6316,13 @@
             <key key="emergency" value="fire_extinguisher"/>
             <reference ref="ref_operator" />
             <reference ref="level"/>
-            <check key="indoor" text="Indoor" match="none"/>
+            <check key="indoor" text="Located inside a building?" disable_off="true" match="none"/>
         </item> <!-- Fire Extinguisher -->
         <item name="Fire Alarm Box" icon="icons/png/emergency_fire_alarm.png" type="node" preset_name_label="true">
             <key key="emergency" value="fire_alarm_box" />
             <text key="ref" text="Reference Code" />
             <reference ref="level"/>
-            <check key="indoor" text="Indoor" match="none"/>
+            <check key="indoor" text="Located inside a building?" disable_off="true" match="none"/>
         </item> <!-- Fire Alarm Box -->
         <item name="Fire Hose" icon="icons/png/emergency_fire_hose_17010.png" type="node" preset_name_label="true">
             <link wiki="Tag:emergency=fire_hose"/>
@@ -6330,7 +6330,7 @@
             <key key="emergency" value="fire_hose"/>
             <reference ref="ref_operator" />
             <reference ref="level"/>
-            <check key="indoor" text="Indoor" match="none"/>
+            <check key="indoor" text="Located inside a building?" disable_off="true" match="none"/>
         </item> <!-- Fire Hose -->
         <item name="Fire Hydrant" icon="icons/png/emergency_fire_hydrant_17020.png" type="node" preset_name_label="true">
             <link wiki="Tag:emergency=fire_hydrant"/>
@@ -6416,7 +6416,7 @@
             <key key="emergency" value="phone"/>
             <reference ref="ref_operator" />
             <reference ref="facility_access" />
-            <check key="indoor" text="Indoor" />
+            <check key="indoor" text="Located inside a building?" disable_off="true" match="none"/>
         </item> <!-- Emergency Phone -->
         <item name="Siren" icon="icons/png/emergency_siren_17026.png" type="node" preset_name_label="true">
             <link wiki="Tag:emergency=siren"/>
@@ -6940,7 +6940,7 @@
             <link wiki="Tag:amenity=drinking_water"/>
             <space/>
             <key key="amenity" value="drinking_water"/>
-            <check key="indoor" text="Indoor" disable_off="true" match="none"/>
+            <check key="indoor" text="Located inside a building?" disable_off="true" match="none"/>
             <optional>
                 <text key="name" text="Name"/>
                 <text key="description" text="Description" length="255"/>
@@ -6958,7 +6958,7 @@
             <optional>
                 <text key="name" text="Name"/>
                 <text key="description" text="Description" length="255"/>
-                <check key="indoor" text="Indoor" />
+                <check key="indoor" text="Located inside a building?" disable_off="true" match="none"/>
                 <reference ref="level"/>
                 <reference ref="facility_access"/>
             </optional>

--- a/src/main/java/de/blau/android/presets/Preset.java
+++ b/src/main/java/de/blau/android/presets/Preset.java
@@ -513,8 +513,8 @@ public class Preset implements Serializable {
      * 
      * @param input the input stream from which to read XML data
      * @throws ParserConfigurationException
-     * @throws SAXException
-     * @throws IOException
+     * @throws SAXException on parsing issues
+     * @throws IOException when reading the presets fails
      */
     private void parseXML(InputStream input) throws ParserConfigurationException, SAXException, IOException {
         SAXParserFactory factory = SAXParserFactory.newInstance(); // NOSONAR
@@ -658,6 +658,7 @@ public class Preset implements Serializable {
                     } else {
                         // Optional fixed tags should not happen, their values will NOT be automatically inserted.
                         field = currentItem.addTag(true, key, PresetKeyType.TEXT, attr.getValue(VALUE), MatchType.fromString(match));
+                        field.setDeprecated(TRUE.equals(attr.getValue(DEPRECATED))); // fixed fields can't be deprecated
                     }
                     if (match != null) {
                         field.setMatchType(match);
@@ -711,6 +712,7 @@ public class Preset implements Serializable {
                             Log.e(DEBUG_TAG, "Parsing of 'length' failed " + length + " " + e.getMessage());
                         }
                     }
+                    field.setDeprecated(TRUE.equals(attr.getValue(DEPRECATED)));
                     break;
                 case LINK:
                     String language = Locale.getDefault().getLanguage();
@@ -741,6 +743,7 @@ public class Preset implements Serializable {
                         checkGroup.setHint(currentLabel);
                     }
                     checkGroup.setOptional(inOptionalSection);
+                    checkGroup.setDeprecated(TRUE.equals(attr.getValue(DEPRECATED)));
                     break;
                 case CHECK_FIELD:
                     key = attr.getValue(KEY_ATTR);
@@ -775,6 +778,7 @@ public class Preset implements Serializable {
                     if (useLastAsDefault != null) {
                         checkField.setUseLastAsDefault(useLastAsDefault);
                     }
+                    checkField.setDeprecated(TRUE.equals(attr.getValue(DEPRECATED)));
                     if (checkGroup != null) {
                         checkGroup.addCheckField(checkField);
                     } else {
@@ -861,6 +865,7 @@ public class Preset implements Serializable {
                     if (valueCountKey != null) {
                         ((PresetComboField) field).setValueCountKey(valueCountKey);
                     }
+                    field.setDeprecated(TRUE.equals(attr.getValue(DEPRECATED)));
                     break;
                 case ROLES:
                     break;
@@ -873,6 +878,7 @@ public class Preset implements Serializable {
                     role.setRequisite(attr.getValue(REQUISITE));
                     role.setCount(attr.getValue(COUNT));
                     role.setRegexp(attr.getValue(REGEXP));
+                    role.setDeprecated(TRUE.equals(attr.getValue(DEPRECATED)));
                     currentItem.addRole(role);
                     break;
                 case REFERENCE:

--- a/src/main/java/de/blau/android/presets/Preset.java
+++ b/src/main/java/de/blau/android/presets/Preset.java
@@ -80,6 +80,7 @@ import de.blau.android.osm.Way;
 import de.blau.android.prefs.AdvancedPrefDatabase;
 import de.blau.android.prefs.PresetEditorActivity;
 import de.blau.android.search.Wrapper;
+import de.blau.android.util.ExtendedStringWithDescription;
 import de.blau.android.util.Hash;
 import de.blau.android.util.SavingHelper;
 import de.blau.android.util.SearchIndexUtils;
@@ -935,11 +936,10 @@ public class Preset implements Serializable {
                                 d = attr.getValue(SHORT_DESCRIPTION);
                             }
                             String iconPath = attr.getValue(ICON);
-                            if (iconPath == null) {
-                                listValues.add(new StringWithDescription(v, d));
-                            } else {
-                                listValues.add(new StringWithDescriptionAndIcon(v, d, iconPath));
-                            }
+                            ExtendedStringWithDescription swd = iconPath == null ? new ExtendedStringWithDescription(v, d)
+                                    : new StringWithDescriptionAndIcon(v, d, iconPath);
+                            swd.setDeprecated(TRUE.equals(attr.getValue(DEPRECATED)));
+                            listValues.add(swd);
                         }
                     }
                     break;

--- a/src/main/java/de/blau/android/presets/PresetComboField.java
+++ b/src/main/java/de/blau/android/presets/PresetComboField.java
@@ -98,7 +98,7 @@ public class PresetComboField extends PresetField implements PresetFieldJavaScri
     /**
      * Get the predefined values for this field
      * 
-     * @return and array of StringWithDescription
+     * @return an array of StringWithDescription
      */
     @Nullable
     public StringWithDescription[] getValues() {

--- a/src/main/java/de/blau/android/presets/PresetField.java
+++ b/src/main/java/de/blau/android/presets/PresetField.java
@@ -36,6 +36,11 @@ public abstract class PresetField {
     private boolean optional = false;
 
     /**
+     * This field is deprecated
+     */
+    private boolean deprecated = false;
+
+    /**
      * Does this key have i18n variants
      */
     private boolean i18n = false;
@@ -76,6 +81,7 @@ public abstract class PresetField {
         this.defaultValue = field.defaultValue;
         this.matchType = field.matchType;
         this.optional = field.optional;
+        this.deprecated = field.deprecated;
         this.setI18n(field.isI18n());
         this.textContext = field.textContext;
         this.valueContext = field.valueContext;
@@ -95,6 +101,20 @@ public abstract class PresetField {
      */
     public void setOptional(boolean optional) {
         this.optional = optional;
+    }
+
+    /**
+     * @return true if deprecated
+     */
+    public boolean isDeprecated() {
+        return deprecated;
+    }
+
+    /**
+     * @param deprecated make this field deprecated
+     */
+    public void setDeprecated(boolean deprecated) {
+        this.deprecated = deprecated;
     }
 
     /**

--- a/src/main/java/de/blau/android/presets/PresetRole.java
+++ b/src/main/java/de/blau/android/presets/PresetRole.java
@@ -29,6 +29,11 @@ public class PresetRole implements Comparable<PresetRole> {
     private String hint;
 
     /**
+     * This role is deprecated
+     */
+    private boolean deprecated = false;
+
+    /**
      * this role applies to
      */
     private boolean appliesToWay;
@@ -123,6 +128,20 @@ public class PresetRole implements Comparable<PresetRole> {
      */
     public void setHint(@Nullable String hint) {
         this.hint = hint;
+    }
+
+    /**
+     * @return true if deprecated
+     */
+    public boolean isDeprecated() {
+        return deprecated;
+    }
+
+    /**
+     * @param deprecated make this field deprecated
+     */
+    public void setDeprecated(boolean deprecated) {
+        this.deprecated = deprecated;
     }
 
     /**

--- a/src/main/java/de/blau/android/presets/ValueWithCount.java
+++ b/src/main/java/de/blau/android/presets/ValueWithCount.java
@@ -58,13 +58,14 @@ public class ValueWithCount implements Comparable<ValueWithCount> {
         if (count == -1) {
             return descriptionOnly ? (description != null ? description : value) : (description != null ? value + " - " + description : value);
         } else if (count >= 1) {
-            return value + " (" + count + ")" + (description != null ? value + " - " + description : "");
+            return value + " (" + count + ")" + (description != null ? " " + description : "");
         }
         return null; // NOSONAR this breaks the implicit contract for toString, however this class is specifically for
                      // use in ArrayAdapters
     }
 
     /**
+     * Get the actual value
      * 
      * @return the value
      */
@@ -74,12 +75,22 @@ public class ValueWithCount implements Comparable<ValueWithCount> {
     }
 
     /**
+     * Get the description for this value
      * 
      * @return the description or null if none
      */
     @Nullable
     public String getDescription() {
         return description;
+    }
+
+    /**
+     * Set the description for this value
+     * 
+     * @param description the description
+     */
+    public void setDescription(@Nullable String description) {
+        this.description = description;
     }
 
     @Override

--- a/src/main/java/de/blau/android/propertyeditor/TagEditorFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/TagEditorFragment.java
@@ -379,7 +379,7 @@ public class TagEditorFragment extends BaseFragment implements PropertyRows, Edi
         if (savedInstanceState == null) { // the following should only happen once on initial creation
             @SuppressWarnings("unchecked")
             List<PresetElementPath> presetsToApply = (ArrayList<PresetElementPath>) getArguments().getSerializable(PRESETSTOAPPLY_KEY);
-            if (presetsToApply != null) {
+            if (presetsToApply != null && !presetsToApply.isEmpty()) {
                 Preset preset = App.getCurrentRootPreset(getActivity());
                 PresetGroup rootGroup = preset.getRootGroup();
                 for (PresetElementPath pp : presetsToApply) {
@@ -388,9 +388,11 @@ public class TagEditorFragment extends BaseFragment implements PropertyRows, Edi
                         applyPreset(editRowLayout, (PresetItem) pi, false, true, true);
                     }
                 }
+                updateAutocompletePresetItem(editRowLayout, null, false); // here after preset has been applied
             } else if (prefs.autoApplyPreset()) {
+                updateAutocompletePresetItem(editRowLayout, null, false); // here before preset has been applied
                 PresetItem pi = getBestPreset();
-                if (pi != null) {
+                if (pi != null) {    
                     if (pi.autoapply()) {
                         applyPreset(editRowLayout, pi, false, true, false);
                     } else {
@@ -412,9 +414,6 @@ public class TagEditorFragment extends BaseFragment implements PropertyRows, Edi
                 } // this could be a bit more refined
             }
         }
-
-        updateAutocompletePresetItem(editRowLayout, null, false); // set preset from initial tags
-
         Log.d(DEBUG_TAG, "onCreateView returning");
         return rowLayout;
     }
@@ -1814,7 +1813,7 @@ public class TagEditorFragment extends BaseFragment implements PropertyRows, Edi
                 }
             }
             tags.put(key, Util.wrapInList(value));
-            return value != null && !"".equals(value);
+            return !"".equals(value);
         }
         return false;
     }

--- a/src/main/java/de/blau/android/propertyeditor/TagEditorFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/TagEditorFragment.java
@@ -1775,8 +1775,9 @@ public class TagEditorFragment extends BaseFragment implements PropertyRows, Edi
      */
     private boolean addTagFromPreset(@NonNull PresetItem item, @Nullable PresetField field, @NonNull Map<String, List<String>> tags, @NonNull String key,
             Map<String, String> scripts, boolean useDefault) {
-        List<String> values = tags.get(key);
-        if (values == null || (values.size() == 1 && "".equals(values.get(0)))) {
+        List<String> values = tags.get(key);      
+        boolean isDeprecated = field != null && field.isDeprecated();
+        if ((values == null || (values.size() == 1 && "".equals(values.get(0)))) && !isDeprecated) {
             String value = "";
             if (field != null && useDefault) {
                 String defaultValue = field.getDefaultValue();

--- a/src/main/java/de/blau/android/propertyeditor/TagEditorFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/TagEditorFragment.java
@@ -1286,7 +1286,6 @@ public class TagEditorFragment extends BaseFragment implements PropertyRows, Edi
             }
             keyEdit = (AutoCompleteTextView) findViewById(R.id.editKey);
             keyEdit.setOnKeyListener(PropertyEditor.myKeyListener);
-            // lastEditKey.setSingleLine(true);
 
             valueEdit = (CustomAutoCompleteTextView) findViewById(R.id.editValue);
             valueEdit.setOnKeyListener(PropertyEditor.myKeyListener);
@@ -1309,16 +1308,16 @@ public class TagEditorFragment extends BaseFragment implements PropertyRows, Edi
         @Override
         public void onSizeChanged(int w, int h, int oldw, int oldh) {
             super.onSizeChanged(w, h, oldw, oldh);
-            // Log.d(DEBUG_TAG, "onSizeChanged");
 
             if (w == 0 && h == 0) {
                 return;
             }
-            // Log.d(DEBUG_TAG,"w=" + w +" h="+h);
+
             // this is not really satisfactory
             keyEdit.setDropDownAnchor(valueEdit.getId());
-            // keyEdit.setDropDownVerticalOffset(-h);
-            // valueEdit.setDropDownVerticalOffset(-h);
+            // note wrap_content does not actually wrap the contents of the drop
+            // down, instead in makes it the same width as the AutoCompleteTextView
+            valueEdit.setDropDownWidth(ViewGroup.LayoutParams.WRAP_CONTENT);
             valueEdit.setParentWidth(w);
             //
         }

--- a/src/main/java/de/blau/android/propertyeditor/tagform/ComboDialogRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/ComboDialogRow.java
@@ -104,12 +104,7 @@ public class ComboDialogRow extends DialogRow {
             for (int i = 0; i < adapter.getCount(); i++) {
                 Object o = adapter.getItem(i);
 
-                StringWithDescription swd;
-                if (o instanceof StringWithDescriptionAndIcon) {
-                    swd = new StringWithDescriptionAndIcon(o);
-                } else {
-                    swd = new StringWithDescription(o);
-                }
+                StringWithDescription swd = o instanceof StringWithDescriptionAndIcon ? new StringWithDescriptionAndIcon(o) : new StringWithDescription(o);
                 String v = swd.getValue();
                 String description = swd.getDescription();
 
@@ -165,8 +160,9 @@ public class ComboDialogRow extends DialogRow {
         Builder builder = new AlertDialog.Builder(caller.getActivity());
         builder.setTitle(hint);
         final LayoutInflater themedInflater = ThemeUtils.getLayoutInflater(caller.getActivity());
-
         final View layout = themedInflater.inflate(R.layout.form_combo_dialog, null);
+        final View divider = themedInflater.inflate(R.layout.divider2, null);
+        divider.setLayoutParams(new RadioGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 2));
         RadioGroup valueGroup = (RadioGroup) layout.findViewById(R.id.valueGroup);
         builder.setView(layout);
 
@@ -188,7 +184,10 @@ public class ComboDialogRow extends DialogRow {
                 Object o = adapter.getItem(i);
                 StringWithDescription swd;
                 Drawable icon = null;
-                if (o instanceof StringWithDescriptionAndIcon) {
+                if (o instanceof TagFormFragment.Ruler) {
+                    valueGroup.addView(divider);
+                    continue;
+                } else if (o instanceof StringWithDescriptionAndIcon) {
                     icon = ((StringWithDescriptionAndIcon) o).getIcon(caller.getContext(), preset);
                     if (icon != null) {
                         swd = new StringWithDescriptionAndIcon(o);

--- a/src/main/java/de/blau/android/propertyeditor/tagform/MultiselectDialogRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/MultiselectDialogRow.java
@@ -11,6 +11,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.LinearLayout;
+import android.widget.RadioGroup;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -188,6 +189,8 @@ public class MultiselectDialogRow extends DialogRow {
 
         final View layout = themedInflater.inflate(R.layout.form_multiselect_dialog, null);
         final LinearLayout valueGroup = (LinearLayout) layout.findViewById(R.id.valueGroup);
+        final View divider = themedInflater.inflate(R.layout.divider2, null);
+        divider.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 2));
         builder.setView(layout);
 
         android.view.ViewGroup.LayoutParams buttonLayoutParams = valueGroup.getLayoutParams();
@@ -201,7 +204,10 @@ public class MultiselectDialogRow extends DialogRow {
                 Object o = adapter.getItem(i);
                 StringWithDescription swd;
                 Drawable icon = null;
-                if (o instanceof StringWithDescriptionAndIcon) {
+                if (o instanceof TagFormFragment.Ruler) {
+                    valueGroup.addView(divider);
+                    continue;
+                } else if (o instanceof StringWithDescriptionAndIcon) {
                     icon = ((StringWithDescriptionAndIcon) o).getIcon(caller.getContext(), preset);
                     if (icon != null) {
                         swd = new StringWithDescriptionAndIcon(o);

--- a/src/main/java/de/blau/android/propertyeditor/tagform/TagFormFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/TagFormFragment.java
@@ -252,7 +252,7 @@ public class TagFormFragment extends BaseFragment implements FormUpdate {
     @Nullable
     ArrayAdapter<?> getValueAutocompleteAdapter(@Nullable String key, @Nullable List<String> values, @Nullable PresetItem preset, @Nullable PresetField field,
             @NonNull Map<String, String> allTags) {
-        return getValueAutocompleteAdapter(key, values, preset, field, allTags, false);
+        return getValueAutocompleteAdapter(key, values, preset, field, allTags, false, maxInlineValues);
     }
 
     /**
@@ -266,11 +266,12 @@ public class TagFormFragment extends BaseFragment implements FormUpdate {
      * @param field a PresetField or null
      * @param allTags all the tags of the element
      * @param addRuler add a special value to indicate the position of a ruler
+     * @param addMruSize number of values from on we add the full MRU tag list
      * @return an ArrayAdapter for key, or null if something went wrong
      */
     @Nullable
     ArrayAdapter<?> getValueAutocompleteAdapter(@Nullable String key, @Nullable List<String> values, @Nullable PresetItem preset, @Nullable PresetField field,
-            @NonNull Map<String, String> allTags, boolean addRuler) {
+            @NonNull Map<String, String> allTags, boolean addRuler, int addMruSize) {
         ArrayAdapter<?> adapter = null;
 
         if (key != null && key.length() > 0) {
@@ -303,6 +304,7 @@ public class TagFormFragment extends BaseFragment implements FormUpdate {
                 ArrayAdapterWithRuler<StringWithDescription> adapter2 = new ArrayAdapterWithRuler<>(getActivity(), R.layout.autocomplete_row, Ruler.class);
                 if (preset != null) {
                     Collection<StringWithDescription> presetValues = field != null ? preset.getAutocompleteValues(field) : preset.getAutocompleteValues(key);
+                    int presetValuesCount = presetValues.size();
                     List<String> mruValues = App.getMruTags().getValues(preset, key);
                     if (mruValues != null) {
                         for (String v : mruValues) {
@@ -315,11 +317,14 @@ public class TagFormFragment extends BaseFragment implements FormUpdate {
                             }
                             if (mruValue == null) {
                                 mruValue = new StringWithDescription(v);
+                            } else if (presetValuesCount < addMruSize) {
+                                // only add unknown values for small numbers
+                                continue;
                             }
                             adapter2.add(mruValue);
                             counter.put(v, position++);
                         }
-                        if (addRuler) {
+                        if (addRuler && !adapter2.isEmpty()) {
                             adapter2.add(new Ruler());
                         }
                     }

--- a/src/main/java/de/blau/android/propertyeditor/tagform/TagFormFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/TagFormFragment.java
@@ -116,7 +116,7 @@ public class TagFormFragment extends BaseFragment implements FormUpdate {
 
     int maxStringLength; // maximum key, value and role length
 
-    private final class Ruler extends StringWithDescription {
+    final class Ruler extends StringWithDescription {
         private static final long serialVersionUID = 1L;
 
         public Ruler() {
@@ -252,7 +252,7 @@ public class TagFormFragment extends BaseFragment implements FormUpdate {
     @Nullable
     ArrayAdapter<?> getValueAutocompleteAdapter(@Nullable String key, @Nullable List<String> values, @Nullable PresetItem preset, @Nullable PresetField field,
             @NonNull Map<String, String> allTags) {
-        return getValueAutocompleteAdapter(key, values, preset, field, allTags, false, maxInlineValues);
+        return getValueAutocompleteAdapter(key, values, preset, field, allTags, false, true, maxInlineValues);
     }
 
     /**
@@ -266,12 +266,13 @@ public class TagFormFragment extends BaseFragment implements FormUpdate {
      * @param field a PresetField or null
      * @param allTags all the tags of the element
      * @param addRuler add a special value to indicate the position of a ruler
+     * @param dedup TODO
      * @param addMruSize number of values from on we add the full MRU tag list
      * @return an ArrayAdapter for key, or null if something went wrong
      */
     @Nullable
     ArrayAdapter<?> getValueAutocompleteAdapter(@Nullable String key, @Nullable List<String> values, @Nullable PresetItem preset, @Nullable PresetField field,
-            @NonNull Map<String, String> allTags, boolean addRuler, int addMruSize) {
+            @NonNull Map<String, String> allTags, boolean addRuler, boolean dedup, int addMruSize) {
         ArrayAdapter<?> adapter = null;
 
         if (key != null && key.length() > 0) {
@@ -343,7 +344,7 @@ public class TagFormFragment extends BaseFragment implements FormUpdate {
                                     StringWithDescription r = adapter2.getItem(storedPosition);
                                     r.setDescription(s.getDescription());
                                 }
-                                addValue = addRuler;
+                                addValue = !dedup;
                             } else {
                                 // skip deprecated values except if it is actually already present
                                 addValue = !deprecated;
@@ -884,7 +885,7 @@ public class TagFormFragment extends BaseFragment implements FormUpdate {
                             rowLayout.addView(TextRow.getRow(this, inflater, rowLayout, preset, field, value, values, allTags));
                         }
                     } else {
-                        ArrayAdapter<?> adapter = getValueAutocompleteAdapter(key, values, preset, field, allTags);
+                        ArrayAdapter<?> adapter = getValueAutocompleteAdapter(key, values, preset, field, allTags, true, true, maxInlineValues * 2);
                         int count = 0;
                         if (adapter != null) {
                             // adapters other than for PresetCheckField have an empty value added that we don't want to

--- a/src/main/java/de/blau/android/propertyeditor/tagform/TextRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/TextRow.java
@@ -193,7 +193,7 @@ public class TextRow extends LinearLayout implements KeyValueRow {
                     ((EditableLayout) rowLayout).putTag(key, rowValue);
                 }
             } else if (hasFocus) {
-                ArrayAdapter<?> adapter = caller.getValueAutocompleteAdapter(key, values, preset, null, allTags, true);
+                ArrayAdapter<?> adapter = caller.getValueAutocompleteAdapter(key, values, preset, null, allTags, true, -1);
                 if (adapter != null && !adapter.isEmpty()) {
                     ourValueView.setAdapter(adapter);
                 }

--- a/src/main/java/de/blau/android/propertyeditor/tagform/TextRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/TextRow.java
@@ -193,7 +193,7 @@ public class TextRow extends LinearLayout implements KeyValueRow {
                     ((EditableLayout) rowLayout).putTag(key, rowValue);
                 }
             } else if (hasFocus) {
-                ArrayAdapter<?> adapter = caller.getValueAutocompleteAdapter(key, values, preset, null, allTags, true, -1);
+                ArrayAdapter<?> adapter = caller.getValueAutocompleteAdapter(key, values, preset, null, allTags, true, false, -1);
                 if (adapter != null && !adapter.isEmpty()) {
                     ourValueView.setAdapter(adapter);
                 }

--- a/src/main/java/de/blau/android/propertyeditor/tagform/TextRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/TextRow.java
@@ -193,7 +193,7 @@ public class TextRow extends LinearLayout implements KeyValueRow {
                     ((EditableLayout) rowLayout).putTag(key, rowValue);
                 }
             } else if (hasFocus) {
-                ArrayAdapter<?> adapter = caller.getValueAutocompleteAdapter(key, values, preset, null, allTags);
+                ArrayAdapter<?> adapter = caller.getValueAutocompleteAdapter(key, values, preset, null, allTags, true);
                 if (adapter != null && !adapter.isEmpty()) {
                     ourValueView.setAdapter(adapter);
                 }

--- a/src/main/java/de/blau/android/util/ArrayAdapterWithRuler.java
+++ b/src/main/java/de/blau/android/util/ArrayAdapterWithRuler.java
@@ -1,0 +1,49 @@
+package de.blau.android.util;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.widget.LinearLayout;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import androidx.annotation.NonNull;
+import de.blau.android.R;
+
+public class ArrayAdapterWithRuler<T> extends ArrayAdapter<T> {
+    private final Class<?>       marker;
+    private final LayoutInflater inflater;
+
+    /**
+     * Construct an array adapter that supports a horizontal ruler
+     * 
+     * @param context an Android Context
+     * @param resource resource id of a layout to use, note this must contain a TextView with id "text1"
+     * @param marker class that will be used as a marker where a Ruler should be used
+     */
+    public ArrayAdapterWithRuler(@NonNull Context context, int resource, @NonNull Class<?> marker) {
+        super(context, resource, R.id.text1);
+        inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        this.marker = marker;
+    }
+
+    @Override
+    public boolean areAllItemsEnabled() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled(int position) {
+        return !marker.isInstance(getItem(position));
+    }
+
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+        if (marker.isInstance(getItem(position))) {
+            return inflater.inflate(R.layout.ruler_row, null);
+        }
+        if (convertView instanceof LinearLayout) {
+            convertView = null;
+        }
+        return super.getView(position, convertView, parent);
+    }
+}

--- a/src/main/java/de/blau/android/util/ExtendedStringWithDescription.java
+++ b/src/main/java/de/blau/android/util/ExtendedStringWithDescription.java
@@ -1,0 +1,76 @@
+package de.blau.android.util;
+
+import java.io.Serializable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class ExtendedStringWithDescription extends StringWithDescription implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private boolean deprecated;
+
+    /**
+     * Construct a new instance
+     * 
+     * @param value the value
+     */
+    public ExtendedStringWithDescription(@NonNull final String value) {
+        super(value);
+    }
+
+    /**
+     * Construct a new instance
+     * 
+     * @param value the value
+     * @param description the description of the value
+     */
+    public ExtendedStringWithDescription(@NonNull final String value, @Nullable final String description) {
+        super(value, description);
+    }
+
+    /**
+     * Construct a new instance from object of a known type
+     * 
+     * @param o one of StringWithDescription, ValueWIihCOunt or String
+     */
+    public ExtendedStringWithDescription(@NonNull Object o) {
+        super(o);
+        if (o instanceof ExtendedStringWithDescription) {
+            this.deprecated = ((ExtendedStringWithDescription) o).deprecated;
+        }
+    }
+
+    /**
+     * Check if this value is deprecated
+     * 
+     * @return true if the value is deprecated
+     */
+    public boolean isDeprecated() {
+        return deprecated;
+    }
+
+    /**
+     * Set this values deprecated status
+     * 
+     * @param deprecated if true the value is considered deprecated
+     */
+    public void setDeprecated(boolean deprecated) {
+        this.deprecated = deprecated;
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + (deprecated ? " (deprecated)" : "");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return this.equals(o) && (!(o instanceof ExtendedStringWithDescription) || this.deprecated == ((ExtendedStringWithDescription) o).deprecated);
+    }
+
+    @Override
+    public int hashCode() {
+        return 37 * super.hashCode() + (deprecated ? 1 : 0);
+    }
+}

--- a/src/main/java/de/blau/android/util/StringWithDescription.java
+++ b/src/main/java/de/blau/android/util/StringWithDescription.java
@@ -105,8 +105,8 @@ public class StringWithDescription implements Comparable<StringWithDescription>,
     @Override
     public boolean equals(Object o) {
         return o != null && (o instanceof StringWithDescription && this == (StringWithDescription) o
-                || (this.value.equals(((StringWithDescription) o).value) && ((this.description == null && ((StringWithDescription) o).description == null)
-                        || (this.description != null && this.description.equals(((StringWithDescription) o).description)))));
+                || (this.value.equals(((StringWithDescription) o).value) && ((this.description == null && ((StringWithDescription) o).description == null
+                        || (this.description != null && this.description.equals(((StringWithDescription) o).description))))));
     }
 
     @Override

--- a/src/main/java/de/blau/android/util/StringWithDescriptionAndIcon.java
+++ b/src/main/java/de/blau/android/util/StringWithDescriptionAndIcon.java
@@ -9,7 +9,7 @@ import androidx.annotation.Nullable;
 import de.blau.android.presets.Preset.PresetElement;
 import de.blau.android.presets.Preset.PresetItem;
 
-public class StringWithDescriptionAndIcon extends StringWithDescription {
+public class StringWithDescriptionAndIcon extends ExtendedStringWithDescription {
     private static final long serialVersionUID = 1L;
 
     private transient Drawable icon;

--- a/src/main/java/de/blau/android/views/CustomAutoCompleteTextView.java
+++ b/src/main/java/de/blau/android/views/CustomAutoCompleteTextView.java
@@ -8,6 +8,7 @@ import android.text.TextUtils;
 import android.text.method.QwertyKeyListener;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.view.ViewGroup;
 import android.widget.Filter;
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.AppCompatAutoCompleteTextView;
@@ -75,20 +76,22 @@ public class CustomAutoCompleteTextView extends AppCompatAutoCompleteTextView {
     @Override
     public void onSizeChanged(int w, int h, int oldw, int oldh) {
         super.onSizeChanged(w, h, oldw, oldh);
-        // Log.d(DEBUG_TAG, "onSizeChanged");
-
         if (w == 0 && h == 0) {
             return;
         }
-        // Log.d(DEBUG_TAG,"w=" + w +" h="+h);
-        // this is not really satisfactory
+
         if (parentWidth == -1) {
-            // upps
+            // We want normal behaviour
             return;
         }
+
+        // this is not really satisfactory
         int ddw = parentWidth - w;
         setDropDownHorizontalOffset(-ddw);
-        setDropDownWidth(ddw);
+        int dropDownWidth = getDropDownWidth();
+        if (dropDownWidth != ViewGroup.LayoutParams.MATCH_PARENT && dropDownWidth != ViewGroup.LayoutParams.WRAP_CONTENT) {
+            setDropDownWidth(ddw);
+        }
     }
 
     /**

--- a/src/main/res/layout/divider2.xml
+++ b/src/main/res/layout/divider2.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<View xmlns:android="http://schemas.android.com/apk/res/android"   
+        android:layout_width="fill_parent"
+        android:layout_height="2dp"
+        android:background="#b2dfdb" />

--- a/src/main/res/layout/list_ruler.xml
+++ b/src/main/res/layout/list_ruler.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<View xmlns:android="http://schemas.android.com/apk/res/android"   
+        android:layout_width="fill_parent"
+        android:layout_height="1dp"
+        android:background="#b2dfdb" />

--- a/src/main/res/layout/ruler_row.xml
+++ b/src/main/res/layout/ruler_row.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+    <View
+        android:layout_width="fill_parent"
+        android:layout_height="2dp"
+        android:background="#b2dfdb" />
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/text1"
+        android:visibility="gone" />
+</LinearLayout>


### PR DESCRIPTION
Support per tag and role deprecated status. Such fields and roles will only be displayed if they already have values assigned.

Implements  https://github.com/MarcusWolschon/osmeditor4android/issues/1276

Partially fixes https://github.com/MarcusWolschon/osmeditor4android/issues/1478

Partially fixes https://github.com/MarcusWolschon/osmeditor4android/issues/1071
