### PR TITLE
add leisure=park styling

### DIFF
--- a/src/main/assets/styles/Color-round-no-mp.xml
+++ b/src/main/assets/styles/Color-round-no-mp.xml
@@ -88,7 +88,8 @@
     <feature type="way" tags="leisure=swimming_pool" updateWidth="true" widthFactor="1.0" color="880000ff" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />    
     <feature type="way" tags="leisure=playground" area="true" updateWidth="true" widthFactor="0.8" color="88f4a460" style="STROKE" cap="BUTT" join="MITER" pathPattern="border_right" />
     <feature type="way" tags="leisure=garden" updateWidth="true" widthFactor="1.0" color="882d6e3a" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
-    
+    <feature type="way" tags="leisure=park" minVisibleZoom="10" color="88DFFCE2" />
+
     <feature type="way" tags="natural" updateWidth="true" widthFactor="0.5" color="ff71BE80" style="STROKE" cap="BUTT" join="MITER"> 
         <feature type="way" tags="natural" closed="true" area="true" pathPattern="border_right" >
             <feature type="way" tags="natural=water" widthFactor="1.0" minVisibleZoom="10" color="ff0000ff" />

--- a/src/main/assets/styles/Color-round.xml
+++ b/src/main/assets/styles/Color-round.xml
@@ -88,7 +88,8 @@
     <feature type="way" tags="leisure=swimming_pool" updateWidth="true" widthFactor="1.0" color="880000ff" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />    
     <feature type="way" tags="leisure=playground" area="true" updateWidth="true" widthFactor="0.8" color="88f4a460" style="STROKE" cap="BUTT" join="MITER" pathPattern="border_right" />
     <feature type="way" tags="leisure=garden" updateWidth="true" widthFactor="1.0" color="882d6e3a" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
-    
+    <feature type="way" tags="leisure=park" minVisibleZoom="10" color="88DFFCE2" />
+
     <feature type="way" tags="natural" updateWidth="true" widthFactor="0.5" color="ff71BE80" style="STROKE" cap="BUTT" join="MITER"> 
         <feature type="way" tags="natural" closed="true" area="true" pathPattern="border_right" >
             <feature type="way" tags="natural=water" widthFactor="1.0" minVisibleZoom="10" color="ff0000ff" />
@@ -402,7 +403,8 @@
         <feature type="relation" tags="leisure=pitch" updateWidth="true" widthFactor="1.0" color="8839AC39" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
         <feature type="relation" tags="leisure=swimming_pool" updateWidth="true" widthFactor="1.0" color="880000ff" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
         <feature type="relation" tags="leisure=garden" updateWidth="true" widthFactor="1.0" color="882d6e3a" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />    
-        
+        <feature type="relation" tags="leisure=park" minVisibleZoom="10" color="88DFFCE2" />
+
         <feature type="relation" tags="natural" color="ff71BE80" >
             <feature type="relation" tags="natural=water" widthFactor="1.0" minVisibleZoom="10" color="ff0000ff" />
             <feature type="relation" tags="natural=cliff" widthFactor="2.0" color="ff555555" pathPattern="triangle_right" />

--- a/src/main/assets/styles/Pen-round.xml
+++ b/src/main/assets/styles/Pen-round.xml
@@ -88,7 +88,8 @@
     <feature type="way" tags="leisure=swimming_pool" updateWidth="true" widthFactor="1.0" color="880000ff" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />    
     <feature type="way" tags="leisure=playground" area="true" updateWidth="true" widthFactor="0.8" color="88f4a460" style="STROKE" cap="BUTT" join="MITER" pathPattern="border_right" />
     <feature type="way" tags="leisure=garden" updateWidth="true" widthFactor="1.0" color="882d6e3a" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
-    
+    <feature type="way" tags="leisure=park" minVisibleZoom="10" color="88DFFCE2" />
+
     <feature type="way" tags="natural" updateWidth="true" widthFactor="0.5" color="ff71BE80" style="STROKE" cap="BUTT" join="MITER"> 
         <feature type="way" tags="natural" closed="true" area="true" pathPattern="border_right" >
             <feature type="way" tags="natural=water" widthFactor="1.0" minVisibleZoom="10" color="ff0000ff" />
@@ -402,6 +403,7 @@
         <feature type="relation" tags="leisure=pitch" updateWidth="true" widthFactor="1.0" color="8839AC39" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
         <feature type="relation" tags="leisure=swimming_pool" updateWidth="true" widthFactor="1.0" color="880000ff" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
         <feature type="relation" tags="leisure=garden" updateWidth="true" widthFactor="1.0" color="882d6e3a" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />    
+        <feature type="relation" tags="leisure=park" updateWidth="true" widthFactor="1.0" color="88DFFCE2" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
         
         <feature type="relation" tags="natural" color="ff71BE80" >
             <feature type="relation" tags="natural=water" widthFactor="1.0" minVisibleZoom="10" color="ff0000ff" />


### PR DESCRIPTION
Not the greatest success, but should be better than current black that always confuses me "why there is barrier mapped around this park? oh, that is just missing styling"

code based on analogy from `leisure=garden` styling

![screen10](https://user-images.githubusercontent.com/899988/146639802-e350a5be-bef9-4754-9efd-a159d6597c07.png)

park border here goes across image, in bottom right there is tree-covered area mapped https://www.openstreetmap.org/?mlat=50.06510&mlon=19.91621#map=19/50.06510/19.91621&layers=N

colour copied from OSM Carto styling due to lack of better ideas
