### PR TITLE
Allow editing note text for locally saved notes

### DIFF
--- a/src/androidTest/java/de/blau/android/easyedit/LongClickTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/LongClickTest.java
@@ -183,7 +183,7 @@ public class LongClickTest {
         assertEquals(1, tasks.size());
         Task t = tasks.get(0);
         assertTrue(t instanceof Note);
-        assertEquals("test", ((Note) t).getComment());
+        assertEquals("test", ((Note) t).getLastComment());
         LayerUtils.removeTaskLayer(main);
     }
 }

--- a/src/androidTest/java/de/blau/android/easyedit/LongClickTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/LongClickTest.java
@@ -183,7 +183,7 @@ public class LongClickTest {
         assertEquals(1, tasks.size());
         Task t = tasks.get(0);
         assertTrue(t instanceof Note);
-        assertEquals("test", ((Note) t).getLastComment());
+        assertEquals("test", ((Note) t).getLastComment().getText());
         LayerUtils.removeTaskLayer(main);
     }
 }

--- a/src/androidTest/java/de/blau/android/easyedit/SimpleActionsTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/SimpleActionsTest.java
@@ -328,7 +328,7 @@ public class SimpleActionsTest {
         assertEquals(1, tasks.size());
         Task t = tasks.get(0);
         assertTrue(t instanceof Note);
-        assertEquals("test", ((Note) t).getComment());
+        assertEquals("test", ((Note) t).getLastComment());
         TestUtils.sleep();
         // new note mode
         TestUtils.clickAtCoordinates(device, map, 8.3890736, 47.3896628, true);

--- a/src/androidTest/java/de/blau/android/easyedit/SimpleActionsTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/SimpleActionsTest.java
@@ -328,7 +328,7 @@ public class SimpleActionsTest {
         assertEquals(1, tasks.size());
         Task t = tasks.get(0);
         assertTrue(t instanceof Note);
-        assertEquals("test", ((Note) t).getLastComment());
+        assertEquals("test", ((Note) t).getLastComment().getText());
         TestUtils.sleep();
         // new note mode
         TestUtils.clickAtCoordinates(device, map, 8.3890736, 47.3896628, true);

--- a/src/main/java/de/blau/android/layer/tasks/MapOverlay.java
+++ b/src/main/java/de/blau/android/layer/tasks/MapOverlay.java
@@ -353,6 +353,10 @@ public class MapOverlay extends MapViewLayer
     @Override
     public void deselectObjects() {
         selected = null;
+        final Context ctx = map.getContext();
+        if (ctx instanceof Main && ((Main) ctx).getEasyEditManager().inNewNoteSelectedMode()) {
+            ((Main) ctx).getEasyEditManager().finish();
+        }
     }
 
     @Override

--- a/src/main/java/de/blau/android/tasks/Note.java
+++ b/src/main/java/de/blau/android/tasks/Note.java
@@ -274,15 +274,18 @@ public class Note extends Task implements Serializable, JosmXmlSerializable {
     /**
      * Get the complete bug comment suitable for use with the OSB database.
      * 
-     * @return All the comments concatenated (joined with &lt;hr /&gt;).
+     * @return All existing comments concatenated (joined with &lt;hr /&gt;).
      */
+    @NonNull
     public String getComment() {
         StringBuilder result = new StringBuilder();
         for (NoteComment comment : comments) {
-            if (result.length() > 0) {
-                result.append("<hr />");
+            if (!comment.isNew()) {
+                if (result.length() > 0) {
+                    result.append("<hr />");
+                }
+                result.append(comment.toString());
             }
-            result.append(comment.toString());
         }
         return result.toString();
     }

--- a/src/main/java/de/blau/android/tasks/NoteComment.java
+++ b/src/main/java/de/blau/android/tasks/NoteComment.java
@@ -9,6 +9,7 @@ import org.xmlpull.v1.XmlSerializer;
 import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import de.blau.android.exception.IllegalOperationException;
 import de.blau.android.osm.JosmXmlSerializable;
 import de.blau.android.util.DateFormatter;
 
@@ -90,6 +91,18 @@ public class NoteComment implements Serializable, JosmXmlSerializable {
     @Nullable
     public String getText() {
         return text;
+    }
+
+    /**
+     * Set the comment text, this is only permissible for new comments
+     * 
+     * @param text the comment text
+     */
+    public void setText(@Nullable String text) {
+        if (!isNew()) {
+            throw new IllegalOperationException("Attempt to set text for an existing note");
+        }
+        this.text = text;
     }
 
     /**
@@ -180,5 +193,4 @@ public class NoteComment implements Serializable, JosmXmlSerializable {
         s.text(text);
         s.endTag("", COMMENT_TAG);
     }
-
 }

--- a/src/main/java/de/blau/android/tasks/NoteFragment.java
+++ b/src/main/java/de/blau/android/tasks/NoteFragment.java
@@ -104,20 +104,19 @@ public class NoteFragment extends TaskFragment {
         comments.setAutoLinkMask(Linkify.WEB_URLS);
         comments.setMovementMethod(LinkMovementMethod.getInstance());
         comments.setTextIsSelectable(true);
-        NoteComment nc = ((Note) task).getLastComment();
         elementLayout.setVisibility(View.GONE); // not used for notes
         boolean hasSavedState = savedInstanceState != null && savedInstanceState.containsKey(COMMENT_KEY);
-        if ((task.isNew() && ((Note) task).count() == 0) || (nc != null && !nc.isNew()) || hasSavedState) {
-            // only show comment field if we don't have an unsaved comment
-            Log.d(DEBUG_TAG, "enabling comment field");
-            comment.setText(hasSavedState ? savedInstanceState.getString(COMMENT_KEY) : "");
-            comment.setFocusable(true);
-            comment.setFocusableInTouchMode(true);
-            comment.setEnabled(true);
-        } else {
-            commentLabel.setVisibility(View.GONE);
-            comment.setVisibility(View.GONE);
+        NoteComment lastComment = ((Note) task).getLastComment();
+        String commentText = "";
+        if (hasSavedState) {
+            commentText = savedInstanceState.getString(COMMENT_KEY);
+        } else if (lastComment != null && lastComment.isNew()) {
+            commentText = lastComment.getText();
         }
+        comment.setText(commentText);
+        comment.setFocusable(true);
+        comment.setFocusableInTouchMode(true);
+        comment.setEnabled(true);
         return ArrayAdapter.createFromResource(getActivity(), R.array.note_state, android.R.layout.simple_spinner_item);
     }
 
@@ -160,7 +159,10 @@ public class NoteFragment extends TaskFragment {
     @Override
     protected <T extends Task> void saveTaskSpecific(T task) {
         String c = comment.getText().toString();
-        if (c.length() > 0) {
+        NoteComment lastComment = ((Note) task).getLastComment();
+        if (lastComment != null && lastComment.isNew()) {
+            lastComment.setText(c);
+        } else if (c.length() > 0) {
             ((Note) task).addComment(c);
         }
     }


### PR DESCRIPTION
This also fixes the display of saved comments that haven't been uploaded yet which was weirdly formatted, and finishes new note selection mode if the note is uploaded from the dialog. 
