### PR TITLE
Enforce that fixed keys need to match

### DIFF
--- a/src/main/java/de/blau/android/presets/Preset.java
+++ b/src/main/java/de/blau/android/presets/Preset.java
@@ -1648,7 +1648,10 @@ public class Preset implements Serializable {
                 continue; // isn't going to help
             }
             int matches = 0;
-            if (fixedTagCount > 0 && possibleMatch.matches(tags)) {
+            if (fixedTagCount > 0) {
+                if (!possibleMatch.matches(tags)) {
+                    continue; // minimum requirement
+                }
                 // has all required tags
                 matches = fixedTagCount;
             }


### PR DESCRIPTION
If the conditions were just right, presets with fixed attributes could match just based on their "recommended" tags. This enforces  that either fixed attributes need to match exactly or that the min_match attribute is respected.