### PR TITLE
This fixes a race condition pan and zoom auto-downloading

### DIFF
--- a/src/main/java/de/blau/android/layer/Downloader.java
+++ b/src/main/java/de/blau/android/layer/Downloader.java
@@ -1,0 +1,36 @@
+package de.blau.android.layer;
+
+import android.util.Log;
+import androidx.annotation.NonNull;
+import de.blau.android.osm.ViewBox;
+
+public abstract class Downloader implements Runnable {
+
+    private static final String DEBUG_TAG = Downloader.class.getSimpleName();
+
+    protected long    lastAutoPrune = 0;
+    protected ViewBox box           = null;
+
+    @Override
+    public void run() {
+        if (box == null || !box.isValidForApi()) {
+            Log.e(DEBUG_TAG, "Downloader run with null or too large ViewBox " + box);
+            return;
+        }
+        download();
+    }
+
+    /**
+     * Actually download
+     */
+    protected abstract void download();
+
+    /**
+     * Set the view to download
+     * 
+     * @param box the ViewBox
+     */
+    public void setBox(@NonNull ViewBox box) {
+        this.box = new ViewBox(box);
+    }
+}

--- a/src/main/java/de/blau/android/layer/data/MapOverlay.java
+++ b/src/main/java/de/blau/android/layer/data/MapOverlay.java
@@ -49,6 +49,7 @@ import de.blau.android.AsyncResult;
 import de.blau.android.dialogs.LayerInfo;
 import de.blau.android.filter.Filter;
 import de.blau.android.layer.ConfigureInterface;
+import de.blau.android.layer.Downloader;
 import de.blau.android.layer.ExtentInterface;
 import de.blau.android.layer.LayerInfoInterface;
 import de.blau.android.layer.LayerType;
@@ -345,7 +346,7 @@ public class MapOverlay extends MapViewLayer implements ExtentInterface, Configu
     /**
      * Runnable for downloading data
      */
-    Runnable download = new Runnable() {
+    Downloader download = new Downloader() {
 
         final PostMergeHandler postMerge = new PostMergeHandler() {
             @Override
@@ -354,12 +355,9 @@ public class MapOverlay extends MapViewLayer implements ExtentInterface, Configu
             }
         };
 
-        private long lastAutoPrune = 0;
-
         @Override
-        public void run() {
+        protected void download() {
             List<BoundingBox> bbList = new ArrayList<>(delegator.getBoundingBoxes());
-            ViewBox box = new ViewBox(map.getViewBox());
             box.scale(1.2); // make sides 20% larger
             box.ensureMinumumSize(minDownloadSize); // enforce a minimum size
             List<BoundingBox> bboxes = BoundingBox.newBoxes(bbList, box);
@@ -422,6 +420,7 @@ public class MapOverlay extends MapViewLayer implements ExtentInterface, Configu
         Location location = map.getLocation();
         if (zoomLevel >= panAndZoomLimit && panAndZoomDownLoad && (location == null || location.getSpeed() < maxDownloadSpeed)) {
             map.getRootView().removeCallbacks(download);
+            download.setBox(map.getViewBox());
             map.getRootView().postDelayed(download, 100);
         }
         paintOsmData(canvas);

--- a/src/main/java/de/blau/android/layer/tasks/MapOverlay.java
+++ b/src/main/java/de/blau/android/layer/tasks/MapOverlay.java
@@ -25,6 +25,7 @@ import de.blau.android.dialogs.LayerInfo;
 import de.blau.android.layer.ClickableInterface;
 import de.blau.android.layer.ConfigureInterface;
 import de.blau.android.layer.DiscardInterface;
+import de.blau.android.layer.Downloader;
 import de.blau.android.layer.ExtentInterface;
 import de.blau.android.layer.LayerInfoInterface;
 import de.blau.android.layer.LayerType;
@@ -113,11 +114,10 @@ public class MapOverlay extends MapViewLayer
      * 
      * There is some code duplication here, however attempts to merge this didn't work out
      */
-    Runnable download = new Runnable() {
-        private long lastAutoPrune = 0;
+    Downloader download = new Downloader() {
 
         @Override
-        public void run() {
+        protected void download() {
             if (mThreadPool == null) {
                 mThreadPool = (ThreadPoolExecutor) Executors.newFixedThreadPool(THREAD_POOL_SIZE);
             }
@@ -165,6 +165,7 @@ public class MapOverlay extends MapViewLayer
 
             if (zoomLevel >= panAndZoomLimit && panAndZoomDownLoad && (location == null || location.getSpeed() < maxDownloadSpeed)) {
                 map.getRootView().removeCallbacks(download);
+                download.setBox(map.getViewBox());
                 map.getRootView().postDelayed(download, 100);
             }
 

--- a/src/main/java/de/blau/android/osm/BoundingBox.java
+++ b/src/main/java/de/blau/android/osm/BoundingBox.java
@@ -503,7 +503,7 @@ public class BoundingBox implements Serializable, JosmXmlSerializable, BoundedOb
      * 
      * @return true, if the bbox is smaller than 0.5*0.5 (here multiplied by 1E7) degree.
      */
-    public boolean isValidForApi() {
+    public boolean isValidForApi() { // FIXME this should use the values from the API Capabilities
         return width < API_MAX_DEGREE_DIFFERENCE && height < API_MAX_DEGREE_DIFFERENCE;
     }
 


### PR DESCRIPTION
Potentially the thread running the downloader could be run with the current bounding box instead of the one the runnable was submitted with bypassing the zoom level check.