### PR TITLE
Dialog lifecycle fixes

### DIFF
--- a/src/main/java/de/blau/android/dialogs/ConfirmUpload.java
+++ b/src/main/java/de/blau/android/dialogs/ConfirmUpload.java
@@ -54,6 +54,7 @@ import de.blau.android.prefs.Preferences;
 import de.blau.android.util.ACRAHelper;
 import de.blau.android.util.FilterlessArrayAdapter;
 import de.blau.android.util.ImmersiveDialogFragment;
+import de.blau.android.util.OnPageSelectedListener;
 import de.blau.android.util.ThemeUtils;
 import de.blau.android.validation.ExtendedValidator;
 import de.blau.android.validation.FormValidation;
@@ -207,17 +208,7 @@ public class ConfirmUpload extends ImmersiveDialogFragment {
 
         pager.setAdapter(new ViewPagerAdapter(activity, layout, new int[] { R.id.review_page, R.id.tags_page },
                 new int[] { R.string.confirm_upload_edits_page, R.string.menu_tags }));
-        pager.addOnPageChangeListener(new OnPageChangeListener() {
-
-            @Override
-            public void onPageScrollStateChanged(int arg0) {
-                // empty
-            }
-
-            @Override
-            public void onPageScrolled(int arg0, float arg1, int arg2) {
-                // empty
-            }
+        pager.addOnPageChangeListener(new OnPageSelectedListener() {
 
             @Override
             public void onPageSelected(int arg0) {
@@ -231,7 +222,6 @@ public class ConfirmUpload extends ImmersiveDialogFragment {
                 InputMethodManager imm = (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
                 imm.hideSoftInputFromWindow(layout.getWindowToken(), 0);
             }
-
         });
 
         builder.setView(layout);

--- a/src/main/java/de/blau/android/photos/PhotoViewerFragment.java
+++ b/src/main/java/de/blau/android/photos/PhotoViewerFragment.java
@@ -30,7 +30,6 @@ import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import androidx.viewpager.widget.PagerAdapter;
 import androidx.viewpager.widget.ViewPager;
-import androidx.viewpager.widget.ViewPager.OnPageChangeListener;
 import de.blau.android.App;
 import de.blau.android.Main;
 import de.blau.android.Map;
@@ -39,6 +38,7 @@ import de.blau.android.contract.Ui;
 import de.blau.android.listener.DoNothingListener;
 import de.blau.android.util.ImageLoader;
 import de.blau.android.util.ImmersiveDialogFragment;
+import de.blau.android.util.OnPageSelectedListener;
 import de.blau.android.util.Snack;
 import de.blau.android.util.ThemeUtils;
 
@@ -223,17 +223,7 @@ public class PhotoViewerFragment extends ImmersiveDialogFragment implements OnMe
         viewPager.setAdapter(photoPagerAdapter);
         viewPager.setOffscreenPageLimit(2);
         viewPager.setCurrentItem(startPos);
-        viewPager.addOnPageChangeListener(new OnPageChangeListener() {
-
-            @Override
-            public void onPageScrollStateChanged(int arg0) {
-                // UNUSED
-            }
-
-            @Override
-            public void onPageScrolled(int arg0, float arg1, int arg2) {
-                // UNUSED
-            }
+        viewPager.addOnPageChangeListener(new OnPageSelectedListener() {
 
             @Override
             public void onPageSelected(int page) {

--- a/src/main/java/de/blau/android/propertyeditor/tagform/CheckGroupDialogRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/CheckGroupDialogRow.java
@@ -61,7 +61,7 @@ public class CheckGroupDialogRow extends MultiselectDialogRow {
     }
 
     /**
-     * Add additional description values as individual TextViews
+     * Set the selected check values
      * 
      * @param keyValues a Map of the current keys and values for this check group
      */
@@ -281,7 +281,6 @@ public class CheckGroupDialogRow extends MultiselectDialogRow {
         android.view.ViewGroup.LayoutParams buttonLayoutParams = valueGroup.getLayoutParams();
         buttonLayoutParams.width = ViewGroup.LayoutParams.MATCH_PARENT;
 
-        layout.setTag(key);
         PresetCheckGroupField field = (PresetCheckGroupField) preset.getField(key);
 
         for (PresetCheckField check : field.getCheckFields()) {
@@ -303,6 +302,7 @@ public class CheckGroupDialogRow extends MultiselectDialogRow {
         builder.setNeutralButton(R.string.clear, (dialog, which) -> {
             // do nothing
         });
+        valueGroup.setTag(key);
         builder.setPositiveButton(R.string.save, (dialog, which) -> {
             Map<String, String> ourKeyValues = new HashMap<>();
             for (int pos = 0; pos < valueGroup.getChildCount(); pos++) {
@@ -325,9 +325,8 @@ public class CheckGroupDialogRow extends MultiselectDialogRow {
                     }
                 }
             }
-            caller.updateTags(ourKeyValues, false); // batch update
-            row.setSelectedValues(ourKeyValues);
-            row.setChanged(true);
+            String k = (String) ((AlertDialog) dialog).findViewById(R.id.valueGroup).getTag();
+            updateTags(((AlertDialog) dialog).getContext(), k, ourKeyValues, false); // batch update
         });
         builder.setNegativeButton(R.string.cancel, null);
         return builder.create();

--- a/src/main/java/de/blau/android/propertyeditor/tagform/ComboDialogRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/ComboDialogRow.java
@@ -63,11 +63,11 @@ public class ComboDialogRow extends DialogRow {
     }
 
     /**
-     * Scroll the view in the dialog to show the value, assumes the ScrollView has id R.id.myScrollView
+     * Scroll the view in the dialog to show the value
      * 
      * @param value the value we want to scroll to
      * @param dialog the enclosing dialog
-     * @param containerId ?
+     * @param containerId resource id of the ViewGroup containing the rows
      */
     static void scrollDialogToValue(String value, AlertDialog dialog, int containerId) {
         Log.d(DEBUG_TAG, "scrollDialogToValue scrolling to " + value);
@@ -216,24 +216,21 @@ public class ComboDialogRow extends DialogRow {
         }
         final Handler handler = new Handler(Looper.getMainLooper());
         builder.setPositiveButton(R.string.clear, (dialog, which) -> {
-            caller.updateSingleValue((String) layout.getTag(), "");
-            row.setValue("", "");
-            row.setChanged(true);
+            String k = (String) ((AlertDialog) dialog).findViewById(R.id.valueGroup).getTag();
+            updateTag(((AlertDialog) dialog).getContext(), k, new StringWithDescription(""));
             // allow a tiny bit of time to see that the action actually worked
             handler.postDelayed(dialog::dismiss, 100);
         });
         builder.setNegativeButton(R.string.cancel, null);
         final AlertDialog dialog = builder.create();
-        layout.setTag(key);
+        valueGroup.setTag(key);
         valueGroup.setOnCheckedChangeListener((group, checkedId) -> {
             Log.d(DEBUG_TAG, "radio group onCheckedChanged");
             StringWithDescription ourValue = null;
             if (checkedId != -1) {
                 RadioButton button = (RadioButton) group.findViewById(checkedId);
                 ourValue = (StringWithDescription) button.getTag();
-                caller.updateSingleValue((String) layout.getTag(), ourValue.getValue());
-                row.setValue(ourValue);
-                row.setChanged(true);
+                updateTag(button.getContext(), (String) group.getTag(), ourValue);
             }
             // allow a tiny bit of time to see that the action actually worked
             handler.postDelayed(dialog::dismiss, 100);

--- a/src/main/java/de/blau/android/propertyeditor/tagform/ComboImageLoader.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/ComboImageLoader.java
@@ -67,7 +67,7 @@ public class ComboImageLoader extends ImageLoader {
     public void onSelected(int pos) {
         final Value v = values.get(pos);
         if (v instanceof StringWithDescriptionAndIcon) {
-            update(((StringWithDescriptionAndIcon) v).getValue());
+            update((StringWithDescriptionAndIcon) v);
         }
     }
 
@@ -76,10 +76,10 @@ public class ComboImageLoader extends ImageLoader {
      * 
      * @param v the selected value
      */
-    private void update(final String v) {
+    private void update(final StringWithDescription v) {
         if (parentFragment instanceof TagFormFragment) {
-            ((TagFormFragment) parentFragment).updateSingleValue(key, v);
-            ((TagFormFragment) parentFragment).tagsUpdated();
+            ((TagFormFragment) parentFragment).updateSingleValue(key, v.getValue());
+            ((TagFormFragment) parentFragment).updateDialogRow(key, v);
         } else {
             Log.e(DEBUG_TAG, "caller not a TagFormFragment " + parentFragment);
         }
@@ -87,6 +87,6 @@ public class ComboImageLoader extends ImageLoader {
 
     @Override
     public void clearSelection() {
-        update("");
+        update(new StringWithDescription(""));
     }
 }

--- a/src/main/java/de/blau/android/propertyeditor/tagform/MultiselectDialogRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/MultiselectDialogRow.java
@@ -98,7 +98,6 @@ public class MultiselectDialogRow extends DialogRow {
         for (StringWithDescription swd : values) {
             String d = swd.getDescription();
             if (first) {
-
                 setValue(swd.getValue(), d != null && !"".equals(d) ? d : swd.getValue());
                 first = false;
             } else {
@@ -196,7 +195,6 @@ public class MultiselectDialogRow extends DialogRow {
         android.view.ViewGroup.LayoutParams buttonLayoutParams = valueGroup.getLayoutParams();
         buttonLayoutParams.width = ViewGroup.LayoutParams.MATCH_PARENT;
 
-        layout.setTag(key);
         List<String> values = Preset.splitValues(Util.wrapInList(row.getValue()), preset, key);
         if (adapter != null) {
             int count = adapter.getCount();
@@ -227,20 +225,27 @@ public class MultiselectDialogRow extends DialogRow {
         builder.setNeutralButton(R.string.clear, (dialog, iwhich) -> {
             // do nothing
         });
+        valueGroup.setTag(new String[] { key, String.valueOf(preset.getDelimiter(key)) });
         builder.setPositiveButton(R.string.save, (dialog, which) -> {
+            String[] kd = (String[]) ((AlertDialog) dialog).findViewById(R.id.valueGroup).getTag();
+            String delimiter = kd[1];
             List<StringWithDescription> valueList = new ArrayList<>();
+            StringBuilder stringBuilder = new StringBuilder();
             for (int pos = 0; pos < valueGroup.getChildCount(); pos++) {
                 View c = valueGroup.getChildAt(pos);
                 if (c instanceof AppCompatCheckBox) {
                     AppCompatCheckBox checkBox = (AppCompatCheckBox) c;
                     if (checkBox.isChecked()) {
-                        valueList.add((StringWithDescription) checkBox.getTag());
+                        if (stringBuilder.length() != 0) {
+                            stringBuilder.append(delimiter);
+                        }
+                        final StringWithDescription swd = (StringWithDescription) checkBox.getTag();
+                        stringBuilder.append(swd.getValue());
+                        valueList.add(swd);
                     }
                 }
             }
-            row.setValue(valueList);
-            caller.updateSingleValue((String) layout.getTag(), row.getValue());
-            row.setChanged(true);
+            updateTag(((AlertDialog) dialog).getContext(), kd[0], stringBuilder.toString(), valueList);
         });
         builder.setNegativeButton(R.string.cancel, null);
         return builder.create();

--- a/src/main/java/de/blau/android/propertyeditor/tagform/ShowDialogOnClickListener.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/ShowDialogOnClickListener.java
@@ -11,6 +11,8 @@ import de.blau.android.R;
 
 abstract class ShowDialogOnClickListener implements OnClickListener {
 
+    private static final long DEBOUNCE_DELAY = 1000;
+
     /**
      * Get the AlertDialog to display
      * 
@@ -22,15 +24,14 @@ abstract class ShowDialogOnClickListener implements OnClickListener {
     @Override
     public void onClick(View v) {
         final AlertDialog dialog = buildDialog();
-        View finalView = v;
-        finalView.setEnabled(false); // debounce
-        final Object tag = finalView.getTag();
+        v.setEnabled(false); // debounce
+        v.postDelayed(() -> v.setEnabled(true), DEBOUNCE_DELAY);
+        final Object tag = v.getTag();
         dialog.setOnShowListener(d -> {
             if (tag instanceof String) {
                 ComboDialogRow.scrollDialogToValue((String) tag, dialog, R.id.valueGroup);
             }
         });
-        dialog.setOnDismissListener(d -> finalView.setEnabled(true));
         dialog.show();
         dialog.getButton(DialogInterface.BUTTON_NEUTRAL).setOnClickListener(unused -> {
             LinearLayout valueGroup = (LinearLayout) dialog.findViewById(R.id.valueGroup);

--- a/src/main/java/de/blau/android/propertyeditor/tagform/TagFormFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/TagFormFragment.java
@@ -1047,7 +1047,7 @@ public class TagFormFragment extends BaseFragment implements FormUpdate {
      * @param key the key value we want to focus on
      * @return true if the key was found
      */
-    private boolean focusOnTag(String key) {
+    public boolean focusOnTag(String key) {
         boolean found = false;
         View sv = getView();
         LinearLayout ll = (LinearLayout) sv.findViewById(R.id.form_container_layout);
@@ -1059,14 +1059,15 @@ public class TagFormFragment extends BaseFragment implements FormUpdate {
                 for (int i = ll2.getChildCount() - 1; i >= 0; --i) {
                     View v = ll2.getChildAt(i);
                     if (v instanceof TextRow && ((TextRow) v).getKey().equals(key)) {
-                        ((TextRow) v).getValueView().requestFocus();
                         Util.scrollToRow(sv, v, true, true);
+                        ((TextRow) v).getValueView().requestFocus();
                         found = true;
                         break;
                     } else if (v instanceof DialogRow && ((DialogRow) v).getKey().equals(key)) {
                         Util.scrollToRow(sv, v, true, true);
                         ((DialogRow) v).click();
                         found = true;
+                        break;
                     }
                 }
                 pos++;
@@ -1106,6 +1107,72 @@ public class TagFormFragment extends BaseFragment implements FormUpdate {
             return false;
         }
         return found;
+    }
+
+    /**
+     * Find a row for a specific key
+     * 
+     * @param key the key to search for
+     * @return the Row or null
+     */
+    public View getRow(@NonNull String key) {
+        View sv = getView();
+        LinearLayout ll = (LinearLayout) sv.findViewById(R.id.form_container_layout);
+        if (ll != null) {
+            int pos = 0;
+            while (ll.getChildAt(pos) instanceof EditableLayout && pos < ll.getChildCount()) {
+                EditableLayout ll2 = (EditableLayout) ll.getChildAt(pos);
+                for (int i = ll2.getChildCount() - 1; i >= 0; --i) {
+                    View v = ll2.getChildAt(i);
+                    if ((v instanceof TextRow && ((TextRow) v).getKey().equals(key)) || (v instanceof DialogRow && ((DialogRow) v).getKey().equals(key))) {
+                        return v;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Update a DialogRow
+     * 
+     * @param key the key
+     * @param value the new value
+     */
+    public void updateDialogRow(@NonNull String key, @NonNull StringWithDescription value) {
+        View row = getRow(key);
+        if (row instanceof DialogRow) {
+            ((DialogRow) row).setValue(value);
+            ((DialogRow) row).setChanged(true);
+        }
+    }
+
+    /**
+     * Update a DialogRow
+     * 
+     * @param key the key
+     * @param valueList a list of new values
+     */
+    public void updateDialogRow(@NonNull String key, @NonNull List<StringWithDescription> valueList) {
+        View row = getRow(key);
+        if (row instanceof MultiselectDialogRow) {
+            ((MultiselectDialogRow) row).setValue(valueList);
+            ((DialogRow) row).setChanged(true);
+        }
+    }
+
+    /**
+     * Update a DialogRow
+     * 
+     * @param key the key
+     * @param tags a Map of selected tags
+     */
+    public void updateDialogRow(@NonNull String key, @NonNull final Map<String, String> tags) {
+        View row = getRow(key);
+        if (row instanceof CheckGroupDialogRow) {
+            ((CheckGroupDialogRow) row).setSelectedValues(tags);
+            ((DialogRow) row).setChanged(true);
+        }
     }
 
     /**

--- a/src/main/java/de/blau/android/util/OnPageSelectedListener.java
+++ b/src/main/java/de/blau/android/util/OnPageSelectedListener.java
@@ -1,0 +1,22 @@
+package de.blau.android.util;
+
+import androidx.viewpager.widget.ViewPager.OnPageChangeListener;
+
+/**
+ * We only ever need onPageSelected
+ * 
+ * @author simon
+ *
+ */
+public abstract class OnPageSelectedListener implements OnPageChangeListener {
+    
+    @Override
+    public void onPageScrollStateChanged(int arg0) {
+        // UNUSED
+    }
+
+    @Override
+    public void onPageScrolled(int arg0, float arg1, int arg2) {
+        // UNUSED
+    }
+}

--- a/src/main/java/de/blau/android/util/SelectByImageFragment.java
+++ b/src/main/java/de/blau/android/util/SelectByImageFragment.java
@@ -28,7 +28,6 @@ import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import androidx.viewpager.widget.PagerAdapter;
 import androidx.viewpager.widget.ViewPager;
-import androidx.viewpager.widget.ViewPager.OnPageChangeListener;
 import de.blau.android.R;
 import de.blau.android.listener.DoNothingListener;
 
@@ -170,17 +169,7 @@ public class SelectByImageFragment extends ImmersiveDialogFragment implements On
         viewPager.setAdapter(imagePagerAdapter);
         viewPager.setOffscreenPageLimit(2);
         viewPager.setCurrentItem(startPos);
-        viewPager.addOnPageChangeListener(new OnPageChangeListener() {
-
-            @Override
-            public void onPageScrollStateChanged(int arg0) {
-                // UNUSED
-            }
-
-            @Override
-            public void onPageScrolled(int arg0, float arg1, int arg2) {
-                // UNUSED
-            }
+        viewPager.addOnPageChangeListener(new OnPageSelectedListener() {
 
             @Override
             public void onPageSelected(int page) {


### PR DESCRIPTION
Navigating away from the Dialogs shown by the TagFormFragment would make them non-functional, this fixes the issue by retrieving the restored fragment and using its methods to manipulate the display.