### PR TITLE
Fix infinite loop in getRow

### DIFF
--- a/src/main/java/de/blau/android/propertyeditor/tagform/ComboDialogRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/ComboDialogRow.java
@@ -215,12 +215,12 @@ public class ComboDialogRow extends DialogRow {
                 }
             }
         }
-        final Handler handler = new Handler(Looper.getMainLooper());
         builder.setPositiveButton(R.string.clear, (dialog, which) -> {
-            String k = (String) ((AlertDialog) dialog).findViewById(R.id.valueGroup).getTag();
+            View groupView =((AlertDialog) dialog).findViewById(R.id.valueGroup);
+            String k = (String)groupView.getTag();
             updateTag(((AlertDialog) dialog).getContext(), k, new StringWithDescription(""));
             // allow a tiny bit of time to see that the action actually worked
-            handler.postDelayed(dialog::dismiss, 100);
+            groupView.postDelayed(dialog::dismiss, 100);
         });
         builder.setNegativeButton(R.string.cancel, null);
         final AlertDialog dialog = builder.create();
@@ -234,7 +234,7 @@ public class ComboDialogRow extends DialogRow {
                 updateTag(button.getContext(), (String) group.getTag(), ourValue);
             }
             // allow a tiny bit of time to see that the action actually worked
-            handler.postDelayed(dialog::dismiss, 100);
+            group.postDelayed(dialog::dismiss, 100);
         });
 
         return dialog;

--- a/src/main/java/de/blau/android/propertyeditor/tagform/TagFormFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/TagFormFragment.java
@@ -1115,6 +1115,7 @@ public class TagFormFragment extends BaseFragment implements FormUpdate {
      * @param key the key to search for
      * @return the Row or null
      */
+    @Nullable
     public View getRow(@NonNull String key) {
         View sv = getView();
         LinearLayout ll = (LinearLayout) sv.findViewById(R.id.form_container_layout);
@@ -1128,6 +1129,7 @@ public class TagFormFragment extends BaseFragment implements FormUpdate {
                         return v;
                     }
                 }
+                pos++;
             }
         }
         return null;


### PR DESCRIPTION
This would only happen if we had more than one "EditableLayout" in the tag form.