### PR TITLE
Keep show gps in sync

### DIFF
--- a/documentation/docs/help/en/Main map display.md
+++ b/documentation/docs/help/en/Main map display.md
@@ -120,13 +120,13 @@ directory, however this depends on the specific camera app.
 
 ### ![GPS](../images/menu_gps.png) GPS
 
-The "on-map" GPS button duplicates the function of the "Follow GPS position" menu entry. When this is activated the GPS arrow will be displayed as an outline.
+The "on-map" GPS button duplicates the function of the "Follow GPS position" menu entry. When this is activated the GPS arrow will be displayed as an outline. Note that the _Show location_ function will enable location updates from the system, just as the recording and similar options.
 
  * **Show location** - show arrow symbol at current position
- * **Follow location** - pan and center screen to follow the current position
+ * **Follow location** - pan and center screen to follow the current position, will enable _Show location_ too.
  * **Add bookmark...** - set a bookmark for the current viewbox
  * **Bookmarks...** - show current viewbox bookmarks
- * **Go to current location** - go to and zoom in to the current position
+ * **Go to current location** - go to and zoom in to the current position. If location updates are not turned on, this will try to get a location without enabling continuous updates.
  * **Go to coordinates...** - go to and zoom in to coordinates or an open location code
  * **Start GPX track** - start recording a GPX track and display a corresponding layer.
  * **Pause GPX track** - pause recording the current GPX track

--- a/src/androidTest/java/de/blau/android/gpx/GpxTest.java
+++ b/src/androidTest/java/de/blau/android/gpx/GpxTest.java
@@ -3,6 +3,7 @@ package de.blau.android.gpx;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -375,6 +376,29 @@ public class GpxTest {
         } catch (IOException e) {
             fail(e.getMessage());
         }
+    }
+    
+    /**
+     * Test goto current location
+     * 
+     * Note: it would be nice to check if location updates remained off
+     */
+    @Test
+    public void gotoCurrentLocation() {
+        TestUtils.setupMockLocation(main, Criteria.ACCURACY_FINE);
+        prefs.setShowGPS(false);
+        main.setFollowGPS(false);
+        assertNull(main.getMap().getLocation());
+        TestUtils.injectLocation(main, 1.0, 1.0, 1000, null);
+        clickGpsButton(device);
+        assertTrue(TestUtils.clickText(device, false, main.getString(R.string.menu_gps_goto), false, false));
+        assertFalse(main.getFollowGPS());
+        assertFalse(prefs.getShowGPS());
+        assertNull(main.getMap().getLocation());
+        TestUtils.sleep();
+        double[] center = main.getMap().getViewBox().getCenter();
+        assertEquals(1.0,center[0],0.0001);
+        assertEquals(1.0,center[1],0.0001);
     }
 
     /**

--- a/src/main/assets/help/en/Main map display.html
+++ b/src/main/assets/help/en/Main map display.html
@@ -133,13 +133,13 @@
 <h3><img src="../images/camera.png" alt="Camera" /> Camera</h3>
 <p>Start a camera app, add the resulting photograph to the photo layer is enabled. The photograph itself should be stored in the Vespucci/Pictures directory, however this depends on the specific camera app.</p>
 <h3><img src="../images/menu_gps.png" alt="GPS" /> GPS</h3>
-<p>The &quot;on-map&quot; GPS button duplicates the function of the &quot;Follow GPS position&quot; menu entry. When this is activated the GPS arrow will be displayed as an outline.</p>
+<p>The &quot;on-map&quot; GPS button duplicates the function of the &quot;Follow GPS position&quot; menu entry. When this is activated the GPS arrow will be displayed as an outline. Note that the <em>Show location</em> function will enable location updates from the system, just as the recording and similar options.</p>
 <ul>
 <li><strong>Show location</strong> - show arrow symbol at current position</li>
-<li><strong>Follow location</strong> - pan and center screen to follow the current position</li>
+<li><strong>Follow location</strong> - pan and center screen to follow the current position, will enable <em>Show location</em> too.</li>
 <li><strong>Add bookmark...</strong> - set a bookmark for the current viewbox</li>
 <li><strong>Bookmarks...</strong> - show current viewbox bookmarks</li>
-<li><strong>Go to current location</strong> - go to and zoom in to the current position</li>
+<li><strong>Go to current location</strong> - go to and zoom in to the current position. If location updates are not turned on, this will try to get a location without enabling continuous updates.</li>
 <li><strong>Go to coordinates...</strong> - go to and zoom in to coordinates or an open location code</li>
 <li><strong>Start GPX track</strong> - start recording a GPX track and display a corresponding layer.</li>
 <li><strong>Pause GPX track</strong> - pause recording the current GPX track</li>

--- a/src/main/java/de/blau/android/Main.java
+++ b/src/main/java/de/blau/android/Main.java
@@ -638,7 +638,7 @@ public class Main extends FullScreenAppCompatActivity
     }
 
     /**
-     * Get the best last position
+     * Get the best last position from the LocactionManager
      * 
      * @return a Location object
      */
@@ -2489,14 +2489,17 @@ public class Main extends FullScreenAppCompatActivity
         Location gotoLoc = null;
         if (getTracker() != null) {
             gotoLoc = getTracker().getLastLocation();
-        } else if (getEnabledLocationProviders() != null) {
+        }
+        if (gotoLoc == null && getEnabledLocationProviders() != null) { // fallback
             gotoLoc = getLastLocation();
         } // else moan? without GPS enabled this shouldn't be selectable
           // currently
         if (gotoLoc != null) {
             App.getLogic().setZoom(getMap(), Ui.ZOOM_FOR_ZOOMTO);
             map.getViewBox().moveTo(getMap(), (int) (gotoLoc.getLongitude() * 1E7d), (int) (gotoLoc.getLatitude() * 1E7d));
-            map.setLocation(gotoLoc);
+            if (prefs.getShowGPS()) {
+                map.setLocation(gotoLoc);
+            }
             map.invalidate();
         }
     }


### PR DESCRIPTION
This checks the show GPS preference in gotoCurrentLocation and only sets the map location (which triggers display of the arrow) if it is set.

Further gotoCurrentLocation now actually uses the location manager last location if the tracker service is present, but doesn't have a last location.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/1588