### PR TITLE
Add support for automatic capitalization on input

### DIFF
--- a/documentation/docs/help/en/Advanced preferences.md
+++ b/documentation/docs/help/en/Advanced preferences.md
@@ -96,6 +96,12 @@ Set how load the beep is Vespucci uses when you are pressing unsupported short c
 
 Set the minimum zoom level for Mapillary data to be displayed. If set too low the application might crash in areas with very high density Mapillary data. Consider increasing the number if your display if very large or very high resolution. Default: _16_
 
+### Name capitalization
+
+Set the capitalization mode for keyboard input for name-like tag. One of _No capitalization_, _Word capitalization_ and _Sentence capitalization_. Default: _Word capitalization_.
+
+Note: this setting is only applicable when the current locale uses latin script.
+
 ## Data and Editing Settings
 
 Settings related to editing.

--- a/src/androidTest/java/de/blau/android/TestUtils.java
+++ b/src/androidTest/java/de/blau/android/TestUtils.java
@@ -1240,7 +1240,6 @@ public class TestUtils {
         } catch (UiObjectNotFoundException e) {
             return false;
         }
-
     }
 
     /**

--- a/src/main/assets/help/en/Advanced preferences.html
+++ b/src/main/assets/help/en/Advanced preferences.html
@@ -54,6 +54,9 @@
 <p>Set how load the beep is Vespucci uses when you are pressing unsupported short cut keys on a connected real keyboard. Default: <em>50</em>.</p>
 <h3>Minimum zoom for Mapillary</h3>
 <p>Set the minimum zoom level for Mapillary data to be displayed. If set too low the application might crash in areas with very high density Mapillary data. Consider increasing the number if your display if very large or very high resolution. Default: <em>16</em></p>
+<h3>Name capitalization</h3>
+<p>Set the capitalization mode for keyboard input for name-like tag. One of <em>No capitalization</em>, <em>Word capitalization</em> and <em>Sentence capitalization</em>. Default: <em>Word capitalization</em>.</p>
+<p>Note: this setting is only applicable when the current locale uses latin script.</p>
 <h2>Data and Editing Settings</h2>
 <p>Settings related to editing.</p>
 <h3>Always use contextual menu</h3>

--- a/src/main/java/de/blau/android/osm/Tags.java
+++ b/src/main/java/de/blau/android/osm/Tags.java
@@ -1,5 +1,6 @@
 package de.blau.android.osm;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -24,13 +25,14 @@ public final class Tags {
     public static final String OSM_VALUE_SEPARATOR = ";";
 
     // Karlsruher schema
-    public static final String KEY_ADDR_BASE        = "addr:";
-    public static final String KEY_ADDR_HOUSENUMBER = "addr:housenumber";
-    public static final String KEY_ADDR_STREET      = "addr:street";
-    public static final String KEY_ADDR_POSTCODE    = "addr:postcode";
-    public static final String KEY_ADDR_CITY        = "addr:city";
-    public static final String KEY_ADDR_COUNTRY     = "addr:country";
-    public static final String KEY_ADDR_FULL        = "addr:full";
+    private static final String KEY_ADDR             = "addr";
+    public static final String  KEY_ADDR_BASE        = KEY_ADDR + ":";
+    public static final String  KEY_ADDR_HOUSENUMBER = "addr:housenumber";
+    public static final String  KEY_ADDR_STREET      = "addr:street";
+    public static final String  KEY_ADDR_POSTCODE    = "addr:postcode";
+    public static final String  KEY_ADDR_CITY        = "addr:city";
+    public static final String  KEY_ADDR_COUNTRY     = "addr:country";
+    public static final String  KEY_ADDR_FULL        = "addr:full";
     // the following are less used but may be necessary
     public static final String KEY_ADDR_HOUSENAME          = "addr:housename";
     public static final String KEY_ADDR_CONSCRIPTIONNUMBER = "addr:conscriptionnumber";
@@ -100,6 +102,28 @@ public final class Tags {
     public static final String       KEY_INT_NAME      = "int_name";
     public static final List<String> I18N_NAME_KEYS    = Collections
             .unmodifiableList(Arrays.asList(KEY_NAME, KEY_OFFICIAL_NAME, KEY_ALT_NAME, KEY_LOC_NAME, KEY_SHORT_NAME, KEY_REG_NAME, KEY_NAT_NAME));
+
+    /**
+     * Check if a key in general can be assumed to have a different value for each occurrence
+     * 
+     * We also assume that key: are variants that follow the same rule
+     * 
+     * @param key the key to check
+     * @return true if the key has name-like semantics
+     */
+    public static boolean isLikeAName(@NonNull String key) {
+        List<String> nameLikeKeys = new ArrayList<>(Tags.I18N_NAME_KEYS);
+        nameLikeKeys.add(Tags.KEY_ADDR);
+        nameLikeKeys.add(Tags.KEY_ADDR_HOUSENAME);
+        nameLikeKeys.add(Tags.KEY_ADDR_UNIT);
+        nameLikeKeys.add(Tags.KEY_REF);
+        for (String k : nameLikeKeys) {
+            if (k.equals(key) || key.startsWith(k + ":")) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     public static final String KEY_NAME_LEFT        = "name:left";
     public static final String KEY_NAME_RIGHT       = "name:right";

--- a/src/main/java/de/blau/android/prefs/AdvancedPrefEditorFragment.java
+++ b/src/main/java/de/blau/android/prefs/AdvancedPrefEditorFragment.java
@@ -75,6 +75,7 @@ public class AdvancedPrefEditorFragment extends ExtendedPreferenceFragment {
         setListPreferenceSummary(R.string.config_followGPSbutton_key, true);
         setRestartRequiredMessage(R.string.config_preferRemovableStorage_key);
         setRestartRequiredMessage(R.string.config_mapillary_min_zoom_key);
+        setListPreferenceSummary(R.string.config_nameCap_key, false);
         setTitle();
     }
 

--- a/src/main/java/de/blau/android/prefs/Preferences.java
+++ b/src/main/java/de/blau/android/prefs/Preferences.java
@@ -108,6 +108,7 @@ public class Preferences {
     private final int         beepVolume;
     private final int         maxOffsetDistance;
     private final Set<String> enabledValidations;
+    private final int         autoNameCap;
 
     private static final String DEFAULT_MAP_PROFILE = "Color Round Nodes";
 
@@ -276,6 +277,23 @@ public class Preferences {
 
         enabledValidations = prefs.getStringSet(r.getString(R.string.config_enabledValidations_key),
                 new HashSet<>(Arrays.asList(r.getStringArray(R.array.validations_values))));
+        autoNameCap = getIntFromStringPref(R.string.config_nameCap_key, 1);
+    }
+
+    /**
+     * Get an integer valued preference from a string pref
+     * 
+     * @param keyResId the res id
+     * @param def default value
+     * @return the stored preference or the default if none found
+     */
+    private int getIntFromStringPref(int keyResId, int def) {
+        try {
+            String temp = prefs.getString(r.getString(keyResId), Integer.toString(def));
+            return Integer.parseInt(temp);
+        } catch (ClassCastException | NumberFormatException e) {
+            return def;
+        }
     }
 
     /**
@@ -1450,6 +1468,17 @@ public class Preferences {
             enableWaySnap(true);
         }
         return prefs.getBoolean(key, false);
+    }
+
+    /**
+     * Get the name input type for caps
+     * 
+     * The value is shifted so that in can directly be used by setInputType
+     * 
+     * @return the flag to set
+     */
+    public int getAutoNameCap() {
+        return autoNameCap << 13;
     }
 
     /**

--- a/src/main/java/de/blau/android/propertyeditor/CustomPreset.java
+++ b/src/main/java/de/blau/android/propertyeditor/CustomPreset.java
@@ -1,7 +1,6 @@
 package de.blau.android.propertyeditor;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -88,7 +87,7 @@ public final class CustomPreset {
                             }
                         } else {
                             PresetField field = item.getField(key).copy();
-                            if (notEmpty && !isLikeAName(key)) {
+                            if (notEmpty && !Tags.isLikeAName(key)) {
                                 field.setDefaultValue(value);
                             }
                             field.setOptional(false);
@@ -101,27 +100,5 @@ public final class CustomPreset {
                         caller.presetSelectedListener.onPresetSelected(customItem);
                     }
                 }).show();
-    }
-
-    /**
-     * Check if a key in general can be assumed to have a different value for each occurrence
-     * 
-     * We also assume that key: are variants that follow the same rule
-     * 
-     * @param key the key to check
-     * @return true if the key has name-like semantics
-     */
-    private static boolean isLikeAName(@NonNull String key) {
-        List<String> nameLikeKeys = new ArrayList<>(Tags.I18N_NAME_KEYS);
-        nameLikeKeys.add(Tags.KEY_ADDR_HOUSENUMBER);
-        nameLikeKeys.add(Tags.KEY_ADDR_HOUSENAME);
-        nameLikeKeys.add(Tags.KEY_ADDR_UNIT);
-        nameLikeKeys.add(Tags.KEY_REF);
-        for (String k : nameLikeKeys) {
-            if (k.equals(key) || key.startsWith(k + ":")) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/src/main/java/de/blau/android/util/LocaleUtils.java
+++ b/src/main/java/de/blau/android/util/LocaleUtils.java
@@ -1,11 +1,36 @@
 package de.blau.android.util;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Locale;
+import java.util.Set;
 
 import android.os.Build;
 import androidx.annotation.NonNull;
 
 public final class LocaleUtils {
+
+    // list of languages that use Latin script from https://gist.github.com/phil-brown/8056700
+    private static Set<String> latin = new HashSet<>(Arrays.asList("aa", "ace", "ach", "ada", "af", "agq", "ak", "ale", "amo", "an", "arn", "arp", "arw", "asa",
+            "ast", "ay", "az", "bal", "ban", "bas", "bbc", "bem", "bez", "bi", "bik", "bin", "bku", "bla", "bm", "bqv", "br", "bs", "buc", "bug", "bya", "ca",
+            "cad", "car", "cay", "cch", "ceb", "cgg", "ch", "chk", "chn", "cho", "chp", "chy", "co", "cpe", "cs", "csb", "cy", "da", "dak", "dav", "de", "del",
+            "den", "dgr", "din", "dje", "dsb", "dua", "dyu", "ebu", "ee", "efi", "eka", "en", "eo", "es", "et", "eu", "ewo", "fan", "ff", "fi", "fil", "fiu",
+            "fj", "fo", "fon", "fr", "frr", "frs", "fur", "fy", "ga", "gaa", "gag", "gay", "gcr", "gd", "gil", "gl", "gn", "gor", "grb", "gsw", "guz", "gv",
+            "gwi", "ha", "hai", "haw", "hil", "hmn", "hnn", "ho", "hop", "hr", "hsb", "ht", "hu", "hup", "hz", "ia", "iba", "ibb", "id", "ig", "ii", "ik",
+            "ilo", "is", "it", "iu", "jmc", "jv", "kab", "kac", "kaj", "kam", "kcg", "kde", "kea", "kfo", "kg", "kha", "khq", "ki", "kj", "kl", "kln", "kmb",
+            "kos", "kpe", "kr", "kri", "krl", "ksb", "ksf", "ksh", "ku", "kut", "kw", "ky", "la", "lag", "lam", "lb", "lg", "li", "ln", "lol", "loz", "lt",
+            "lu", "lua", "lui", "lun", "luo", "lut", "luy", "lv", "mad", "mak", "man", "mas", "mdh", "mdr", "men", "mer", "mfe", "mg", "mgh", "mh", "mi", "mic",
+            "min", "moh", "mos", "ms", "mt", "mua", "mus", "mwl", "na", "nap", "naq", "nb", "nd", "nds", "ng", "nia", "niu", "nl", "nmg", "nn", "nr", "nso",
+            "nus", "nv", "ny", "nym", "nyn", "nyo", "nzi", "oc", "om", "osa", "pag", "pam", "pap", "pau", "pl", "pon", "prg", "pt", "qu", "raj", "rap", "rar",
+            "rcf", "rej", "rm", "rn", "ro", "rof", "rup", "rw", "rwk", "sad", "saf", "saq", "sas", "sat", "sbp", "sc", "scn", "sco", "se", "see", "seh", "ses",
+            "sg", "sga", "sid", "sk", "sl", "sm", "sma", "smi", "smj", "smn", "sms", "sn", "snk", "so", "son", "sq", "sr", "srn", "srr", "ss", "ssy", "st",
+            "su", "suk", "sus", "sv", "sw", "swb", "swc", "tbw", "tem", "teo", "ter", "tet", "tiv", "tk", "tkl", "tli", "tmh", "tn", "to", "tog", "tpi", "tr",
+            "tru", "trv", "ts", "tsg", "tsi", "tum", "tvl", "twq", "ty", "tzm", "udm", "uli", "umb", "uz", "ve", "vi", "vo", "vot", "vun", "wa", "wae", "wak",
+            "war", "was", "wo", "xh", "xog", "yao", "yap", "yav", "yo", "za", "zap", "zu", "zun", "zza", "sbp", "sc", "scn", "sco", "se", "see", "seh", "ses",
+            "sg", "sga", "sid", "sk", "sl", "sm", "sma", "smi", "smj", "smn", "sms", "sn", "snk", "so", "son", "sq", "sr", "srn", "srr", "ss", "ssy", "st",
+            "su", "suk", "sus", "sv", "sw", "swb", "swc", "tbw", "tem", "teo", "ter", "tet", "tiv", "tk", "tkl", "tli", "tmh", "tn", "to", "tog", "tpi", "tr",
+            "tru", "trv", "ts", "tsg", "tsi", "tum", "tvl", "twq", "ty", "tzm", "udm", "uli", "umb", "uz", "ve", "vi", "vo", "vot", "vun", "wa", "wae", "wak",
+            "war", "was", "wo", "xh", "xog", "yao", "yap", "yav", "yo", "za", "zap", "zu", "zun"));
 
     /**
      * Private constructor to prevent instantiation
@@ -135,5 +160,15 @@ public final class LocaleUtils {
             return Locale.forLanguageTag(languageTag);
         }
         return forLanguageTagCompat(languageTag);
+    }
+
+    /**
+     * Determine if the Locale uses Latin script
+     * 
+     * @param locale the Locale to check
+     * @return true if the Locale uses Latin script and we are running at least on SDK 21 / Lollipop
+     */
+    public static boolean usesLatinScript(@NonNull Locale locale) {
+        return latin.contains(locale.getLanguage());
     }
 }

--- a/src/main/res/values/prefkeys.xml
+++ b/src/main/res/values/prefkeys.xml
@@ -88,6 +88,7 @@
     <string name="config_preferRemovableStorage_key">preferRemovableStorage</string>
     <string name="config_disableTranslations_key">disableTranslations</string>
     <string name="config_savedLocale_key">savedLocale</string>
+    <string name="config_nameCap_key">nameCap</string>
     
 	<!-- Preference keys used in the pref editor(s) int prefs -->
 	<string name="config_maxInlineValues_key">maxInlineValuesInt</string>

--- a/src/main/res/values/string-arrays.xml
+++ b/src/main/res/values/string-arrays.xml
@@ -158,4 +158,15 @@
         <item>com.flavionet.android.camera.pro</item>
         <item>ch.poole.android.dummycameraapp</item>
     </string-array>
+        <!-- automatic name tag capitalization -->
+    <string-array translatable="true" name="name_cap_entries">
+        <item>No capitalization</item>
+        <item>Word capitalization</item>
+        <item>Sentence capitalization</item>
+    </string-array>
+    <string-array translatable="false" name="name_cap_values">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
  </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1088,7 +1088,9 @@ avoided by using an offline data source.</string>
     <string name="config_mapillary_min_zoom_title">Minimum zoom for Mapillary</string>
     <string name="config_mapillary_min_zoom_summary">Minimum zoom level required before Mapillary data is displayed.</string>
     <string name="config_mapillary_min_zoom_current">%1$d</string>
-    
+    <string name="config_nameCap_summary">Automatic capitalization of name tags on input</string>
+    <string name="config_nameCap_title">Name capitalization</string>
+            
     <!-- Data and Editing Settings -->
     <string name="config_category_editing">Data and edit settings</string>
     <string name="config_category_editing_summary">Auto-download, saving and notification settings.</string>

--- a/src/main/res/xml-v19/advancedpreferences.xml
+++ b/src/main/res/xml-v19/advancedpreferences.xml
@@ -193,6 +193,13 @@
             app:spt_increment="1"
             app:spt_currentValueText="@string/config_mapillary_min_zoom_current"
             app:spt_setWrapSelectorWheel="false" />
+        <androidx.preference.ListPreference
+            android:defaultValue="1"
+            android:entries="@array/name_cap_entries"
+            android:entryValues="@array/name_cap_values"
+            android:key="@string/config_nameCap_key"
+            android:summary="@string/config_nameCap_summary"
+            android:title="@string/config_nameCap_title" />
     </androidx.preference.PreferenceScreen>
     <androidx.preference.PreferenceScreen
         android:key="config_category_editing"

--- a/src/main/res/xml-v24/advancedpreferences.xml
+++ b/src/main/res/xml-v24/advancedpreferences.xml
@@ -193,6 +193,13 @@
             app:spt_increment="1"
             app:spt_currentValueText="@string/config_mapillary_min_zoom_current"
             app:spt_setWrapSelectorWheel="false" />
+        <androidx.preference.ListPreference
+            android:defaultValue="1"
+            android:entries="@array/name_cap_entries"
+            android:entryValues="@array/name_cap_values"
+            android:key="@string/config_nameCap_key"
+            android:summary="@string/config_nameCap_summary"
+            android:title="@string/config_nameCap_title" />
     </androidx.preference.PreferenceScreen>
     <androidx.preference.PreferenceScreen
         android:key="config_category_editing"

--- a/src/main/res/xml/advancedpreferences.xml
+++ b/src/main/res/xml/advancedpreferences.xml
@@ -193,6 +193,13 @@
             app:spt_increment="1"
             app:spt_currentValueText="@string/config_mapillary_min_zoom_current"
             app:spt_setWrapSelectorWheel="false" />
+        <androidx.preference.ListPreference
+            android:defaultValue="1"
+            android:entries="@array/name_cap_entries"
+            android:entryValues="@array/name_cap_values"
+            android:key="@string/config_nameCap_key"
+            android:summary="@string/config_nameCap_summary"
+            android:title="@string/config_nameCap_title" />
     </androidx.preference.PreferenceScreen>
     <androidx.preference.PreferenceScreen
         android:key="config_category_editing"

--- a/src/test/java/de/blau/android/osm/TagsTest.java
+++ b/src/test/java/de/blau/android/osm/TagsTest.java
@@ -1,0 +1,20 @@
+package de.blau.android.osm;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class TagsTest {
+
+    /**
+     * Test that name keys are recognized
+     */
+    @Test
+    public void nameKeys() {
+        assertTrue(Tags.isLikeAName(Tags.KEY_NAME));
+        assertTrue(Tags.isLikeAName(Tags.KEY_ADDR_STREET));
+        assertTrue(Tags.isLikeAName(Tags.KEY_NAME + ":test"));
+        assertFalse(Tags.isLikeAName(Tags.KEY_ACCESS));
+    }
+}

--- a/src/test/java/de/blau/android/util/LocaleUtilsTest.java
+++ b/src/test/java/de/blau/android/util/LocaleUtilsTest.java
@@ -1,6 +1,8 @@
 package de.blau.android.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Locale;
 
@@ -37,13 +39,24 @@ public class LocaleUtilsTest {
         assertEquals(java, locale);
         locale = LocaleUtils.forLanguageTagCompat("de-CH");
         assertEquals(java, locale);
-        
+
         java = Locale.forLanguageTag("");
         locale = LocaleUtils.forLanguageTag("");
         assertEquals(java, locale);
-        
+
         java = Locale.forLanguageTag("de");
         locale = LocaleUtils.forLanguageTag("de");
         assertEquals(java, locale);
+    }
+
+    /**
+     * Check for latin script use
+     */
+    @Test
+    public void latinScript() {
+        Locale locale = Locale.forLanguageTag("de-CH");
+        assertTrue(LocaleUtils.usesLatinScript(locale));
+        locale = Locale.forLanguageTag("cn");
+        assertFalse(LocaleUtils.usesLatinScript(locale));
     }
 }


### PR DESCRIPTION
This adds support for automatic capitalization of name tags. The
preference is switchable between non, all words capitalized and sentence
capitalized. The default is all words capitalized.

This is only active if the current script is Latin.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/1484