### PR TITLE
Add support for offseting ways when rendering

### DIFF
--- a/documentation/docs/tutorials/data_styling.md
+++ b/documentation/docs/tutorials/data_styling.md
@@ -1,5 +1,5 @@
 ## Vespucci Data Styling
-_Documentation for Vespucci 16.0 Style file format version 0.3.0_
+_Documentation for Vespucci 16.0 Style file format version 0.3.1_
 
 The data styling configuration is not a work of art, it was created ad hoc (in other words it is an awful hack) to allow slightly more flexible configuration of the rendering.
 
@@ -40,6 +40,7 @@ Node styling is limited to the __labelKey__ and __iconPath__ attributes.
 |                           | cap            |         | One of "BUTT", "ROUND", "SQUARE"
 |                           | join           |         | One of "BEVEL", "MITER", "ROUND"
 |                           | strokeWidth    |         | A float value for the width of the lines, 0 draws a one pixel width line, ignored if updateWidth is true
+|                           | offset         |         | Offset in units of the current stroke width
 |                           | typefacestyle  |         |
 |                           | textsize       |         |
 |                           | shadow         |         |

--- a/src/androidTest/java/de/blau/android/util/UploadCheckerTest.java
+++ b/src/androidTest/java/de/blau/android/util/UploadCheckerTest.java
@@ -12,13 +12,16 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import android.Manifest;
 import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.rule.GrantPermissionRule;
 import androidx.test.uiautomator.UiDevice;
 import androidx.work.ListenableWorker.Result;
 import androidx.work.testing.TestWorkerBuilder;
@@ -32,6 +35,10 @@ public class UploadCheckerTest {
     private Context  context;
     private Executor executor;
     private UiDevice device;
+    
+    /** this is needed for writing coverage information */
+    @Rule
+    public GrantPermissionRule mRuntimePermissionRule = GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE);
 
     /**
      * Pre-test setup

--- a/src/main/assets/styles/Color-round-no-mp.xml
+++ b/src/main/assets/styles/Color-round-no-mp.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' ?>
-<profile name="Color Round Nodes No Multipolygons" format="0.3.0">
+<profile name="Color Round Nodes No Multipolygons" format="0.3.1">
     <!-- Assorted config -->
     <config type="min_handle_length" length="200.0" />
     <config type="icon_zoom_limit" zoom="15" />
@@ -73,7 +73,7 @@
     		<interval length="3.0" />
     	</dash>
     </feature>
-    <feature type="way" tags="landuse" area="true" updateWidth="true" widthFactor="2.0" color="8871BE80" style="STROKE" cap="BUTT" join="MITER" pathPattern="border_right">
+    <feature type="way" tags="landuse" area="true" updateWidth="true" widthFactor="2.0" color="8871BE80" style="STROKE" cap="BUTT" join="MITER" offset="0.50">
         <feature type="way" tags="landuse=construction" color="88996633" style="FILL_AND_STROKE" pathPattern="" />
         <feature type="way" tags="landuse=residential" minVisibleZoom="10" color="88888888" />
         <feature type="way" tags="landuse=quarry" color="88d8a2a2" />
@@ -86,11 +86,11 @@
     
     <feature type="way" tags="leisure=pitch" updateWidth="true" widthFactor="1.0" color="8839AC39" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
     <feature type="way" tags="leisure=swimming_pool" updateWidth="true" widthFactor="1.0" color="880000ff" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />    
-    <feature type="way" tags="leisure=playground" area="true" updateWidth="true" widthFactor="0.8" color="88f4a460" style="STROKE" cap="BUTT" join="MITER" pathPattern="border_right" />
+    <feature type="way" tags="leisure=playground" area="true" updateWidth="true" widthFactor="0.8" color="88f4a460" style="STROKE" cap="BUTT" join="MITER" offset="0.50"/>
     <feature type="way" tags="leisure=garden" updateWidth="true" widthFactor="1.0" color="882d6e3a" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
     
     <feature type="way" tags="natural" updateWidth="true" widthFactor="0.5" color="ff71BE80" style="STROKE" cap="BUTT" join="MITER"> 
-        <feature type="way" tags="natural" closed="true" area="true" pathPattern="border_right" >
+        <feature type="way" tags="natural" closed="true" area="true" offset="0.50" >
             <feature type="way" tags="natural=water" widthFactor="1.0" minVisibleZoom="10" color="ff0000ff" />
         </feature>
         <feature type="way" tags="natural=water" widthFactor="1.0" minVisibleZoom="10" color="ff0000ff" />
@@ -205,6 +205,9 @@
         </dash>
     </feature>
     <feature type="residential_casing" updateWidth="true" widthFactor="1.1" color="FFFFFFFF" style="STROKE" cap="BUTT" join="MITER" />
+    <feature type="residential_sidewalk_right_casing" updateWidth="true" widthFactor="0.7" color="FFFF0000" style="STROKE" cap="BUTT" join="MITER" offset="0.50"/>
+    <feature type="residential_sidewalk_left_casing" updateWidth="true" widthFactor="0.7" color="FFFF0000" style="STROKE" cap="BUTT" join="MITER" offset="-0.50"/>
+    <feature type="residential_sidewalk_both_casing" updateWidth="true" widthFactor="1.2" color="FFFF0000" style="STROKE" cap="BUTT" join="MITER" />
     <feature type="residential_bridge_casing" updateWidth="true" widthFactor="1.1" color="FFFFFFFF" style="STROKE" cap="BUTT" join="MITER">
         <dash phase="1.0">
             <interval length="2.0" />
@@ -353,6 +356,9 @@
         </feature>
         <feature type="way" tags="highway=residential" widthFactor="0.9" color="ffCCCCCC" casingStyle="residential_casing" >
             <feature type="way" tags="bridge=yes" casingStyle="residential_bridge_casing" />
+            <feature type="way" tags="sidewalk=right" casingStyle="residential_sidewalk_right_casing" />
+            <feature type="way" tags="sidewalk=left" casingStyle="residential_sidewalk_left_casing" />
+            <feature type="way" tags="sidewalk=both" casingStyle="residential_sidewalk_both_casing" />
         </feature>
         <feature type="way" tags="highway=living_street" widthFactor="0.9" color="ffff4500" />
         <feature type="way" tags="highway=service" widthFactor="0.7" color="ffCCCCCC" />

--- a/src/main/assets/styles/Color-round.xml
+++ b/src/main/assets/styles/Color-round.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' ?>
-<profile name="Color Round Nodes" format="0.3.0">
+<profile name="Color Round Nodes" format="0.3.1">
     <!-- Assorted config -->
     <config type="min_handle_length" length="200.0" />
     <config type="icon_zoom_limit" zoom="15" />
@@ -73,7 +73,7 @@
     		<interval length="3.0" />
     	</dash>
     </feature>
-    <feature type="way" tags="landuse" area="true" updateWidth="true" widthFactor="2.0" color="8871BE80" style="STROKE" cap="BUTT" join="MITER" pathPattern="border_right">
+    <feature type="way" tags="landuse" area="true" updateWidth="true" widthFactor="2.0" color="8871BE80" style="STROKE" cap="BUTT" join="MITER" offset="0.50">
         <feature type="way" tags="landuse=construction" color="88996633" style="FILL_AND_STROKE" pathPattern="" />
         <feature type="way" tags="landuse=residential" minVisibleZoom="10" color="88888888" />
         <feature type="way" tags="landuse=quarry" color="88d8a2a2" />
@@ -86,11 +86,11 @@
     
     <feature type="way" tags="leisure=pitch" updateWidth="true" widthFactor="1.0" color="8839AC39" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
     <feature type="way" tags="leisure=swimming_pool" updateWidth="true" widthFactor="1.0" color="880000ff" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />    
-    <feature type="way" tags="leisure=playground" area="true" updateWidth="true" widthFactor="0.8" color="88f4a460" style="STROKE" cap="BUTT" join="MITER" pathPattern="border_right" />
+    <feature type="way" tags="leisure=playground" area="true" updateWidth="true" widthFactor="0.8" color="88f4a460" style="STROKE" cap="BUTT" join="MITER" offset="0.50"/>
     <feature type="way" tags="leisure=garden" updateWidth="true" widthFactor="1.0" color="882d6e3a" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
     
     <feature type="way" tags="natural" updateWidth="true" widthFactor="0.5" color="ff71BE80" style="STROKE" cap="BUTT" join="MITER"> 
-        <feature type="way" tags="natural" closed="true" area="true" pathPattern="border_right" >
+        <feature type="way" tags="natural" closed="true" area="true" offset="0.50" >
             <feature type="way" tags="natural=water" widthFactor="1.0" minVisibleZoom="10" color="ff0000ff" />
         </feature>
         <feature type="way" tags="natural=water" widthFactor="1.0" minVisibleZoom="10" color="ff0000ff" />
@@ -205,6 +205,9 @@
         </dash>
     </feature>
     <feature type="residential_casing" updateWidth="true" widthFactor="1.1" color="FFFFFFFF" style="STROKE" cap="BUTT" join="MITER" />
+    <feature type="residential_sidewalk_right_casing" updateWidth="true" widthFactor="0.7" color="FFFF0000" style="STROKE" cap="BUTT" join="MITER" offset="0.50"/>
+    <feature type="residential_sidewalk_left_casing" updateWidth="true" widthFactor="0.7" color="FFFF0000" style="STROKE" cap="BUTT" join="MITER" offset="-0.50"/>
+    <feature type="residential_sidewalk_both_casing" updateWidth="true" widthFactor="1.2" color="FFFF0000" style="STROKE" cap="BUTT" join="MITER" />
     <feature type="residential_bridge_casing" updateWidth="true" widthFactor="1.1" color="FFFFFFFF" style="STROKE" cap="BUTT" join="MITER">
         <dash phase="1.0">
             <interval length="2.0" />
@@ -353,6 +356,9 @@
         </feature>
         <feature type="way" tags="highway=residential" widthFactor="0.9" color="ffCCCCCC" casingStyle="residential_casing" >
             <feature type="way" tags="bridge=yes" casingStyle="residential_bridge_casing" />
+            <feature type="way" tags="sidewalk=right" casingStyle="residential_sidewalk_right_casing" />
+            <feature type="way" tags="sidewalk=left" casingStyle="residential_sidewalk_left_casing" />
+            <feature type="way" tags="sidewalk=both" casingStyle="residential_sidewalk_both_casing" />
         </feature>
         <feature type="way" tags="highway=living_street" widthFactor="0.9" color="ffff4500" />
         <feature type="way" tags="highway=service" widthFactor="0.7" color="ffCCCCCC" />
@@ -397,7 +403,7 @@
     <!-- relations (only multipolygons currently) -->
     <feature type="relation" updateWidth="true" widthFactor="1.0" color="ff222222" style="STROKE" cap="BUTT" join="MITER" />
     <feature type="relation" tags="boundary" dontrender="true" />
-    <feature type="relation" tags="type=multipolygon" updateWidth="true" widthFactor="0.8" color="88222222" style="STROKE" cap="BUTT" join="MITER" pathPattern="border_right">
+    <feature type="relation" tags="type=multipolygon" updateWidth="true" widthFactor="0.8" color="88222222" style="STROKE" cap="BUTT" join="MITER" offset="0.50">
         <feature type="relation" tags="building" widthFactor="1.0" color="ffcc9999"/>
         <feature type="relation" tags="leisure=playground" widthFactor="0.8" color="88f4a460" style="FILL_AND_STROKE" />
         <feature type="relation" tags="leisure=pitch" updateWidth="true" widthFactor="1.0" color="8839AC39" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
@@ -410,7 +416,7 @@
             <feature type="relation" tags="natural=coastline" widthFactor="2.0" minVisibleZoom="10" color="ff71BE80" pathPattern="triangle_left" />
             <feature type="relation" tags="natural=tree_row" widthFactor="2.0" color="ff4b7a54" cap="ROUND" />
         </feature>
-        <feature type="relation" tags="landuse" updateWidth="true" widthFactor="2.0" color="8871BE80" style="STROKE" cap="BUTT" join="BEVEL" pathPattern="border_right" >
+        <feature type="relation" tags="landuse" updateWidth="true" widthFactor="2.0" color="8871BE80" style="STROKE" cap="BUTT" join="BEVEL" offset="0.50">
             <feature type="relation" tags="landuse=construction" color="88996633" />
             <feature type="relation" tags="landuse=residential" minVisibleZoom="10" color="88888888" />
             <feature type="relation" tags="landuse=quarry" color="88d8a2a2" />

--- a/src/main/assets/styles/Pen-round.xml
+++ b/src/main/assets/styles/Pen-round.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' ?>
-<profile name="Pen Round Nodes" format="0.3.0">
+<profile name="Pen Round Nodes" format="0.3.1">
     <!-- Assorted config -->
     <config type="min_handle_length" length="200.0" />
     <config type="icon_zoom_limit" zoom="15" />
@@ -73,7 +73,7 @@
     		<interval length="3.0" />
     	</dash>
     </feature>
-    <feature type="way" tags="landuse" area="true" updateWidth="true" widthFactor="2.0" color="8871BE80" style="STROKE" cap="BUTT" join="MITER" pathPattern="border_right">
+    <feature type="way" tags="landuse" area="true" updateWidth="true" widthFactor="2.0" color="8871BE80" style="STROKE" cap="BUTT" join="MITER" offset="0.50">
         <feature type="way" tags="landuse=construction" color="88996633" style="FILL_AND_STROKE" pathPattern="" />
         <feature type="way" tags="landuse=residential" minVisibleZoom="10" color="88888888" />
         <feature type="way" tags="landuse=quarry" color="88d8a2a2" />
@@ -86,11 +86,11 @@
     
     <feature type="way" tags="leisure=pitch" updateWidth="true" widthFactor="1.0" color="8839AC39" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
     <feature type="way" tags="leisure=swimming_pool" updateWidth="true" widthFactor="1.0" color="880000ff" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />    
-    <feature type="way" tags="leisure=playground" area="true" updateWidth="true" widthFactor="0.8" color="88f4a460" style="STROKE" cap="BUTT" join="MITER" pathPattern="border_right" />
+    <feature type="way" tags="leisure=playground" area="true" updateWidth="true" widthFactor="0.8" color="88f4a460" style="STROKE" cap="BUTT" join="MITER" offset="0.50"/>
     <feature type="way" tags="leisure=garden" updateWidth="true" widthFactor="1.0" color="882d6e3a" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
     
     <feature type="way" tags="natural" updateWidth="true" widthFactor="0.5" color="ff71BE80" style="STROKE" cap="BUTT" join="MITER"> 
-        <feature type="way" tags="natural" closed="true" area="true" pathPattern="border_right" >
+        <feature type="way" tags="natural" closed="true" area="true" offset="0.50" >
             <feature type="way" tags="natural=water" widthFactor="1.0" minVisibleZoom="10" color="ff0000ff" />
         </feature>
         <feature type="way" tags="natural=water" widthFactor="1.0" minVisibleZoom="10" color="ff0000ff" />
@@ -205,6 +205,9 @@
         </dash>
     </feature>
     <feature type="residential_casing" updateWidth="true" widthFactor="1.1" color="FFFFFFFF" style="STROKE" cap="BUTT" join="MITER" />
+    <feature type="residential_sidewalk_right_casing" updateWidth="true" widthFactor="0.7" color="FFFF0000" style="STROKE" cap="BUTT" join="MITER" offset="0.50"/>
+    <feature type="residential_sidewalk_left_casing" updateWidth="true" widthFactor="0.7" color="FFFF0000" style="STROKE" cap="BUTT" join="MITER" offset="-0.50"/>
+    <feature type="residential_sidewalk_both_casing" updateWidth="true" widthFactor="1.2" color="FFFF0000" style="STROKE" cap="BUTT" join="MITER" />
     <feature type="residential_bridge_casing" updateWidth="true" widthFactor="1.1" color="FFFFFFFF" style="STROKE" cap="BUTT" join="MITER">
         <dash phase="1.0">
             <interval length="2.0" />
@@ -353,6 +356,9 @@
         </feature>
         <feature type="way" tags="highway=residential" widthFactor="0.9" color="ffCCCCCC" casingStyle="residential_casing" >
             <feature type="way" tags="bridge=yes" casingStyle="residential_bridge_casing" />
+            <feature type="way" tags="sidewalk=right" casingStyle="residential_sidewalk_right_casing" />
+            <feature type="way" tags="sidewalk=left" casingStyle="residential_sidewalk_left_casing" />
+            <feature type="way" tags="sidewalk=both" casingStyle="residential_sidewalk_both_casing" />
         </feature>
         <feature type="way" tags="highway=living_street" widthFactor="0.9" color="ffff4500" />
         <feature type="way" tags="highway=service" widthFactor="0.7" color="ffCCCCCC" />
@@ -397,7 +403,7 @@
     <!-- relations (only multipolygons currently) -->
     <feature type="relation" updateWidth="true" widthFactor="1.0" color="ff222222" style="STROKE" cap="BUTT" join="MITER" />
     <feature type="relation" tags="boundary" dontrender="true" />
-    <feature type="relation" tags="type=multipolygon" updateWidth="true" widthFactor="0.8" color="88222222" style="STROKE" cap="BUTT" join="MITER" pathPattern="border_right">
+    <feature type="relation" tags="type=multipolygon" updateWidth="true" widthFactor="0.8" color="88222222" style="STROKE" cap="BUTT" join="MITER" offset="0.50">
         <feature type="relation" tags="building" widthFactor="1.0" color="ffcc9999"/>
         <feature type="relation" tags="leisure=playground" widthFactor="0.8" color="88f4a460" style="FILL_AND_STROKE" />
         <feature type="relation" tags="leisure=pitch" updateWidth="true" widthFactor="1.0" color="8839AC39" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
@@ -410,7 +416,7 @@
             <feature type="relation" tags="natural=coastline" widthFactor="2.0" minVisibleZoom="10" color="ff71BE80" pathPattern="triangle_left" />
             <feature type="relation" tags="natural=tree_row" widthFactor="2.0" color="ff4b7a54" cap="ROUND" />
         </feature>
-        <feature type="relation" tags="landuse" updateWidth="true" widthFactor="2.0" color="8871BE80" style="STROKE" cap="BUTT" join="BEVEL" pathPattern="border_right" >
+        <feature type="relation" tags="landuse" updateWidth="true" widthFactor="2.0" color="8871BE80" style="STROKE" cap="BUTT" join="BEVEL" offset="0.50">
             <feature type="relation" tags="landuse=construction" color="88996633" />
             <feature type="relation" tags="landuse=residential" minVisibleZoom="10" color="88888888" />
             <feature type="relation" tags="landuse=quarry" color="88d8a2a2" />

--- a/src/main/java/de/blau/android/Map.java
+++ b/src/main/java/de/blau/android/Map.java
@@ -95,7 +95,7 @@ public class Map extends View implements IMapView {
     /** half the width/height of a node icon in px */
     private final int iconRadius;
 
-    private final ArrayList<BoundingBox> boundingBoxes = new ArrayList<>();
+    private final List<BoundingBox> boundingBoxes = new ArrayList<>();
 
     private Preferences prefs;
 
@@ -117,6 +117,8 @@ public class Map extends View implements IMapView {
      * The visible area in decimal-degree (WGS84) -space.
      */
     private ViewBox myViewBox;
+
+    private ViewBox clipBox = new ViewBox(); // used for clipping
 
     private StorageDelegator delegator;
 
@@ -559,6 +561,9 @@ public class Map extends View implements IMapView {
 
         zoomLevel = calcZoomLevel(canvas);
 
+        clipBox.set(myViewBox);
+        clipBox.scale(1.1);
+
         final Logic logic = App.getLogic();
         final Mode tmpDrawingEditMode = logic.getMode();
         tmpLocked = logic.isLocked();
@@ -969,14 +974,14 @@ public class Map extends View implements IMapView {
                     nextNode = nodes.get(i + 1);
                     nextNodeLat = nextNode.getLat();
                     nextNodeLon = nextNode.getLon();
-                    nextIntersects = box.isIntersectionPossible(nextNodeLon, nextNodeLat, nodeLon, nodeLat);
+                    nextIntersects = clipBox.isIntersectionPossible(nextNodeLon, nextNodeLat, nodeLon, nodeLat);
                 } else {
                     nextNode = null;
                 }
                 x = -Float.MAX_VALUE; // misuse this as a flag
                 if (!interrupted && prevNode != null) {
                     if (thisIntersects || nextIntersects || (!(nextNode != null && lastDrawnNode != null)
-                            || box.isIntersectionPossible(nextNodeLon, nextNodeLat, lastDrawnNodeLon, lastDrawnNodeLat))) {
+                            || clipBox.isIntersectionPossible(nextNodeLon, nextNodeLat, lastDrawnNodeLon, lastDrawnNodeLat))) {
                         x = GeoMath.lonE7ToX(w, box, nodeLon);
                         y = GeoMath.latE7ToY(h, w, box, nodeLat);
                         if (prevX == -Float.MAX_VALUE) { // last segment didn't intersect

--- a/src/main/java/de/blau/android/resources/DataStyle.java
+++ b/src/main/java/de/blau/android/resources/DataStyle.java
@@ -167,6 +167,7 @@ public final class DataStyle extends DefaultHandler {
     private static final String LABEL_ZOOM_LIMIT_ATTR = "labelZoomLimit";
     private static final String ICON_PATH_ATTR        = "iconPath";
     private static final String PRESET                = "preset";
+    private static final String OFFSET_ATTR           = "offset";
 
     private static final int DEFAULT_MIN_VISIBLE_ZOOM = 15;
 
@@ -179,6 +180,7 @@ public final class DataStyle extends DefaultHandler {
         boolean                   updateWidth    = true;
         final Paint               paint;
         float                     widthFactor;
+        float                     offset         = 0f;
         DashPath                  dashPath       = null;
         private FontMetrics       fontMetrics    = null;
         private PathPattern       pathPattern    = null;
@@ -248,6 +250,7 @@ public final class DataStyle extends DefaultHandler {
             setArea(fp.isArea());
             dontrender = fp.dontrender;
             updateWidth = fp.updateWidth;
+            offset = fp.offset;
             widthFactor = fp.widthFactor;
             if (fp.dashPath != null) {
                 dashPath = new DashPath();
@@ -340,6 +343,24 @@ public final class DataStyle extends DefaultHandler {
          */
         public void setUpdateWidth(boolean update) {
             updateWidth = update;
+        }
+
+        /**
+         * Set an offset
+         * 
+         * @param f the value to set
+         */
+        public void setOffset(float f) {
+            offset = f;
+        }
+
+        /**
+         * Get the offset
+         * 
+         * @return the offset multiplied with the current stroke width
+         */
+        public float getOffset() {
+            return offset * paint.getStrokeWidth();
         }
 
         /**
@@ -651,6 +672,7 @@ public final class DataStyle extends DefaultHandler {
             if (!updateWidth()) {
                 s.attribute("", STROKEWIDTH_ATTR, Float.toString(getPaint().getStrokeWidth()));
             }
+            s.attribute("", OFFSET_ATTR, Float.toString(offset));
             Typeface tf = getPaint().getTypeface();
             if (tf != null) {
                 s.attribute("", TYPEFACESTYLE_ATTR, Integer.toString(tf.getStyle()));
@@ -1556,6 +1578,11 @@ public final class DataStyle extends DefaultHandler {
                             wayToleranceValue = strokeWidth;
                         }
                     }
+                }
+
+                String offsetString = atts.getValue(OFFSET_ATTR);
+                if (offsetString != null) {
+                    tempFeatureStyle.setOffset(Float.parseFloat(offsetString));
                 }
 
                 if (atts.getValue(TYPEFACESTYLE_ATTR) != null) {

--- a/src/test/java/de/blau/android/util/GeometryTest.java
+++ b/src/test/java/de/blau/android/util/GeometryTest.java
@@ -1,6 +1,7 @@
 package de.blau.android.util;
 
 import static de.blau.android.osm.DelegatorUtil.toE7;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -38,5 +39,23 @@ public class GeometryTest {
 
         Node outside2 = factory.createNodeWithNewId(toE7(51.5017543D), toE7(-0.1422112D));
         assertFalse(Geometry.isInside(nodes, outside2));
+    }
+
+    /**
+     * Test offseting a geometry, the input data is rather trivial
+     */
+    @Test
+    public void offsetTest() {
+        float[] input = { -5f, 5f, 5f, 5f };
+        Geometry.offset(input, input.length, false, 1);
+        assertArrayEquals(new float[] { -5f, 4f, 5f, 4f }, input, 0.000001f);
+
+        float[] input2 = { -5f, -5f, 5f, 5f };
+        Geometry.offset(input2, input2.length, false, 1);
+        assertArrayEquals(new float[] { -4.2928934f, -5.7071066f, 5.7071066f, 4.2928934f }, input2, 0.000001f);
+
+        float[] input3 = { -5f, 5f, 5f, 5f, 5f, 5f, 5f, -5f, 5f, -5f, -5f, -5f, -5f, -5f, -5f, 5f };
+        Geometry.offset(input3, input3.length, true, 1);
+        assertArrayEquals(new float[] { -4f, 4f, 4f, 4f, 4f, 4f, 4f, -4f, 4f, -4f, -4f, -4f, -4f, -4f, -4f, 4f }, input3, 0.000001f);
     }
 }


### PR DESCRIPTION
This adds support for offsetting way geometries for rendering purposes, a corresponding attribute in the style files and updates the styles to use this instead of a pattern.

Further this adds casing for residential roads if a sidewalk has been tagged, using the offset facility for indicating the side.

Fixes: https://github.com/MarcusWolschon/osmeditor4android/issues/1389