### PR TITLE
Fix CheckGoupDialogRow regression

### DIFF
--- a/src/main/java/de/blau/android/presets/PresetItem.java
+++ b/src/main/java/de/blau/android/presets/PresetItem.java
@@ -594,13 +594,29 @@ public class PresetItem extends PresetElement {
      * @return a PresetCheckField or null if not found
      */
     @Nullable
-    private PresetField getCheckFieldFromGroup(String key) {
+    private PresetField getCheckFieldFromGroup(@NonNull String key) {
         for (PresetField f : fields.values()) {
             if (f instanceof PresetCheckGroupField) {
                 PresetCheckField check = ((PresetCheckGroupField) f).getCheckField(key);
                 if (check != null) {
                     return check;
                 }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Return the PresetCheckGroupField for a key
+     * 
+     * @param key the key
+     * @return a PresetCheckGroupField or null if not found
+     */
+    @Nullable
+    public PresetCheckGroupField getCheckGroupField(@NonNull String key) {
+        for (PresetField f : fields.values()) {
+            if (f instanceof PresetCheckGroupField && ((PresetCheckGroupField) f).getCheckField(key) != null) {
+                return (PresetCheckGroupField) f;
             }
         }
         return null;

--- a/src/main/java/de/blau/android/propertyeditor/tagform/CheckGroupDialogRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/CheckGroupDialogRow.java
@@ -25,7 +25,6 @@ import ch.poole.android.checkbox.IndeterminateCheckBox.OnStateChangedListener;
 import de.blau.android.R;
 import de.blau.android.presets.PresetCheckField;
 import de.blau.android.presets.PresetCheckGroupField;
-import de.blau.android.presets.PresetField;
 import de.blau.android.presets.PresetItem;
 import de.blau.android.propertyeditor.tagform.TagFormFragment.EditableLayout;
 import de.blau.android.util.StringWithDescription;
@@ -83,11 +82,11 @@ public class CheckGroupDialogRow extends MultiselectDialogRow {
             String key = entry.getKey();
             String value = entry.getValue();
             if (field == null) {
-                PresetField f = preset.getField(key);
-                if (!(f instanceof PresetCheckGroupField)) {
-                    return;
+                field = preset.getCheckGroupField(key);
+                if (field == null) {
+                    Log.e(DEBUG_TAG, key + " isn't in a checkgroup");
+                    continue;
                 }
-                field = (PresetCheckGroupField) f;
             }
             PresetCheckField check = field.getCheckField(key);
             if (check != null && !"".equals(value)) {


### PR DESCRIPTION
This fixes a regression that caused the inline values of a CheckGroupDialogRow not to be displayed and adds a test for the specific situation.