### PR TITLE
Never automatically enable full screen mode on Android 11 and later

### DIFF
--- a/documentation/docs/help/en/17.1.0 Release notes.md
+++ b/documentation/docs/help/en/17.1.0 Release notes.md
@@ -1,6 +1,6 @@
-# Vespucci 17.1 BETA Highlights
+# Vespucci 17.1 Highlights
 
-2022-05-11
+2022-05-22
   
 ### Bing imagery no longer available for 3rd-party builds
 
@@ -9,6 +9,12 @@ Since we added Bing support over a decade ago, the API key to access the service
 With other words starting with version 17.1 Bing imagery will no longer be available for F-Droid users. If you have your own key, you can load it via the   the [_Tools_ menu](http://vespucci.io/help/en/Main%20map%20display/#available-actions), just as any other key. See the [default key file]( https://github.com/MarcusWolschon/osmeditor4android/blob/master/src/main/assets/keys2-default.txt) and [test key file](https://github.com/MarcusWolschon/osmeditor4android/blob/master/src/test/resources/keys2.txt) for the format and an example.
 
 It should be noted that the other claims by F-Droid in this context are incorrect, neither Mapillary support or Github access has ever been available in 3rd-party builds of Vespucci.
+
+### _Auto_ full screen mode on Android 11 and later behaviour change
+
+On Android 11 and later the default _Auto_ mode for the full screen mode preference will never enable full screen mode as navigation gestures provide a viable alternative and googles and subcontractors full screen support has become even less predictable than on earlier versions. 
+
+If you are using a device that previously had full screen mode automatically turned on and that is now disabled, you can force the use of full screen mode by setting the preference to _Force_.
 
 ### Improved GPX layer support
 

--- a/documentation/docs/help/en/Advanced preferences.md
+++ b/documentation/docs/help/en/Advanced preferences.md
@@ -38,7 +38,7 @@ If on the non-downloaded areas will be dimmed when the screen is locked. Default
 
 ### Fullscreen mode
 
-Configure the behaviour on devices with "soft" buttons. Default on Android 4.4 and later: _automatic_, 4.0 - 4.3: off, earlier versions: not available. You need to restart the app for changes to this setting to take effect.
+On devices without hardware buttons Vespucci can run in full screen mode, that means that "virtual" navigation buttons will be automatically hidden while the map is displayed, providing more space on the screen for the map. Depending on your device this may work well or not,  In _Auto_ mode we try to determine automatically if using full screen mode is sensible or not, setting it to _Force_ or _Never_ skips the automatic check and full screen mode will always be used or always not be used respectively. On devices running Android 11 or higher the _Auto_ mode will never turn full screen mode on as Androids gesture navigation provides a viable alternative to it. Default on Android 4.4 and later: _Auto_, 4.0 - 4.3: _Never_. You need to restart the app for changes to this setting to take effect.
 
 ### Map screen orientation
 

--- a/documentation/docs/help/en/Introduction.md
+++ b/documentation/docs/help/en/Introduction.md
@@ -283,7 +283,8 @@ The full description can be found here [Preferences](Preferences.md)
 
 #### Advanced preferences
 
-* Node icons. Default: on.
+* Full screen mode. On devices without hardware buttons Vespucci can run in full screen mode, that means that "virtual" navigation buttons will be automatically hidden while the map is displayed, providing more space on the screen for the map. Depending on your device this may work well or not,  In _Auto_ mode we try to determine automatically if using full screen mode is sensible or not, setting it to _Force_ or _Never_ skips the automatic check and full screen mode will always be used or always not be used respectively. On devices running Android 11 or higher the _Auto_ mode will never turn full screen mode on as Androids gesture navigation provides a viable alternative to it. Default: _Auto_.  
+* Node icons. Default: _on_.
 * Always show context menu. When turned on every selection process will show the context menu, turned off the menu is displayed only when no unambiguous selection can be determined. Default: off (used to be on).
 * Enable light theme. On modern devices this is turned on by default. While you can enable it for older Android versions the style is likely to be inconsistent. 
 

--- a/src/main/assets/help/en/17.1.0 Release notes.html
+++ b/src/main/assets/help/en/17.1.0 Release notes.html
@@ -5,12 +5,15 @@
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
 </head>
 <body>
-<h1>Vespucci 17.1 BETA Highlights</h1>
-<p>2022-05-11</p>
+<h1>Vespucci 17.1 Highlights</h1>
+<p>2022-05-22</p>
 <h3>Bing imagery no longer available for 3rd-party builds</h3>
 <p>Since we added Bing support over a decade ago, the API key to access the service has been included with the source code for third parties to use, most notably F-Droid as a courtesy. Starting with this version this is no longer the case as allowing access to a wide range of sources is considered an anti-feature by the operators of F-Droid, see <a href="https://f-droid.org/en/packages/de.blau.android/">Vespucci on F-Droid</a>.</p>
 <p>With other words starting with version 17.1 Bing imagery will no longer be available for F-Droid users. If you have your own key, you can load it via the   the <a href="http://vespucci.io/help/en/Main%20map%20display/#available-actions"><em>Tools</em> menu</a>, just as any other key. See the <a href="https://github.com/MarcusWolschon/osmeditor4android/blob/master/src/main/assets/keys2-default.txt">default key file</a> and <a href="https://github.com/MarcusWolschon/osmeditor4android/blob/master/src/test/resources/keys2.txt">test key file</a> for the format and an example.</p>
 <p>It should be noted that the other claims by F-Droid in this context are incorrect, neither Mapillary support or Github access has ever been available in 3rd-party builds of Vespucci.</p>
+<h3><em>Auto</em> full screen mode on Android 11 and later behaviour change</h3>
+<p>On Android 11 and later the default <em>Auto</em> mode for the full screen mode preference will never enable full screen mode as navigation gestures provide a viable alternative and googles and subcontractors full screen support has become even less predictable than on earlier versions.</p>
+<p>If you are using a device that previously had full screen mode automatically turned on and that is now disabled, you can force the use of full screen mode by setting the preference to <em>Force</em>.</p>
 <h3>Improved GPX layer support</h3>
 <p>The GPX layer has been reworked to allow multiple individual layers that can be created by either loading a GPX file from device or downloading from the OSM website. Some additional functionality has been implemented per layer, see <a href="http://vespucci.io/help/en/Main%20map%20display/#layer-control">layer control</a> and some more styling options have been added.</p>
 <h3>Preset improvements</h3>

--- a/src/main/assets/help/en/Advanced preferences.html
+++ b/src/main/assets/help/en/Advanced preferences.html
@@ -25,7 +25,7 @@
 <h3>Always dim non-downloaded areas</h3>
 <p>If on the non-downloaded areas will be dimmed when the screen is locked. Default: <em>off</em>.</p>
 <h3>Fullscreen mode</h3>
-<p>Configure the behaviour on devices with &quot;soft&quot; buttons. Default on Android 4.4 and later: <em>automatic</em>, 4.0 - 4.3: off, earlier versions: not available. You need to restart the app for changes to this setting to take effect.</p>
+<p>On devices without hardware buttons Vespucci can run in full screen mode, that means that &quot;virtual&quot; navigation buttons will be automatically hidden while the map is displayed, providing more space on the screen for the map. Depending on your device this may work well or not,  In <em>Auto</em> mode we try to determine automatically if using full screen mode is sensible or not, setting it to <em>Force</em> or <em>Never</em> skips the automatic check and full screen mode will always be used or always not be used respectively. On devices running Android 11 or higher the <em>Auto</em> mode will never turn full screen mode on as Androids gesture navigation provides a viable alternative to it. Default on Android 4.4 and later: <em>Auto</em>, 4.0 - 4.3: <em>Never</em>. You need to restart the app for changes to this setting to take effect.</p>
 <h3>Map screen orientation</h3>
 <p>If set to any other value than <em>Auto</em> Vespucci will try to override your device settings for screen rotation.</p>
 <h3>Show tolerance</h3>

--- a/src/main/assets/help/en/Introduction.html
+++ b/src/main/assets/help/en/Introduction.html
@@ -200,7 +200,8 @@
 <p>The full description can be found here <a href="Preferences.md">Preferences</a></p>
 <h4>Advanced preferences</h4>
 <ul>
-<li>Node icons. Default: on.</li>
+<li>Full screen mode. On devices without hardware buttons Vespucci can run in full screen mode, that means that &quot;virtual&quot; navigation buttons will be automatically hidden while the map is displayed, providing more space on the screen for the map. Depending on your device this may work well or not,  In <em>Auto</em> mode we try to determine automatically if using full screen mode is sensible or not, setting it to <em>Force</em> or <em>Never</em> skips the automatic check and full screen mode will always be used or always not be used respectively. On devices running Android 11 or higher the <em>Auto</em> mode will never turn full screen mode on as Androids gesture navigation provides a viable alternative to it. Default: <em>Auto</em>.</li>
+<li>Node icons. Default: <em>on</em>.</li>
 <li>Always show context menu. When turned on every selection process will show the context menu, turned off the menu is displayed only when no unambiguous selection can be determined. Default: off (used to be on).</li>
 <li>Enable light theme. On modern devices this is turned on by default. While you can enable it for older Android versions the style is likely to be inconsistent.</li>
 </ul>

--- a/src/main/java/de/blau/android/Main.java
+++ b/src/main/java/de/blau/android/Main.java
@@ -453,7 +453,7 @@ public class Main extends FullScreenAppCompatActivity
 
     private Bundle shortcutExtras;
 
-    private static final float LARGE_FAB_ELEVATION = 16; // used for renabling elevation on the FABs
+    private static final float LARGE_FAB_ELEVATION = 16; // used for re-enabling elevation on the FABs
 
     /**
      * {@inheritDoc}
@@ -468,22 +468,14 @@ public class Main extends FullScreenAppCompatActivity
         updatePrefs(new Preferences(this));
 
         int layout = R.layout.main;
-        if (useFullScreen(prefs)) {
+        if (useFullScreen(prefs) && !statusBarHidden()) {
             Log.d(DEBUG_TAG, "using full screen layout");
-            if (!statusBarHidden()) {
-                layout = R.layout.main_fullscreen;
-            }
+            layout = R.layout.main_fullscreen;
         }
         if (prefs.lightThemeEnabled()) {
-            if (statusBarHidden()) {
-                setTheme(R.style.Theme_customMain_Light_FullScreen);
-            } else {
-                setTheme(R.style.Theme_customMain_Light);
-            }
-        } else {
-            if (statusBarHidden()) {
-                setTheme(R.style.Theme_customMain_FullScreen);
-            }
+            setTheme(statusBarHidden() ? R.style.Theme_customMain_Light_FullScreen : R.style.Theme_customMain_Light);
+        } else if (statusBarHidden()) {
+            setTheme(R.style.Theme_customMain_FullScreen);
         }
 
         super.onCreate(savedInstanceState);

--- a/src/main/java/de/blau/android/imageryoffset/BackgroundAlignmentActionModeCallback.java
+++ b/src/main/java/de/blau/android/imageryoffset/BackgroundAlignmentActionModeCallback.java
@@ -457,7 +457,7 @@ public class BackgroundAlignmentActionModeCallback implements Callback {
         final Comparator<ImageryOffset> cmp = (offset1, offset2) -> {
             double d1 = GeoMath.haversineDistance(centerLon, centerLat, offset1.getLon(), offset1.getLat());
             double d2 = GeoMath.haversineDistance(centerLon, centerLat, offset2.getLon(), offset2.getLat());
-            return Double.valueOf(d1).compareTo(d2);
+            return Double.compare(d1, d2);
         };
         Logic logic = App.getLogic();
         OffsetLoader loader = new OffsetLoader(logic.getExecutorService(), logic.getHandler(), () -> {

--- a/src/main/java/de/blau/android/util/FullScreenAppCompatActivity.java
+++ b/src/main/java/de/blau/android/util/FullScreenAppCompatActivity.java
@@ -25,7 +25,7 @@ public abstract class FullScreenAppCompatActivity extends LocaleAwareCompatActiv
     private static final String DEBUG_TAG  = FullScreenAppCompatActivity.class.getSimpleName();
     private boolean             fullScreen = false;
     private boolean             hideStatus = false;
-    private final Handler       handler    = new Handler();
+    private final Handler       handler    = new Handler(getMainLooper());
 
     @SuppressLint("NewApi")
     @Override
@@ -117,10 +117,13 @@ public abstract class FullScreenAppCompatActivity extends LocaleAwareCompatActiv
         fullScreen = false;
         String fullScreenPref = prefs.getFullscreenMode();
         if (fullScreenPref.equals(getString(R.string.full_screen_auto))) {
-            fullScreen = (hasNavBar(getResources()) && isEdgeToEdgeEnabled(getResources()) == 0)
-                    || (!KeyCharacterMap.deviceHasKey(KeyEvent.KEYCODE_BACK) && !KeyCharacterMap.deviceHasKey(KeyEvent.KEYCODE_HOME));
-            Log.d(DEBUG_TAG, "full screen auto " + fullScreen + " KEYCODE_BACK " + KeyCharacterMap.deviceHasKey(KeyEvent.KEYCODE_BACK) + " KEYCODE_HOME "
-                    + KeyCharacterMap.deviceHasKey(KeyEvent.KEYCODE_HOME));
+            final boolean hasNavBar = hasNavBar(getResources());
+            final int edgeToEdgeEnabled = isEdgeToEdgeEnabled(getResources());
+            final boolean hasBack = KeyCharacterMap.deviceHasKey(KeyEvent.KEYCODE_BACK);
+            final boolean hasHome = KeyCharacterMap.deviceHasKey(KeyEvent.KEYCODE_HOME);
+            fullScreen = Build.VERSION.SDK_INT < Build.VERSION_CODES.R && ((hasNavBar && edgeToEdgeEnabled == 0) || (!hasBack && !hasHome));
+            Log.d(DEBUG_TAG, "full screen auto " + fullScreen + " hasNavBar " + hasNavBar + " isEdgeToEdgeEnabled " + edgeToEdgeEnabled + " KEYCODE_BACK "
+                    + hasBack + " KEYCODE_HOME " + hasHome);
             if (fullScreen && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 hideStatus = isInMultiWindowMode();
             } else {
@@ -143,7 +146,7 @@ public abstract class FullScreenAppCompatActivity extends LocaleAwareCompatActiv
     /**
      * Test if the device has a navigation bar
      * 
-     * This uses an undocumented internal resource id, but there is nothing else
+     * This uses an undocumented internal resource id, but there is nothing else prior to Android 11 / API 30 
      * 
      * @param resources to retrieve the setting from
      * @return true if the device has a navigation bar
@@ -160,7 +163,7 @@ public abstract class FullScreenAppCompatActivity extends LocaleAwareCompatActiv
     /**
      * Determine which navigation mode the device supports
      * 
-     * This uses an undocumented internal resource id, but there is nothing else
+     * This uses an undocumented internal resource id, but there is nothing else prior to Android 11 / API 30
      * 
      * @param resources to retrieve the setting from
      * @return 0 : Navigation is displaying with 3 buttons, 1 : displaying with 2 button(Android P navigation mode), 2 :

--- a/src/main/java/de/blau/android/util/FullScreenAppCompatActivity.java
+++ b/src/main/java/de/blau/android/util/FullScreenAppCompatActivity.java
@@ -5,6 +5,7 @@ import com.zeugmasolutions.localehelper.LocaleAwareCompatActivity;
 import android.annotation.SuppressLint;
 import android.content.res.Resources;
 import android.os.Build;
+import android.os.Bundle;
 import android.os.Handler;
 import android.util.Log;
 import android.view.KeyCharacterMap;
@@ -22,16 +23,26 @@ import de.blau.android.prefs.Preferences;
  */
 public abstract class FullScreenAppCompatActivity extends LocaleAwareCompatActivity {
 
-    private static final String DEBUG_TAG  = FullScreenAppCompatActivity.class.getSimpleName();
-    private boolean             fullScreen = false;
-    private boolean             hideStatus = false;
-    private final Handler       handler    = new Handler(getMainLooper());
+    private static final String DEBUG_TAG = FullScreenAppCompatActivity.class.getSimpleName();
 
+    private static final int FULLSCREEN_UI = View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN | View.SYSTEM_UI_FLAG_FULLSCREEN;
+    private static final int NAV_HIDDEN    = View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION;
+
+    private boolean fullScreen = false;
+    private boolean hideStatus = false;
+    private Handler handler;
+
+    @Override
+    protected void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        handler = new Handler(getMainLooper());
+    }
+
+    @SuppressWarnings("deprecation")
     @SuppressLint("NewApi")
     @Override
     protected void onResume() {
         super.onResume();
-
         View decorView = getWindow().getDecorView();
         decorView.setOnSystemUiVisibilityChangeListener(visibility -> {
             Log.d(DEBUG_TAG, "onSystemUiVisibilityChange " + Integer.toHexString(visibility));
@@ -89,19 +100,19 @@ public abstract class FullScreenAppCompatActivity extends LocaleAwareCompatActiv
      * @return true if we are not showing the status bar
      */
     protected boolean statusBarHidden() {
-        return hideStatus;
+        return hideStatus && !safeIsInMultiWIndowMode();
     }
 
     /**
      * Turn off a soft button navigation button, note this only works if the main view of the app actually has focus
      */
+    @SuppressWarnings("deprecation")
     @SuppressLint("NewApi")
     private void hideSystemUI() {
-        View view = getWindow().getDecorView();
-        if (view != null && fullScreen) {
+        if (fullScreen) {
             Log.d(DEBUG_TAG, "hiding nav bar");
-            int fullScreenMode = (hideStatus ? View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN | View.SYSTEM_UI_FLAG_FULLSCREEN : 0)
-                    | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION;
+            View view = getWindow().getDecorView();
+            int fullScreenMode = (statusBarHidden() ? FULLSCREEN_UI : 0) | NAV_HIDDEN;
             view.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE | fullScreenMode
                     | (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT ? View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY : 0));
         }
@@ -115,6 +126,7 @@ public abstract class FullScreenAppCompatActivity extends LocaleAwareCompatActiv
      */
     protected boolean useFullScreen(@NonNull Preferences prefs) {
         fullScreen = false;
+        hideStatus = false;
         String fullScreenPref = prefs.getFullscreenMode();
         if (fullScreenPref.equals(getString(R.string.full_screen_auto))) {
             final boolean hasNavBar = hasNavBar(getResources());
@@ -124,11 +136,6 @@ public abstract class FullScreenAppCompatActivity extends LocaleAwareCompatActiv
             fullScreen = Build.VERSION.SDK_INT < Build.VERSION_CODES.R && ((hasNavBar && edgeToEdgeEnabled == 0) || (!hasBack && !hasHome));
             Log.d(DEBUG_TAG, "full screen auto " + fullScreen + " hasNavBar " + hasNavBar + " isEdgeToEdgeEnabled " + edgeToEdgeEnabled + " KEYCODE_BACK "
                     + hasBack + " KEYCODE_HOME " + hasHome);
-            if (fullScreen && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                hideStatus = isInMultiWindowMode();
-            } else {
-                hideStatus = false;
-            }
         } else if (fullScreenPref.equals(getString(R.string.full_screen_never))) {
             fullScreen = false;
             Log.d(DEBUG_TAG, "full screen never");
@@ -142,11 +149,20 @@ public abstract class FullScreenAppCompatActivity extends LocaleAwareCompatActiv
         }
         return fullScreen;
     }
+    
+    /**
+     * Variant of isInMultiWindowMode that can be called on any platform
+     * 
+     * @return true if in multi windo mode
+     */
+    protected boolean safeIsInMultiWIndowMode() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && isInMultiWindowMode();
+    }
 
     /**
      * Test if the device has a navigation bar
      * 
-     * This uses an undocumented internal resource id, but there is nothing else prior to Android 11 / API 30 
+     * This uses an undocumented internal resource id, but there is nothing else prior to Android 11 / API 30
      * 
      * @param resources to retrieve the setting from
      * @return true if the device has a navigation bar

--- a/src/main/java/de/blau/android/util/Util.java
+++ b/src/main/java/de/blau/android/util/Util.java
@@ -471,7 +471,7 @@ public final class Util {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             return Long.compare(x, y);
         }
-        return Long.valueOf(x).compareTo(y);
+        return Long.valueOf(x).compareTo(y); // NOSONAR
     }
 
     private static class UlTagHandler implements Html.TagHandler {

--- a/src/main/res/layout/main_fullscreen.xml
+++ b/src/main/res/layout/main_fullscreen.xml
@@ -1,29 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical" >
-	<LinearLayout 
-	    android:layout_width="match_parent"
-        android:layout_height="24dp" 
-        android:orientation="vertical" 
-        />
+    android:orientation="vertical">
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="24dp"
+        android:orientation="vertical" />
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/mainToolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:layout_weight="0"
         android:background="?attr/colorPrimary"
-        android:minHeight="?attr/actionBarSize" >
+        android:minHeight="?attr/actionBarSize">
     </androidx.appcompat.widget.Toolbar>
-
     <RelativeLayout
         android:id="@+id/mainMap"
         android:layout_width="match_parent"
         android:layout_height="fill_parent"
-        android:layout_weight="99999" >
-
+        android:layout_weight="99999">
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/floatingLock"
             android:layout_width="wrap_content"
@@ -36,7 +34,6 @@
             app:backgroundTint="?attr/colorAccent"
             app:fabSize="mini"
             app:useCompatPadding="true" />
-        
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/layers"
             android:layout_width="wrap_content"
@@ -50,7 +47,6 @@
             app:backgroundTint="?attr/colorControlNormal"
             app:fabSize="mini"
             app:useCompatPadding="true" />
-        
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/follow"
             android:layout_width="wrap_content"
@@ -61,10 +57,9 @@
             android:clickable="true"
             android:src="@drawable/ic_gps_fixed_black_36dp"
             android:theme="@style/Theme.customMain"
-        	app:backgroundTint="?attr/colorControlNormal"
+            app:backgroundTint="?attr/colorControlNormal"
             app:fabSize="mini"
             app:useCompatPadding="true" />
-            
         <de.blau.android.views.ZoomControls
             android:id="@+id/zoom_controls"
             android:layout_width="wrap_content"
@@ -72,22 +67,18 @@
             android:layout_alignParentRight="true"
             android:layout_alignParentBottom="true" />
     </RelativeLayout>
-
     <FrameLayout
         android:id="@+id/bottomBar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
-        android:layout_weight="0" 
+        android:layout_weight="0"
         android:background="?attr/colorPrimary">
-
         <include
             android:id="@+id/bottomToolbar"
             layout="@layout/toolbar" />
-
         <ViewStub
             android:id="@+id/cab_stub"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize" />
     </FrameLayout>
-
 </LinearLayout>


### PR DESCRIPTION
Never automatically enable full screen mode on Android 11 and later.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/1502