### PR TITLE
Fix auto-preset application business logic

### DIFF
--- a/src/main/java/de/blau/android/propertyeditor/AlternativePresetItemsFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/AlternativePresetItemsFragment.java
@@ -112,7 +112,7 @@ public class AlternativePresetItemsFragment extends ImmersiveDialogFragment {
 
         final PresetClickHandler presetClickHandler = (PresetItem item) -> {
             Log.d(DEBUG_TAG, "normal click");
-            presetSelectedListener.onPresetSelected(item);
+            presetSelectedListener.onPresetSelected(item, false, true);
         };
         PresetGroup alternatives = Preset.dummyInstance().getRootGroup();
         List<PresetItemLink> links = presetItem.getAlternativePresetItems();

--- a/src/main/java/de/blau/android/propertyeditor/PresetFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/PresetFragment.java
@@ -79,14 +79,15 @@ public class PresetFragment extends BaseFragment implements PresetUpdate, Preset
          * @param item the PresetItem
          */
         void onPresetSelected(@NonNull PresetItem item);
-
+        
         /**
          * Call back when a PresetItem is selected
          * 
          * @param item the PresetItem
          * @param applyOptional if true apply optional fields
+         * @param isAlternative if true if the item is an alternative to the existing tagging
          */
-        void onPresetSelected(@NonNull PresetItem item, boolean applyOptional);
+        void onPresetSelected(@NonNull PresetItem item, boolean applyOptional, boolean isAlternative);
     }
 
     private OnPresetSelectedListener mListener;

--- a/src/main/java/de/blau/android/propertyeditor/PropertyEditor.java
+++ b/src/main/java/de/blau/android/propertyeditor/PropertyEditor.java
@@ -1044,13 +1044,13 @@ public class PropertyEditor extends LocaleAwareCompatActivity implements Propert
 
     @Override
     public void onPresetSelected(PresetItem item) {
-        onPresetSelected(item, false);
+        onPresetSelected(item, false, false);
     }
 
     @Override
-    public void onPresetSelected(PresetItem item, boolean applyOptional) {
+    public void onPresetSelected(PresetItem item, boolean applyOptional, boolean isAlternative) {
         if (item != null && tagEditorFragment != null) {
-            tagEditorFragment.applyPreset(item, applyOptional, true);
+            tagEditorFragment.applyPreset(item, applyOptional, isAlternative, true);
             if (tagFormFragment != null) {
                 tagFormFragment.update();
                 mViewPager.setCurrentItem(tagFormFragmentPosition);

--- a/src/main/java/de/blau/android/propertyeditor/tagform/TagFormFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/TagFormFragment.java
@@ -422,7 +422,7 @@ public class TagFormFragment extends BaseFragment implements FormUpdate {
         case R.id.tag_menu_apply_preset_with_optional:
             PresetItem pi = tagListener.getBestPreset();
             if (pi != null) {
-                presetSelectedListener.onPresetSelected(pi, item.getItemId() == R.id.tag_menu_apply_preset_with_optional);
+                presetSelectedListener.onPresetSelected(pi, item.getItemId() == R.id.tag_menu_apply_preset_with_optional, false);
             }
             return true;
         case R.id.tag_menu_revert:


### PR DESCRIPTION
This ensures that the logic that removes fixed tags from alternative presets when applying an alternative doesn't get used in the generic case.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/1644