### PR TITLE
Add functionality to prefer matches where the element type is correct

### DIFF
--- a/src/main/java/de/blau/android/geocode/QueryPhoton.java
+++ b/src/main/java/de/blau/android/geocode/QueryPhoton.java
@@ -133,7 +133,7 @@ class QueryPhoton extends Query {
                         String value = osmValue.getAsString();
                         Map<String, String> tag = new HashMap<>();
                         tag.put(key, value);
-                        PresetItem preset = Preset.findBestMatch(App.getCurrentPresets(activity), tag, null, false);
+                        PresetItem preset = Preset.findBestMatch(App.getCurrentPresets(activity), tag, null, null, false);
                         if (preset != null) {
                             sb.append("<br>[" + preset.getTranslatedName() + "]<br>");
                         } else {

--- a/src/main/java/de/blau/android/presets/Preset.java
+++ b/src/main/java/de/blau/android/presets/Preset.java
@@ -1737,7 +1737,7 @@ public class Preset {
      */
     @Nullable
     public static PresetItem findBestMatch(@Nullable Preset[] presets, @Nullable Map<String, String> tags, String region) {
-        return findBestMatch(presets, tags, region, false);
+        return findBestMatch(presets, tags, region, null, false);
     }
 
     /**
@@ -1751,11 +1751,13 @@ public class Preset {
      * @param presets presets presets to match against
      * @param tags tags to check against (i.e. tags of a map element)
      * @param region if not null this will be taken in to account wrt scoring
+     * @param elementType if not null the ElementType will be considered
      * @param useAddressKeys use addr: keys if true
      * @return a preset or null if none found
      */
     @Nullable
-    public static PresetItem findBestMatch(@Nullable Preset[] presets, @Nullable Map<String, String> tags, @Nullable String region, boolean useAddressKeys) {
+    public static PresetItem findBestMatch(@Nullable Preset[] presets, @Nullable Map<String, String> tags, @Nullable String region,
+            @Nullable ElementType elementType, boolean useAddressKeys) {
         int bestMatchStrength = 0;
         PresetItem bestMatch = null;
 
@@ -1786,6 +1788,10 @@ public class Preset {
                 }
                 if (region != null && !possibleMatch.appliesIn(region)) {
                     // downgrade so much that recommended tags can't compensate
+                    matches -= 200;
+                }
+                if (elementType != null && !possibleMatch.appliesTo(elementType)) {
+                    // downgrade even more
                     matches -= 200;
                 }
                 if (recommendedTagCount > 0) {

--- a/src/main/java/de/blau/android/propertyeditor/TagEditorFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/TagEditorFragment.java
@@ -659,7 +659,7 @@ public class TagEditorFragment extends BaseFragment implements PropertyRows, Edi
         clearPresets();
         clearSecondaryPresets();
         if (presetItem == null) {
-            primaryPresetItem = Preset.findBestMatch(presets, allTags, propertyEditorListener.getCountryIsoCode(), true); // FIXME
+            primaryPresetItem = Preset.findBestMatch(presets, allTags, propertyEditorListener.getCountryIsoCode(), null, true); // FIXME
                                                                                                                           // multiselect;
         } else {
             primaryPresetItem = presetItem;
@@ -667,7 +667,7 @@ public class TagEditorFragment extends BaseFragment implements PropertyRows, Edi
         Map<String, String> nonAssigned = addPresetsToTags(primaryPresetItem, allTags);
         int nonAssignedCount = nonAssigned.size();
         while (nonAssignedCount > 0) {
-            PresetItem nonAssignedPreset = Preset.findBestMatch(presets, nonAssigned, propertyEditorListener.getCountryIsoCode(), true);
+            PresetItem nonAssignedPreset = Preset.findBestMatch(presets, nonAssigned, propertyEditorListener.getCountryIsoCode(), null, true);
             if (nonAssignedPreset == null) {
                 // no point in continuing
                 break;

--- a/src/main/java/de/blau/android/util/SearchIndexUtils.java
+++ b/src/main/java/de/blau/android/util/SearchIndexUtils.java
@@ -180,7 +180,7 @@ public final class SearchIndexUtils {
                     for (NameAndTags nat : nats) {
                         if (nat.inUseIn(regions)) {
                             TagMap tags = nat.getTags();
-                            PresetItem pi = Preset.findBestMatch(presets, tags, null, false);
+                            PresetItem pi = Preset.findBestMatch(presets, tags, null, null, false);
                             PresetItem namePi = new PresetItem(preset, null, nat.getName(), pi == null ? null : pi.getIconpath(), null);
 
                             for (Entry<String, String> entry : tags.entrySet()) {

--- a/src/main/java/de/blau/android/validation/ExtendedValidator.java
+++ b/src/main/java/de/blau/android/validation/ExtendedValidator.java
@@ -12,6 +12,7 @@ import de.blau.android.Logic;
 import de.blau.android.R;
 import de.blau.android.osm.Node;
 import de.blau.android.osm.OsmElement;
+import de.blau.android.osm.OsmElement.ElementType;
 import de.blau.android.osm.Relation;
 import de.blau.android.osm.RelationMember;
 import de.blau.android.osm.Way;
@@ -104,7 +105,7 @@ public class ExtendedValidator implements Validator {
         List<RelationMember> members = relation.getMembers();
         if (missingRoleValidation && members != null) {
             // check for missing roles
-            PresetItem pi = Preset.findBestMatch(base.getPresets(), relation.getTags(), base.getCountry(relation));
+            PresetItem pi = Preset.findBestMatch(base.getPresets(), relation.getTags(), base.getCountry(relation), ElementType.RELATION, false);
             if (pi != null) {
                 List<PresetRole> presetRoles = pi.getRoles();
                 if (presetRoles != null) {


### PR DESCRIPTION
In some cases, for example relation validation, we only want to match with presets for a specific element type.