### PR TITLE
Protect against element not being found on restore

### DIFF
--- a/src/main/java/de/blau/android/dialogs/ElementInfo.java
+++ b/src/main/java/de/blau/android/dialogs/ElementInfo.java
@@ -183,6 +183,11 @@ public class ElementInfo extends InfoDialogFragment {
             getArguments().remove(ELEMENT_KEY);
             getArguments().remove(UNDOELEMENT_INDEX_KEY);
         }
+        if (element == null) {
+            Log.e(DEBUG_TAG, "element is null");
+            Snack.toastTopError(getContext(), R.string.toast_element_not_found_on_restore);
+            return; // dialog will come up empty
+        }
         if (ueIndex >= 0) {
             List<UndoElement> undoElements = App.getDelegator().getUndo().getUndoElements(element);
             if (undoElements.size() > ueIndex) {

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -220,6 +220,7 @@
     <string name="current">Current</string>
     <string name="goto_element">Go to element</string>
     <string name="edit_properties">Edit Tags</string>
+    <string name="toast_element_not_found_on_restore">Could not find element on restore</string>
     <!--  GeoJSON feature display dialog -->
     <string name="feature_information">GeoJSON feature info</string>
     <string name="vt_feature_information">Vector tile feature info</string>


### PR DESCRIPTION
Fixes a crash if on restore of the element info dialog the element could not be found in storage.