### PR TITLE
Handle one node ways when calculating the centroid

### DIFF
--- a/src/main/java/de/blau/android/util/Geometry.java
+++ b/src/main/java/de/blau/android/util/Geometry.java
@@ -143,8 +143,8 @@ public final class Geometry {
             return null;
         }
         List<Node> nodes = way.getNodes();
-        boolean closed = way.isClosed();
         int size = nodes.size();
+        boolean closed = way.isClosed() && size != 1; // handle 1 node ways
         size = closed ? size - 1 : size;
         Coordinates[] points = new Coordinates[size];
         Coordinates start = new Coordinates(nodes.get(0).getLon() / 1E7D, GeoMath.latE7ToMercator(nodes.get(0).getLat()));

--- a/src/test/java/de/blau/android/util/GeometryTest.java
+++ b/src/test/java/de/blau/android/util/GeometryTest.java
@@ -2,15 +2,23 @@ package de.blau.android.util;
 
 import static de.blau.android.osm.DelegatorUtil.toE7;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import de.blau.android.App;
 import de.blau.android.osm.Node;
 import de.blau.android.osm.OsmElementFactory;
+import de.blau.android.osm.StorageDelegator;
+import de.blau.android.osm.Way;
 
+@RunWith(RobolectricTestRunner.class)
 public class GeometryTest {
 
     /**
@@ -60,5 +68,24 @@ public class GeometryTest {
         float[] output3 = new float[16];
         Geometry.offset(input3, output3, input3.length, true, 1);
         assertArrayEquals(new float[] { -4f, 4f, 4f, 4f, 4f, 4f, 4f, -4f, 4f, -4f, -4f, -4f, -4f, -4f, -4f, 4f }, output3, 0.000001f);
+    }
+    
+    /**
+     * Test that calculating the centroid of degenerate ways does what is expected 
+     */
+    @Test
+    public void centroidDegenerateWays() {
+        final StorageDelegator delegator = App.getDelegator();
+        OsmElementFactory factory = delegator.getFactory();
+        Way w = factory.createWayWithNewId();
+        
+        double[] centroid = Geometry.centroidLonLat(w);
+        assertNull(centroid);
+        Node n0 = factory.createNodeWithNewId(toE7(51.5019094D), toE7(-0.1417412D));
+        delegator.addNodeToWay(n0, w);
+        centroid = Geometry.centroidLonLat(w);
+        assertNotNull(centroid);
+        assertEquals(centroid[0],-0.1417412D, 0.0000001);
+        assertEquals(centroid[1],51.5019094D, 0.0000001);
     }
 }


### PR DESCRIPTION
One node ways would cause the improved code to crash because they were considered to be closed.