### PR TITLE
Display PropertyEditor in split window

### DIFF
--- a/documentation/docs/help/en/Advanced preferences.md
+++ b/documentation/docs/help/en/Advanced preferences.md
@@ -352,3 +352,7 @@ Enable voice command support: Default: _off_.
 ### Enable hardware acceleration
 
 Do not use, may cause hangs of the app and other problems.
+
+### Enable split window property editor
+
+Enable displaying the property editor in a separate window if available. Default: _off_

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -67,7 +67,7 @@
             android:name=".Main"
             android:configChanges="orientation|screenSize|keyboardHidden|density|screenLayout|uiMode|fontScale"
             android:exported="true"
-            android:launchMode="singleTask"
+            android:launchMode="singleInstance"
             android:theme="@style/Theme.customMain" >
             <meta-data
                 android:name="com.samsung.android.keepalive.density"
@@ -120,7 +120,8 @@
         <activity
             android:name=".propertyeditor.PropertyEditorActivity"
             android:configChanges="orientation|screenSize|keyboardHidden|density|screenLayout|uiMode|fontScale"
-            android:theme="@style/Theme.customTagEditor" />
+            android:theme="@style/Theme.customTagEditor"
+               android:launchMode="singleTask" />
         <activity
             android:name=".prefs.APIEditorActivity"
             android:configChanges="orientation|screenSize|keyboardHidden|density|screenLayout|uiMode|fontScale"

--- a/src/main/assets/help/en/Advanced preferences.html
+++ b/src/main/assets/help/en/Advanced preferences.html
@@ -182,6 +182,8 @@
 <p>Enable voice command support: Default: <em>off</em>.</p>
 <h3>Enable hardware acceleration</h3>
 <p>Do not use, may cause hangs of the app and other problems.</p>
+<h3>Enable split window property editor</h3>
+<p>Enable displaying the property editor in a separate window if available. Default: <em>off</em></p>
 
 </body>
 </html>

--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -1291,7 +1291,7 @@ public class Logic {
                 selectedTask = taskLayer.getSelected();
             }
             final boolean largeDragArea = prefs.largeDragArea();
-            final Selection currentSelection = selectionStack.getLast();
+            final Selection currentSelection = selectionStack.getFirst();
             final int selectedWayCount = currentSelection.wayCount();
             final int selectedNodeCount = currentSelection.nodeCount();
             // single node or task dragging
@@ -1440,7 +1440,7 @@ public class Logic {
      * @throws OsmIllegalOperationException if one of the operations triggered went wrong
      */
     synchronized void handleTouchEventMove(@NonNull Main main, final float absoluteX, final float absoluteY, final float relativeX, final float relativeY) {
-        final Selection currentSelection = selectionStack.getLast();
+        final Selection currentSelection = selectionStack.getFirst();
         if (draggingNode || draggingWay || draggingHandle || draggingNote) {
             int lat = yToLatE7(absoluteY);
             int lon = xToLonE7(absoluteX);
@@ -4347,8 +4347,8 @@ public class Logic {
      * @param selectedNode node to select
      */
     public synchronized void setSelectedNode(@Nullable final Node selectedNode) {
-        selectionStack.getLast().setNode(selectedNode);
-        map.setSelectedNodes(selectionStack.getLast().getNodes());
+        selectionStack.getFirst().setNode(selectedNode);
+        map.setSelectedNodes(selectionStack.getFirst().getNodes());
         resetFilterCache();
     }
 
@@ -4358,7 +4358,7 @@ public class Logic {
      * @param selectedNode node to add to selection
      */
     public synchronized void addSelectedNode(@NonNull final Node selectedNode) {
-        selectionStack.getLast().add(selectedNode);
+        selectionStack.getFirst().add(selectedNode);
         resetFilterCache();
     }
 
@@ -4367,7 +4367,7 @@ public class Logic {
      */
     @Nullable
     public final synchronized Node getSelectedNode() {
-        return selectionStack.getLast().getNode();
+        return selectionStack.getFirst().getNode();
     }
 
     /**
@@ -4377,7 +4377,7 @@ public class Logic {
      */
     @Nullable
     public List<Node> getSelectedNodes() {
-        return selectionStack.getLast().getNodes();
+        return selectionStack.getFirst().getNodes();
     }
 
     /**
@@ -4386,7 +4386,7 @@ public class Logic {
      * @return a count of the selected Nodes
      */
     public int selectedNodesCount() {
-        return selectionStack.getLast().nodeCount();
+        return selectionStack.getFirst().nodeCount();
     }
 
     /**
@@ -4395,7 +4395,7 @@ public class Logic {
      * @param node node to remove from selection
      */
     public synchronized void removeSelectedNode(@NonNull Node node) {
-        if (selectionStack.getLast().remove(node)) {
+        if (selectionStack.getFirst().remove(node)) {
             resetFilterCache();
         }
     }
@@ -4406,8 +4406,8 @@ public class Logic {
      * @param selectedWay way to select
      */
     public synchronized void setSelectedWay(@Nullable final Way selectedWay) {
-        selectionStack.getLast().setWay(selectedWay);
-        map.setSelectedWays(selectionStack.getLast().getWays());
+        selectionStack.getFirst().setWay(selectedWay);
+        map.setSelectedWays(selectionStack.getFirst().getWays());
         resetFilterCache();
     }
 
@@ -4417,7 +4417,7 @@ public class Logic {
      * @param selectedWay way to add to selection
      */
     public synchronized void addSelectedWay(@NonNull final Way selectedWay) {
-        selectionStack.getLast().add(selectedWay);
+        selectionStack.getFirst().add(selectedWay);
         resetFilterCache();
     }
 
@@ -4426,7 +4426,7 @@ public class Logic {
      */
     @Nullable
     public final synchronized Way getSelectedWay() {
-        return selectionStack.getLast().getWay();
+        return selectionStack.getFirst().getWay();
     }
 
     /**
@@ -4436,7 +4436,7 @@ public class Logic {
      */
     @Nullable
     public List<Way> getSelectedWays() {
-        return selectionStack.getLast().getWays();
+        return selectionStack.getFirst().getWays();
     }
 
     /**
@@ -4445,7 +4445,7 @@ public class Logic {
      * @return a count of the selected Ways
      */
     public int selectedWaysCount() {
-        return selectionStack.getLast().wayCount();
+        return selectionStack.getFirst().wayCount();
     }
 
     /**
@@ -4454,7 +4454,7 @@ public class Logic {
      * @param way way to de-select
      */
     public synchronized void removeSelectedWay(@NonNull Way way) {
-        if (selectionStack.getLast().remove(way)) {
+        if (selectionStack.getFirst().remove(way)) {
             resetFilterCache();
         }
     }
@@ -4465,7 +4465,7 @@ public class Logic {
      * @param selectedRelation relation to select
      */
     public synchronized void setSelectedRelation(@Nullable final Relation selectedRelation) {
-        selectionStack.getLast().setRelation(selectedRelation);
+        selectionStack.getFirst().setRelation(selectedRelation);
         if (selectedRelation != null) {
             setSelectedRelationMembers(selectedRelation);
         }
@@ -4478,10 +4478,10 @@ public class Logic {
      * @param relation relation to remove from selection
      */
     public synchronized void removeSelectedRelation(@NonNull Relation relation) {
-        if (selectionStack.getLast().remove(relation)) {
+        if (selectionStack.getFirst().remove(relation)) {
             setSelectedRelationNodes(null); // de-select all
             setSelectedRelationWays(null);
-            if (selectionStack.getLast().relationCount() > 0) {
+            if (selectionStack.getFirst().relationCount() > 0) {
                 for (Relation r : getSelectedRelations()) { // re-select
                     setSelectedRelationMembers(r);
                 }
@@ -4496,7 +4496,7 @@ public class Logic {
      * @param selectedRelation relation to add to selection
      */
     public synchronized void addSelectedRelation(@NonNull final Relation selectedRelation) {
-        selectionStack.getLast().add(selectedRelation);
+        selectionStack.getFirst().add(selectedRelation);
         setSelectedRelationMembers(selectedRelation);
         resetFilterCache();
     }
@@ -4507,7 +4507,7 @@ public class Logic {
      * @return a List of Relations that are selected
      */
     public List<Relation> getSelectedRelations() {
-        return selectionStack.getLast().getRelations();
+        return selectionStack.getFirst().getRelations();
     }
 
     /**
@@ -4516,7 +4516,7 @@ public class Logic {
      * @return a count of the selected Relations
      */
     public int selectedRelationsCount() {
-        return selectionStack.getLast().relationCount();
+        return selectionStack.getFirst().relationCount();
     }
 
     /**
@@ -4525,7 +4525,7 @@ public class Logic {
      * @param elements a List of OsmElement to select
      */
     public synchronized void setSelection(@NonNull List<OsmElement> elements) {
-        Selection currentSelection = selectionStack.getLast();
+        Selection currentSelection = selectionStack.getFirst();
         for (OsmElement e : elements) {
             currentSelection.add(e);
         }
@@ -4549,7 +4549,7 @@ public class Logic {
     @NonNull
     public synchronized List<OsmElement> getSelectedElements() {
         List<OsmElement> result = new ArrayList<>();
-        final Selection currentSelection = selectionStack.getLast();
+        final Selection currentSelection = selectionStack.getFirst();
         List<Node> selectedNodes = currentSelection.getNodes();
         if (selectedNodes != null) {
             result.addAll(selectedNodes);
@@ -4611,7 +4611,7 @@ public class Logic {
      * @return true is e is selected
      */
     public synchronized boolean isSelected(@Nullable OsmElement e) {
-        return e != null && selectionStack.getLast().contains(e);
+        return e != null && selectionStack.getFirst().contains(e);
     }
 
     /**
@@ -4711,7 +4711,7 @@ public class Logic {
         map.setViewBox(viewBox);
         if (deselect) {
             map.deselectObjects();
-            selectionStack.getLast().reset();
+            selectionStack.getFirst().reset();
             resetFilterCache();
         }
         invalidateMap();
@@ -5228,7 +5228,7 @@ public class Logic {
      * Do map and filter setup from current top of selection stack
      */
     private void selectFromTop() {
-        final Selection currentSelection = selectionStack.getLast();
+        final Selection currentSelection = selectionStack.getFirst();
         map.setSelectedNodes(currentSelection.getNodes());
         map.setSelectedWays(currentSelection.getWays());
         reselectRelationMembers();
@@ -5251,7 +5251,16 @@ public class Logic {
      * Push a new empty Selection and reset everything
      */
     public synchronized void pushSelection() {
-        selectionStack.add(new Selection());
+        pushSelection(new Selection());
+    }
+
+    /**
+     * Use a new Selection and push it to the top of the stack
+     *
+     * @param selection the Selection to use
+     */
+    public synchronized void pushSelection(@NonNull Selection selection) {
+        selectionStack.push(selection);
         selectFromTop();
     }
 

--- a/src/main/java/de/blau/android/Selection.java
+++ b/src/main/java/de/blau/android/Selection.java
@@ -14,6 +14,8 @@ import de.blau.android.osm.Way;
 
 public class Selection {
 
+    public static final String SELECTION_KEY = "SELECTION";
+
     public static class Ids implements Serializable {
         private static final long serialVersionUID = 1L;
 

--- a/src/main/java/de/blau/android/easyedit/EasyEditManager.java
+++ b/src/main/java/de/blau/android/easyedit/EasyEditManager.java
@@ -180,7 +180,7 @@ public class EasyEditManager {
      * @param mode the new ActionMode
      * @param callback the new Callback
      */
-    public void setCallBack(ActionMode mode, EasyEditActionModeCallback callback) {
+    public void setCallBack(@Nullable ActionMode mode, @Nullable EasyEditActionModeCallback callback) {
         synchronized (actionModeCallbackLock) {
             currentActionMode = mode;
             currentActionModeCallback = callback;
@@ -335,7 +335,7 @@ public class EasyEditManager {
     }
 
     /**
-     * Edit currently selected elements, tries to restart a previous mode if it has been saved
+     * Edit currently selected elements
      */
     public void editElements() {
         synchronized (actionModeCallbackLock) {

--- a/src/main/java/de/blau/android/easyedit/ElementSelectionActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/ElementSelectionActionModeCallback.java
@@ -375,7 +375,7 @@ public abstract class ElementSelectionActionModeCallback extends EasyEditActionM
             main.confirmUpload(addRequiredElements(main, Util.wrapInList(element)));
             break;
         case MENUITEM_PREFERENCES:
-            PrefEditor.start(main);
+            PrefEditor.start(main, Main.REQUEST_PREFERENCES);
             break;
         case MENUITEM_ZOOM_TO_SELECTION:
             main.zoomTo(element);

--- a/src/main/java/de/blau/android/prefs/Preferences.java
+++ b/src/main/java/de/blau/android/prefs/Preferences.java
@@ -113,6 +113,7 @@ public class Preferences {
     private final Set<String> enabledValidations;
     private final int         autoNameCap;
     private final boolean     wayNodeDragging;
+    private final boolean     splitWindowForPropertyEditor;
 
     private static final String DEFAULT_MAP_PROFILE = "Color Round Nodes";
 
@@ -288,6 +289,8 @@ public class Preferences {
         autoNameCap = getIntFromStringPref(R.string.config_nameCap_key, 1);
 
         wayNodeDragging = prefs.getBoolean(r.getString(R.string.config_wayNodeDragging_key), false);
+
+        splitWindowForPropertyEditor = prefs.getBoolean(r.getString(R.string.config_splitWindowForPropertyEditor_key), false);
     }
 
     /**
@@ -1528,6 +1531,15 @@ public class Preferences {
     }
 
     /**
+     * Check if we should try to use split window functionality for the PropertyEditor
+     * 
+     * @return true if we should use split windows
+     */
+    public boolean useSplitWindowForPropertyEditor() {
+        return splitWindowForPropertyEditor;
+    }
+
+    /**
      * Get a string from shared preferences
      * 
      * @param prefKey preference key as a string resource
@@ -1558,7 +1570,7 @@ public class Preferences {
             Log.e(DEBUG_TAG, "putString " + ex.getMessage());
         }
     }
-    
+
     /**
      * Close anything that needs closing
      */

--- a/src/main/res/values/prefkeys.xml
+++ b/src/main/res/values/prefkeys.xml
@@ -92,6 +92,7 @@
     <string name="config_nameCap_key">nameCap</string>
     <string name="config_indexMediaStore_key">indexMediaStore</string>
     <string name="config_wayNodeDragging_key">wayNodeDragging</string>
+    <string name="config_splitWindowForPropertyEditor_key">splitWindowForPropertyEditor</string>
     <!-- Preference keys used in the pref editor(s) int prefs -->
     <string name="config_maxInlineValues_key">maxInlineValuesInt</string>
     <string name="config_autoLockDelay_key">autoLockDelayInt</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1283,6 +1283,8 @@
     <string name="config_js_console_summary">Make the JS console available in "live" mode.</string>
     <string name="config_voiceCommandsEnabled_title">Enable voice commands</string>
     <string name="config_voiceCommandsEnabled_summary">Enable voice command support.</string>
+    <string name="config_splitWindowForPropertyEditor_summary">Enable displaying the property editor in a separate window if available.</string>
+    <string name="config_splitWindowForPropertyEditor_title">Enable split window property editor</string>
     <!--  -->
     <string name="manage_apis">Manage APIs</string>
     <string name="config_api_url_title">API URL</string>

--- a/src/main/res/xml-v19/advancedpreferences.xml
+++ b/src/main/res/xml-v19/advancedpreferences.xml
@@ -638,5 +638,10 @@
             android:key="@string/config_enableHwAcceleration_key"
             android:summary="@string/config_enableHwAcceleration_summary"
             android:title="@string/config_enableHwAcceleration_title" />
+        <androidx.preference.CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/config_splitWindowForPropertyEditor_key"
+            android:summary="@string/config_splitWindowForPropertyEditor_summary"
+            android:title="@string/config_splitWindowForPropertyEditor_title" />
     </androidx.preference.PreferenceScreen>
 </androidx.preference.PreferenceScreen>

--- a/src/main/res/xml-v24/advancedpreferences.xml
+++ b/src/main/res/xml-v24/advancedpreferences.xml
@@ -643,5 +643,10 @@
             android:key="@string/config_enableHwAcceleration_key"
             android:summary="@string/config_enableHwAcceleration_summary"
             android:title="@string/config_enableHwAcceleration_title" />
+        <androidx.preference.CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/config_splitWindowForPropertyEditor_key"
+            android:summary="@string/config_splitWindowForPropertyEditor_summary"
+            android:title="@string/config_splitWindowForPropertyEditor_title" />
     </androidx.preference.PreferenceScreen>
 </androidx.preference.PreferenceScreen>

--- a/src/main/res/xml/advancedpreferences.xml
+++ b/src/main/res/xml/advancedpreferences.xml
@@ -633,5 +633,10 @@
             android:key="@string/config_voiceCommandsEnabled_key"
             android:summary="@string/config_voiceCommandsEnabled_summary"
             android:title="@string/config_voiceCommandsEnabled_title" />
+        <androidx.preference.CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/config_splitWindowForPropertyEditor_key"
+            android:summary="@string/config_splitWindowForPropertyEditor_summary"
+            android:title="@string/config_splitWindowForPropertyEditor_title" />
     </androidx.preference.PreferenceScreen>
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
This adds experimental support for running the property editor in a separate window (if split window is enabled), including selection deselection logic on drill down to relation members.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/1174