### PR TITLE
Differentiate between exact matches with and without accents

### DIFF
--- a/src/main/java/de/blau/android/util/IndexSearchResult.java
+++ b/src/main/java/de/blau/android/util/IndexSearchResult.java
@@ -41,7 +41,7 @@ public class IndexSearchResult {
         return result;
     }
 
-    public static final Comparator<IndexSearchResult> weightComparator = (isr1, isr2) -> {
+    public static final Comparator<IndexSearchResult> WEIGHT_COMPARATOR = (isr1, isr2) -> {
         if (isr2.weight > isr1.weight) {
             return -1;
         } else if (isr2.weight < isr1.weight) {


### PR DESCRIPTION
This change increases the weight of matches including accents, and includes some other minor clean up.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/1722