### PR TITLE
Fix imagery layer MRU list not being restored

### DIFF
--- a/src/main/java/de/blau/android/resources/TileLayerSource.java
+++ b/src/main/java/de/blau/android/resources/TileLayerSource.java
@@ -397,7 +397,7 @@ public class TileLayerSource implements Serializable {
 
     private transient Context        ctx;
     private boolean                  metadataLoaded;
-    private String                   id;
+    private final String             id;
     private String                   name;
     private String                   type;
     private Category                 category;
@@ -591,7 +591,6 @@ public class TileLayerSource implements Serializable {
             @Nullable String[] noTileValues, @Nullable String description, @Nullable String privacyPolicyUrl, boolean async) {
 
         this.ctx = ctx;
-        this.id = id;
         this.name = name;
         this.type = type;
         this.category = category;
@@ -627,12 +626,9 @@ public class TileLayerSource implements Serializable {
             // parse error or other fatal issue
             this.name = "INVALID";
         }
-        if (this.id == null) {
-            // generate id from name
-            this.id = nameToId(this.name);
-        }
-        //
-        this.id = this.id.toUpperCase(Locale.US);
+
+        // generate id from name if necessary
+        this.id = (id != null ? id : nameToId(this.name)).toUpperCase(Locale.US);
 
         if (originalUrl.startsWith(FileUtil.FILE_SCHEME_PREFIX)) { // mbtiles no further processing needed
             readOnly = true;
@@ -718,7 +714,7 @@ public class TileLayerSource implements Serializable {
      * @param name input name String
      * @return a String with an id
      */
-    public static String nameToId(final String name) {
+    public static String nameToId(@NonNull final String name) {
         return name.replaceAll("[\\W\\_]", "").toUpperCase(Locale.US);
     }
 

--- a/src/main/java/de/blau/android/util/collections/MRUList.java
+++ b/src/main/java/de/blau/android/util/collections/MRUList.java
@@ -3,6 +3,8 @@ package de.blau.android.util.collections;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import androidx.annotation.NonNull;
+
 /**
  * A list that can be used in a stack like fashion for implementing MRU (Most Recently Used) semantics
  * 
@@ -30,7 +32,7 @@ public class MRUList<T> extends ArrayList<T> {
      * 
      * @param collection the Collection to use for construction
      */
-    public MRUList(Collection<T> collection) {
+    public MRUList(@NonNull Collection<T> collection) {
         super(collection);
         this.capacity = collection.size();
     }
@@ -49,6 +51,17 @@ public class MRUList<T> extends ArrayList<T> {
             remove(size() - 1);
         }
         add(0, o);
+    }
+
+    /**
+     * Add all elements in collection to the stack
+     * 
+     * @param collection a Collection of T
+     */
+    public void pushAll(@NonNull Collection<T> collection) {
+        for (T o : collection) {
+            push(o);
+        }
     }
 
     /**

--- a/src/main/java/de/blau/android/views/layers/MapTilesOverlayLayer.java
+++ b/src/main/java/de/blau/android/views/layers/MapTilesOverlayLayer.java
@@ -31,7 +31,7 @@ public class MapTilesOverlayLayer<T> extends MapTilesLayer<T> {
             enabled = false;
         } else {
             String id = layer.getId();
-            enabled = !(id == null || TileLayerSource.LAYER_NOOVERLAY.equals(id) || TileLayerSource.LAYER_NONE.equals(id) || "".equals(id));
+            enabled = !(TileLayerSource.LAYER_NOOVERLAY.equals(id) || TileLayerSource.LAYER_NONE.equals(id) || "".equals(id));
         }
         return enabled && super.isReadyToDraw();
     }

--- a/src/test/java/de/blau/android/util/CollectionTest.java
+++ b/src/test/java/de/blau/android/util/CollectionTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -18,6 +19,7 @@ import de.blau.android.osm.OsmElement;
 import de.blau.android.osm.OsmElementFactory;
 import de.blau.android.util.collections.LongHashSet;
 import de.blau.android.util.collections.LongOsmElementMap;
+import de.blau.android.util.collections.MRUList;
 import de.blau.android.util.collections.MultiHashMap;
 import de.blau.android.util.collections.UnsignedSparseBitSet;
 import de.blau.android.util.rtree.RTree;
@@ -178,5 +180,26 @@ public class CollectionTest {
         // misc
         assertEquals(25035, UnsignedSparseBitSet.inc(25034));
         assertEquals(0x80150A01, UnsignedSparseBitSet.inc(0x80150A00));
+    }
+
+    /**
+     * Test Most-Recently-Used list implementation
+     */
+    @Test
+    public void mruList() {
+        MRUList<String> mru = new MRUList<>(10);
+        mru.push("bottom");
+        mru.push("top");
+        assertEquals(2, mru.size());
+        assertEquals("top", mru.last());
+        mru.push("bottom");
+        assertEquals(2, mru.size());
+        assertEquals("bottom", mru.last());
+
+        mru.pushAll(Arrays.asList("1", "2"));
+        assertEquals(4, mru.size());
+        assertEquals("2", mru.last());
+        mru.push("top");
+        assertEquals(4, mru.size());
     }
 }


### PR DESCRIPTION
After a complete restart the imagery layer was not being restored as the
"saved" flag was being set to false due to a change in the order of the
way imagery layers are set up.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/1727