### PR TITLE
Remove the onFocusChangedListener on the role AutoCompleteTextView

### DIFF
--- a/src/main/java/de/blau/android/propertyeditor/RelationMembershipFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/RelationMembershipFragment.java
@@ -355,17 +355,11 @@ public class RelationMembershipFragment extends BaseFragment implements Property
 
             parentEdit = (Spinner) findViewById(R.id.editParent);
 
-            roleEdit.setOnFocusChangeListener((v, hasFocus) -> {
-                if (hasFocus) {
-                    roleEdit.setAdapter(getMembershipRoleAutocompleteAdapter());
-                    if (roleEdit.getText().length() == 0) {
-                        roleEdit.showDropDown();
-                    }
-                }
-            });
-
             roleEdit.setOnClickListener(v -> {
                 if (v.hasFocus()) {
+                    if (roleEdit.getAdapter() == null) {
+                        roleEdit.setAdapter(getMembershipRoleAutocompleteAdapter());
+                    }
                     ((AutoCompleteTextView) v).showDropDown();
                 }
             });


### PR DESCRIPTION
The view getting focus early on a restore could potential cause a crash and the onClickListener is really enough in any case.