### PR TITLE
Improve handling of duplicate keys in the tag editor

### DIFF
--- a/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
+++ b/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
@@ -230,6 +230,70 @@ public class PropertyEditorTest {
     }
 
     /**
+     * Check that we moan if a duplicate key is added
+     */
+    @Test
+    public void duplicateKey() {
+        Logic logic = App.getLogic();
+        Map map = main.getMap();
+        logic.setZoom(map, 20);
+
+        logic.setSelectedWay(null);
+        logic.setSelectedNode(null);
+        logic.setSelectedRelation(null);
+        try {
+            logic.performAdd(main, 1000.0f, 0.0f);
+        } catch (OsmIllegalOperationException e1) {
+            fail(e1.getMessage());
+        }
+
+        Node n = logic.getSelectedNode();
+        assertNotNull(n);
+
+        main.performTagEdit(n, null, false, false);
+        waitForPropertyEditor();
+        TestUtils.clickText(device, true, main.getString(R.string.tag_details), false, false);
+        device.wait(Until.findObject(By.clickable(true).res(device.getCurrentPackageName() + ":id/editKey")), 500);
+        UiObject editText = device.findObject(new UiSelector().clickable(true).resourceId(device.getCurrentPackageName() + ":id/editKey"));
+        try {
+            editText.setText("key");
+        } catch (UiObjectNotFoundException e) {
+            fail(e.getMessage());
+        }
+        editText = device.findObject(new UiSelector().clickable(true).resourceId(device.getCurrentPackageName() + ":id/editValue"));
+        try {
+            editText.setText("value");
+        } catch (UiObjectNotFoundException e) {
+            fail(e.getMessage());
+        }
+
+        editText = device.findObject(new UiSelector().clickable(true).resourceId(device.getCurrentPackageName() + ":id/editKey").instance(1));
+        try {
+            editText.setText("key");
+        } catch (UiObjectNotFoundException e) {
+            fail(e.getMessage());
+        }
+        editText = device.findObject(new UiSelector().clickable(true).resourceId(device.getCurrentPackageName() + ":id/editValue").instance(1));
+        try {
+            editText.setText("value2");
+        } catch (UiObjectNotFoundException e) {
+            fail(e.getMessage());
+        }
+
+        TestUtils.clickHome(device, true);
+        assertTrue(TestUtils.findText(device, false, main.getString(R.string.duplicate_tag_key_title)));
+        assertTrue(TestUtils.clickText(device, false, main.getString(R.string.okay), true));
+        try {
+            editText.setText("");
+        } catch (UiObjectNotFoundException e) {
+            fail(e.getMessage());
+        }
+        TestUtils.clickHome(device, true);
+        assertTrue(n.hasTag("key", "value"));
+
+    }
+
+    /**
      * Select an untagged node, then - apply restaurant preset - set cuisine and opening_hours
      */
     @Test
@@ -739,7 +803,7 @@ public class PropertyEditorTest {
         assertTrue(TestUtils.clickText(device, false, main.getString(R.string.delete), true));
         assertEquals(OsmElement.STATE_DELETED, r.getState());
     }
-    
+
     /**
      * Select a relation and check that the membership tab doesn't allow adding to itself
      */

--- a/src/main/java/de/blau/android/ErrorCodes.java
+++ b/src/main/java/de/blau/android/ErrorCodes.java
@@ -37,4 +37,5 @@ public final class ErrorCodes {
     public static final int REQUIRED_FEATURE_MISSING = 56;
     public static final int APPLYING_OSC_FAILED      = 57;
     public static final int MISSING_API_KEY          = 58;
+    public static final int DUPLICATE_TAG_KEY        = 59;
 }

--- a/src/main/java/de/blau/android/dialogs/ErrorAlert.java
+++ b/src/main/java/de/blau/android/dialogs/ErrorAlert.java
@@ -147,6 +147,8 @@ public class ErrorAlert extends ImmersiveDialogFragment {
             return "applying_osc_failed";
         case ErrorCodes.CORRUPTED_DATA:
             return "alert_corrupt_data";
+        case ErrorCodes.DUPLICATE_TAG_KEY:
+            return "alert_duplicate_tag_key";
         default:
             // nothing
         }
@@ -207,6 +209,8 @@ public class ErrorAlert extends ImmersiveDialogFragment {
             return createNewInstance(R.string.applying_osc_failed_title, R.string.applying_osc_failed_message, msg);
         case ErrorCodes.CORRUPTED_DATA:
             return createNewInstance(R.string.corrupted_data_title, R.string.corrupted_data_message, msg);
+        case ErrorCodes.DUPLICATE_TAG_KEY:
+            return createNewInstance(R.string.duplicate_tag_key_title, R.string.duplicate_tag_key_message, msg);
         default:
             // ignore
         }

--- a/src/main/java/de/blau/android/exception/DuplicateKeyException.java
+++ b/src/main/java/de/blau/android/exception/DuplicateKeyException.java
@@ -1,0 +1,37 @@
+package de.blau.android.exception;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Thrown when we have two keys that are identical
+ * 
+ * @author simon
+ *
+ */
+public class DuplicateKeyException extends RuntimeException {
+
+    private final String key;
+    
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Construct a new exception
+     * 
+     * @param key the duplicate key
+     */
+    public DuplicateKeyException(@NonNull String key) {
+        super();
+        this.key = key;
+    }
+
+    /**
+     * @return the key
+     */
+    @NonNull
+    public String getKey() {
+        return key;
+    }
+}

--- a/src/main/java/de/blau/android/propertyeditor/TagEditorFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/TagEditorFragment.java
@@ -366,7 +366,7 @@ public class TagEditorFragment extends BaseFragment implements PropertyRows, Edi
             } else {
                 updateAutocompletePresetItem(editRowLayout, null, false); // here before preset has been applied
                 PresetItem pi = getBestPreset();
-                if (prefs.autoApplyPreset() && pi != null) {
+                if (elements.length == 1 && prefs.autoApplyPreset() && pi != null) {
                     if (pi.autoapply()) {
                         applyPreset(editRowLayout, pi, false, false, true, false);
                     } else {
@@ -2005,13 +2005,10 @@ public class TagEditorFragment extends BaseFragment implements PropertyRows, Edi
      * @return The LinkedHashMap&lt;String,List&lt;String&gt;&gt; of key-value pairs.
      */
     private LinkedHashMap<String, List<String>> getKeyValueMap(LinearLayout rowLayout, final boolean allowBlanks) {
-
         final LinkedHashMap<String, List<String>> tags = new LinkedHashMap<>();
-
         if (rowLayout == null && savedTags != null) {
             return savedTags;
         }
-
         if (rowLayout != null) {
             processKeyValues(rowLayout, (keyEdit, valueEdit, tagValues) -> {
                 String key = keyEdit.getText().toString().trim();

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -66,6 +66,8 @@
     <string name="file_write_failed_message">Vespucci could not change or save the file.</string>
     <string name="applying_osc_failed_title">Applying the OSC file failed</string>
     <string name="applying_osc_failed_message">Most likely you have not loaded all the original data that is required to apply the changes.</string>
+    <string name="duplicate_tag_key_title">Duplicate keys</string>
+    <string name="duplicate_tag_key_message">You have added the following key more than once, this needs to be resolved before you can proceed:</string>
     <!--  -->
     <string name="welcome_title">Welcome</string>
     <string name="welcome_message">Thank you for installing Vespucci.\n&lt;br&gt;&lt;br&gt;To get started you need to know three things:\n&lt;ul&gt;&lt;li&gt;tapping the lock icon in the upper left corner will switch between locked (no editing) and unlocked mode,&lt;/li&gt;&lt;li&gt;to edit OpenStreetMap you need to download the data for the area where you want to change something first (zoom in before attempting that),&lt;/li&gt;&lt;li&gt;to add a new object: tap the large green button and select what you want to add, then tap the position you want to locate it at.&lt;/li&gt;&lt;/ul&gt;\nYou are all set to go now. Start mapping and have fun!</string>


### PR DESCRIPTION
Previously if duplicate keys were present the last one added would "win", potentially overwriting an existing value with an empty one.

This changes the behaviour so that on the one hand entries with empty values never overwrite entries with values and further stops the user from navigating away from the "Details" tab if they have added duplicated keys.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/1761