### PR TITLE
Indicate that the layer or layer meta data isn't available

### DIFF
--- a/src/main/java/de/blau/android/views/layers/ImageryLayerInfo.java
+++ b/src/main/java/de/blau/android/views/layers/ImageryLayerInfo.java
@@ -49,7 +49,10 @@ public class ImageryLayerInfo extends LayerInfo {
         tp.setMargins(10, 2, 10, 2);
         tableLayout.setColumnShrinkable(1, false);
         tableLayout.setColumnStretchable(2, true);
-        if (layer != null && layer.isMetadataLoaded()) {
+        if (layer == null || !layer.isMetadataLoaded()) {
+            Log.e(DEBUG_TAG, "layer null or meta data not loaded");
+            tableLayout.addView(TableLayoutUtils.createFullRowTitle(activity, activity.getString(R.string.layer_info_layer_not_available), tp));
+        } else {
             tableLayout.addView(TableLayoutUtils.createFullRowTitle(activity, layer.getName(), tp));
             tableLayout.addView(TableLayoutUtils.divider(activity));
             String description = layer.getDescription();
@@ -99,8 +102,6 @@ public class ImageryLayerInfo extends LayerInfo {
                     }
                 }
             }
-        } else {
-            Log.e(DEBUG_TAG, "layer null");
         }
         return sv;
     }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -398,6 +398,7 @@
     <string name="layer_info_privacy_policy">Privacy policy</string>
     <string name="projection">Projection</string>
     <string name="errors">Errors</string>
+    <string name="layer_info_layer_not_available">Layer information not available</string>
     <!--  Mapillary layer -->
     <string name="mapillary_image">mapillary %1$s</string>
     <!-- Photo viewer -->


### PR DESCRIPTION
This is really bing specific as this is the only layer that requires a round trip to a metadata endpoint before the layer can be shown.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/1775