### PR TITLE
Remove search results when search term is too short

### DIFF
--- a/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
+++ b/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
@@ -1121,6 +1121,42 @@ public class PropertyEditorTest {
     }
 
     /**
+     * Search for McDo then delete chars
+     */
+    @Test
+    public void presetSearch2() {
+        final CountDownLatch signal = new CountDownLatch(1);
+        mockServer.enqueue("capabilities1");
+        mockServer.enqueue("download1");
+        Logic logic = App.getLogic();
+        logic.downloadBox(main, new BoundingBox(8.3879800D, 47.3892400D, 8.3844600D, 47.3911300D), false, new SignalHandler(signal));
+        try {
+            signal.await(30, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            fail(e.getMessage());
+        }
+        Node n = (Node) App.getDelegator().getOsmElement(Node.NAME, 577098580L);
+        assertNotNull(n);
+        main.performTagEdit(n, null, false, true);
+        waitForPropertyEditor();
+
+        UiSelector uiSelector = new UiSelector().resourceId(device.getCurrentPackageName() + ":id/preset_search_edit");
+        UiObject field = device.findObject(uiSelector);
+        try {
+            field.click();
+        } catch (UiObjectNotFoundException e) {
+            fail(e.getMessage());
+        }
+        instrumentation.sendCharacterSync(KeyEvent.KEYCODE_M);
+        instrumentation.sendCharacterSync(KeyEvent.KEYCODE_C);
+        instrumentation.sendCharacterSync(KeyEvent.KEYCODE_D);
+        assertTrue(TestUtils.findText(device, false, "MCM", 5000));
+        assertTrue(TestUtils.findText(device, false, "McDonald's", 1000));
+        instrumentation.sendCharacterSync(KeyEvent.KEYCODE_DEL);
+        assertTrue(TestUtils.textGone(device, "McDonald's", 5000));
+    }
+
+    /**
      * Navigate to a specific preset item
      */
     @Test

--- a/src/main/java/de/blau/android/propertyeditor/PresetFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/PresetFragment.java
@@ -58,10 +58,12 @@ import de.blau.android.util.Sound;
 import de.blau.android.util.Util;
 
 public class PresetFragment extends BaseFragment implements PresetUpdate, PresetClickHandler {
+
     private static final String DEBUG_TAG = PresetFragment.class.getSimpleName();
 
-    static final int         MAX_SEARCHRESULTS = 10;
-    private static final int MAX_DISTANCE      = 2;
+    static final int         MAX_SEARCHRESULTS      = 10;
+    private static final int MAX_DISTANCE           = 2;
+    private static final int MIN_SEARCH_TERM_LENGTH = 3;
 
     private static final String ALTERNATE_ROOT_PATHS = "alternateRootPaths";
 
@@ -246,8 +248,7 @@ public class PresetFragment extends BaseFragment implements PresetUpdate, Preset
                         int iconWidth = icon.getBounds().width();
                         if ((rtlLayout && rawX <= outLocation[0] + iconWidth) || (rawX >= outLocation[0] + presetSearch.getWidth() - iconWidth)) {
                             presetSearch.setText("");
-                            final FragmentManager fm = getChildFragmentManager();
-                            de.blau.android.propertyeditor.Util.removeChildFragment(fm, FRAGMENT_PRESET_SEARCH_RESULTS_TAG);
+                            de.blau.android.propertyeditor.Util.removeChildFragment(getChildFragmentManager(), FRAGMENT_PRESET_SEARCH_RESULTS_TAG);
                             return true;
                         }
                     }
@@ -264,10 +265,12 @@ public class PresetFragment extends BaseFragment implements PresetUpdate, Preset
 
                 @Override
                 public void onTextChanged(CharSequence s, int start, int before, int count) {
-                    if (s.length() >= 3) {
-                        displaySearchResults.cancel();
-                        presetSearch.removeCallbacks(displaySearchResults);
+                    displaySearchResults.cancel();
+                    presetSearch.removeCallbacks(displaySearchResults);
+                    if (s.length() >= MIN_SEARCH_TERM_LENGTH) {
                         presetSearch.postDelayed(displaySearchResults, 200);
+                    } else {
+                        de.blau.android.propertyeditor.Util.removeChildFragment(getChildFragmentManager(), FRAGMENT_PRESET_SEARCH_RESULTS_TAG);
                     }
                 }
 
@@ -364,7 +367,6 @@ public class PresetFragment extends BaseFragment implements PresetUpdate, Preset
                             return;
                         }
                     }
-
                     PresetSearchResultsFragment searchResultDialog = (PresetSearchResultsFragment) fm.findFragmentByTag(FRAGMENT_PRESET_SEARCH_RESULTS_TAG);
                     if (searchResultDialog == null) {
                         searchResultDialog = PresetSearchResultsFragment.newInstance(term, result);
@@ -372,7 +374,7 @@ public class PresetFragment extends BaseFragment implements PresetUpdate, Preset
                             Log.d(DEBUG_TAG, "Creating new result fragment");
                             FragmentTransaction ft = fm.beginTransaction();
                             ft.add(R.id.preset_results, searchResultDialog, FRAGMENT_PRESET_SEARCH_RESULTS_TAG);
-                            ft.commit();
+                            ft.commitNow();
                         } catch (IllegalStateException isex) {
                             Log.e(DEBUG_TAG, "show of seach results failed with ", isex);
                         }


### PR DESCRIPTION
This changes the behaviour of the preset search to remove the result fragment if the search term is shorter than chars (currently hardwired).

Further it fixes the race condition that now and then caused two or more result fragments to be added.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/1793