### PR TITLE
Access media location permission fix

### DIFF
--- a/src/main/java/de/blau/android/Main.java
+++ b/src/main/java/de/blau/android/Main.java
@@ -878,10 +878,10 @@ public class Main extends FullScreenAppCompatActivity
      * 
      * @param whenDone run this when finished, use this if you need permissions before an operation is executed
      */
-    private void checkPermissions(Runnable whenDone) {
+    private void checkPermissions(@NonNull Runnable whenDone) {
         final List<String> permissionsList = new ArrayList<>();
         synchronized (locationPermissionLock) {
-            if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+            if (Util.permissionGranted(this, Manifest.permission.ACCESS_FINE_LOCATION)) {
                 locationPermissionGranted = false;
                 if (askedForLocationPermission) {
                     // Should we show an explanation?
@@ -899,7 +899,8 @@ public class Main extends FullScreenAppCompatActivity
             }
         }
         synchronized (storagePermissionLock) {
-            if (ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+            if (Util.permissionGranted(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                    || (prefs.scanMediaStore() && Util.permissionGranted(this, Manifest.permission.ACCESS_MEDIA_LOCATION))) {
                 storagePermissionGranted = false;
                 // Should we show an explanation?
                 if (askedForStoragePermission) {

--- a/src/main/java/de/blau/android/photos/PhotoIndex.java
+++ b/src/main/java/de/blau/android/photos/PhotoIndex.java
@@ -12,7 +12,6 @@ import org.acra.ACRA;
 import android.Manifest;
 import android.content.ContentValues;
 import android.content.Context;
-import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
@@ -26,7 +25,6 @@ import android.provider.MediaStore.MediaColumns;
 import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.content.ContextCompat;
 import de.blau.android.App;
 import de.blau.android.Logic;
 import de.blau.android.contract.MimeTypes;
@@ -36,6 +34,7 @@ import de.blau.android.prefs.Preferences;
 import de.blau.android.util.ACRAHelper;
 import de.blau.android.util.ContentResolverUtil;
 import de.blau.android.util.SavingHelper;
+import de.blau.android.util.Util;
 import de.blau.android.util.rtree.RTree;
 
 /**
@@ -141,8 +140,7 @@ public class PhotoIndex extends SQLiteOpenHelper {
         Logic logic = App.getLogic();
         Preferences prefs = logic != null ? logic.getPrefs() : null;
         if (prefs != null) {
-            final boolean accessMediaLocation = ContextCompat.checkSelfPermission(context,
-                    Manifest.permission.ACCESS_MEDIA_LOCATION) == PackageManager.PERMISSION_GRANTED;
+            final boolean accessMediaLocation = Util.permissionGranted(context, Manifest.permission.ACCESS_MEDIA_LOCATION);
             Log.d(DEBUG_TAG, "ACCESS_MEDIA_LOCATION permission " + accessMediaLocation);
             if (prefs.scanMediaStore() && (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q || accessMediaLocation)) {
                 indexMediaStore();

--- a/src/main/java/de/blau/android/prefs/AdvancedPrefEditorFragment.java
+++ b/src/main/java/de/blau/android/prefs/AdvancedPrefEditorFragment.java
@@ -81,6 +81,7 @@ public class AdvancedPrefEditorFragment extends ExtendedPreferenceFragment {
         setRestartRequiredMessage(R.string.config_autosaveInterval_key);
         setRestartRequiredMessage(R.string.config_autosaveChanges_key);
         setRestartRequiredMessage(R.string.config_autosaveMaxFiles_key);
+        setRestartRequiredMessage(R.string.config_indexMediaStore_key);
         setTitle();
     }
 

--- a/src/main/java/de/blau/android/util/Util.java
+++ b/src/main/java/de/blau/android/util/Util.java
@@ -41,6 +41,7 @@ import android.view.View;
 import android.widget.ScrollView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
 import androidx.core.text.HtmlCompat;
 import androidx.core.view.ViewCompat;
 import androidx.core.widget.NestedScrollView;
@@ -783,5 +784,16 @@ public final class Util {
         }
         implementsInterface(parent, interfaces);
         return parent; // NOSONAR null will cause a ClassCastException to be thrown
+    }
+
+    /**
+     * Check if a permission is granted
+     * 
+     * @param ctx an Android Context
+     * @param permission the permission to check
+     * @return true if the permission has been granted
+     */
+    public static boolean permissionGranted(@NonNull Context ctx, @NonNull String permission) {
+        return ContextCompat.checkSelfPermission(ctx, permission) != PackageManager.PERMISSION_GRANTED;
     }
 }


### PR DESCRIPTION
Older installs don't have ACCESS_MEDIA_LOCATION granted, the PR forces an update by re-asking for WRITE_EXTERNAL_STORAGE if ACCESS_MEDIA_LOCATION is required and not granted. Further we now delay indexing of the photo layer until permissions have been granted.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/1904