### PR TITLE
Reduce superfluous fetches of Bing metadata if layer is visible on start

### DIFF
--- a/src/main/java/de/blau/android/Splash.java
+++ b/src/main/java/de/blau/android/Splash.java
@@ -107,6 +107,7 @@ public class Splash extends AppCompatActivity {
                         if (newInstall || newConfig) {
                             TileLayerSource.createOrUpdateFromAssetsSource(Splash.this, db.getWritableDatabase(), newConfig, true);
                         }
+                        TileLayerSource.getListsLocked(Splash.this, db.getReadableDatabase(), true);
                     }
                 }
                 if (newInstall || newConfig) {

--- a/src/main/java/de/blau/android/dialogs/Layers.java
+++ b/src/main/java/de/blau/android/dialogs/Layers.java
@@ -726,7 +726,7 @@ public class Layers extends AbstractConfigurationDialog {
                             TileLayerDialog.showLayerDialog(activity, rowid, null, () -> {
                                 // the original DB is closed here
                                 try (TileLayerDatabase tlDb2 = new TileLayerDatabase(activity); SQLiteDatabase db2 = tlDb2.getReadableDatabase()) {
-                                    TileLayerSource.getListsLocked(activity, db2, false); // recreate in memory lists
+                                    TileLayerSource.getListsLocked(activity, db2, true); // recreate in memory lists
                                     layer.invalidate();
                                 }
                             });

--- a/src/main/java/de/blau/android/resources/TileLayerDatabaseView.java
+++ b/src/main/java/de/blau/android/resources/TileLayerDatabaseView.java
@@ -185,7 +185,8 @@ public class TileLayerDatabaseView {
                 }
             }
             layer.getTileProvider().update();
-            checkMru(layer, TileLayerSource.getIds(null, false, null, null));
+            checkMru(layer, layer.getType() == LayerType.OVERLAYIMAGERY ? TileLayerSource.getOverlayIds(null, false, null, null)
+                    : TileLayerSource.getIds(null, false, null, null));
         }
     }
 

--- a/src/main/java/de/blau/android/resources/TileLayerSource.java
+++ b/src/main/java/de/blau/android/resources/TileLayerSource.java
@@ -1489,11 +1489,11 @@ public class TileLayerSource implements Serializable {
      * @param category category of layer that should be returned or null for all
      * @return available tile layer IDs.
      */
-    private static String[] getIds(@NonNull Map<String, TileLayerSource> serverList, @Nullable BoundingBox box, boolean filtered, @Nullable TileType tileType,
+    private static String[] getIds(@Nullable Map<String, TileLayerSource> serverList, @Nullable BoundingBox box, boolean filtered, @Nullable TileType tileType,
             @Nullable Category category) {
         List<String> ids = new ArrayList<>();
         synchronized (serverListLock) {
-            if (backgroundServerList != null) {
+            if (serverList != null) {
                 List<TileLayerSource> list = getServersFilteredSorted(filtered, serverList, category, tileType, box);
                 for (TileLayerSource t : list) {
                     ids.add(t.id);

--- a/src/main/java/de/blau/android/services/util/MapTileFilesystemProvider.java
+++ b/src/main/java/de/blau/android/services/util/MapTileFilesystemProvider.java
@@ -397,8 +397,6 @@ public class MapTileFilesystemProvider extends MapAsyncTileProvider {
             Log.d(DEBUG_TAG, "Setting cache size to " + tileCacheSize + " on " + mountPoint.getPath());
             try {
                 result = new MapTileFilesystemProvider(ctx, mountPoint, tileCacheSize * 1024 * 1024); // FSCache
-                // try to get BING layer early so the meta-data is already loaded
-                TileLayerSource.get(ctx, TileLayerSource.LAYER_BING, false);
             } catch (SQLiteException slex) {
                 Log.d(DEBUG_TAG, "Opening DB hit " + slex);
                 Snack.toastTopError(ctx, ctx.getString(R.string.toast_tile_database_issue, slex.getMessage()));

--- a/src/main/java/de/blau/android/views/layers/ImageryLayerInfo.java
+++ b/src/main/java/de/blau/android/views/layers/ImageryLayerInfo.java
@@ -49,9 +49,12 @@ public class ImageryLayerInfo extends LayerInfo {
         tp.setMargins(10, 2, 10, 2);
         tableLayout.setColumnShrinkable(1, false);
         tableLayout.setColumnStretchable(2, true);
-        if (layer == null || !layer.isMetadataLoaded()) {
-            Log.e(DEBUG_TAG, "layer null or meta data not loaded");
+        if (layer == null) {
+            Log.e(DEBUG_TAG, "layer null");
             tableLayout.addView(TableLayoutUtils.createFullRowTitle(activity, activity.getString(R.string.layer_info_layer_not_available), tp));
+        } else if (!layer.isMetadataLoaded()) {
+            Log.e(DEBUG_TAG, "meta data not loaded");
+            tableLayout.addView(TableLayoutUtils.createFullRowTitle(activity, activity.getString(R.string.layer_info_no_meta_data), tp));
         } else {
             tableLayout.addView(TableLayoutUtils.createFullRowTitle(activity, layer.getName(), tp));
             tableLayout.addView(TableLayoutUtils.divider(activity));

--- a/src/main/java/de/blau/android/views/layers/MapTilesLayer.java
+++ b/src/main/java/de/blau/android/views/layers/MapTilesLayer.java
@@ -820,11 +820,20 @@ public class MapTilesLayer<T> extends MapViewLayer implements ExtentInterface, L
                     handler.postDelayed(invalidator, 100); // wait 1/10th of a second
                 }
                 viewInvalidates++;
-            } else if (msg.what == MapTile.MAPTILE_FAIL_ID && msg.arg1 != MapAsyncTileProvider.RETRY) {
-                MapTilesLayer.this.incErrorCount();
-            } else {
-                Log.e(DEBUG_TAG_1, "Unknown message " + msg);
+                return;
+            } else if (msg.what == MapTile.MAPTILE_FAIL_ID) {
+                switch (msg.arg1) {
+                case MapAsyncTileProvider.RETRY:
+                case MapAsyncTileProvider.IOERR:
+                    MapTilesLayer.this.incErrorCount();
+                    return;
+                case MapAsyncTileProvider.NONETWORK:
+                case MapAsyncTileProvider.DOESNOTEXIST:
+                    return; // ignore
+                default: // fall though to log
+                }
             }
+            Log.e(DEBUG_TAG_1, "Unknown message " + msg);
         }
     }
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -405,6 +405,7 @@
     <string name="projection">Projection</string>
     <string name="errors">Errors</string>
     <string name="layer_info_layer_not_available">Layer information not available</string>
+    <string name="layer_info_no_meta_data">Meta data not loaded</string>
     <!--  Mapillary layer -->
     <string name="mapillary_image">mapillary %1$s</string>
     <!-- Photo viewer -->


### PR DESCRIPTION
If the Bing layer was configured on startup the metadata could potentially be fetched multiple times in rapid succession, sometimes leading to Bing refusing connections.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/1784
Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/1910 