### PR TITLE
Add tip for disambiguation menu

### DIFF
--- a/src/androidTest/java/de/blau/android/KeyboardTest.java
+++ b/src/androidTest/java/de/blau/android/KeyboardTest.java
@@ -149,6 +149,7 @@ public class KeyboardTest {
         TestUtils.unlock(device);
 
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
+        TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
         Assert.assertTrue(TestUtils.clickText(device, false, "Path", false, false));
         Way way = App.getLogic().getSelectedWay();
         Assert.assertNotNull(way);

--- a/src/androidTest/java/de/blau/android/TestUtils.java
+++ b/src/androidTest/java/de/blau/android/TestUtils.java
@@ -1502,31 +1502,45 @@ public final class TestUtils {
      * @return true if found
      */
     public static boolean findNotification(@NonNull UiDevice device, @NonNull String app, @NonNull String message) {
-        device.openNotification();
-        boolean found = device.wait(Until.hasObject(By.textContains(message)), 5000);
-        if (!found) {
-            UiObject2 notification = device.findObject(By.textContains(app));
-            if (notification != null) {
-                notification.click();
-                found = device.wait(Until.hasObject(By.textContains(message)), 5000);
+        if (device.openNotification()) {
+            boolean found = device.wait(Until.hasObject(By.textContains(message)), 5000);
+            if (!found) {
+                UiObject2 notification = device.findObject(By.textContains(app));
+                if (notification != null) {
+                    notification.click();
+                    found = device.wait(Until.hasObject(By.textContains(message)), 5000);
+                }
             }
+            UiObject2 clearAll = device.findObject(By.text(Pattern.compile("CLEAR ALL", Pattern.CASE_INSENSITIVE)));
+            if (clearAll != null) {
+                clearAll.click();
+            } else {
+                device.pressBack();
+            }
+            return found;
         }
-        UiObject2 clearAll = device.findObject(By.text(Pattern.compile("CLEAR ALL", Pattern.CASE_INSENSITIVE)));
-        if (clearAll != null) {
-            clearAll.click();
-        } else {
-            device.click(device.getDisplayWidth() / 2, (int) (device.getDisplayHeight() * 0.75));
-        }
-        return found;
+        return false;
     }
 
     /**
      * Disable a tip
      * 
-     * @param ctx an Android COntext
+     * @param ctx an Android Context
      * @param res the tip key
      */
     public static void disableTip(@NonNull Context ctx, int res) {
         PreferenceManager.getDefaultSharedPreferences(ctx).edit().putBoolean(ctx.getString(res), false).commit();
+    }
+
+    /**
+     * Click away a tip dialod
+     * 
+     * @param device the current UiDevice
+     * @param ctx an Android Context
+     */
+    public static void clickAwayTip(@NonNull UiDevice device, @NonNull Context ctx) {
+        if (TestUtils.findText(device, false, ctx.getString(R.string.tip_title))) {
+            TestUtils.clickText(device, false, ctx.getString(R.string.okay), true, false); // TIP
+        }
     }
 }

--- a/src/androidTest/java/de/blau/android/UndoRedoTest.java
+++ b/src/androidTest/java/de/blau/android/UndoRedoTest.java
@@ -79,6 +79,7 @@ public class UndoRedoTest {
     @Test
     public void dialog() {
         TestUtils.clickAtCoordinates(device, map, 8.38782, 47.390339, true);
+        TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
         TestUtils.clickText(device, false, "Toilets", false, false);
         TestUtils.sleep();
         Node node = App.getLogic().getSelectedNode();

--- a/src/androidTest/java/de/blau/android/easyedit/ExtendedSelectionTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/ExtendedSelectionTest.java
@@ -88,6 +88,7 @@ public class ExtendedSelectionTest {
         TestUtils.unlock(device);
         TestUtils.sleep(2000);
         TestUtils.clickAtCoordinates(device, map, 8.38782, 47.390339, true);
+        TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
         TestUtils.findText(device, false, "Toilets", 10000);
         assertTrue(TestUtils.clickText(device, false, "Toilets", false, false));
         Node node = App.getLogic().getSelectedNode();
@@ -126,6 +127,7 @@ public class ExtendedSelectionTest {
         TestUtils.unlock(device);
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
+        TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
         assertTrue(TestUtils.clickText(device, false, "Path", false, false));
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_wayselect)));
         Way way = App.getLogic().getSelectedWay();

--- a/src/androidTest/java/de/blau/android/easyedit/NodeTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/NodeTest.java
@@ -89,6 +89,7 @@ public class NodeTest {
     @Test
     public void selectNode() {
         TestUtils.clickAtCoordinates(device, map, 8.38782, 47.390339, true);
+        TestUtils.clickAwayTip(device, context); 
         assertTrue(TestUtils.clickText(device, false, "Toilets", true, false, 5000));
         Node node = App.getLogic().getSelectedNode();
         assertNotNull(node);
@@ -118,6 +119,7 @@ public class NodeTest {
     @Test
     public void dragNode() {
         TestUtils.clickAtCoordinates(device, map, 8.38782, 47.390339, true);
+        TestUtils.clickAwayTip(device, context); 
         assertTrue(TestUtils.clickText(device, false, "Toilets", true, false, 5000));
         Node node = App.getLogic().getSelectedNode();
         assertNotNull(node);
@@ -160,6 +162,7 @@ public class NodeTest {
         assertEquals(OsmElement.STATE_UNCHANGED, unjoinedWay.getState());
 
         TestUtils.clickAtCoordinates(device, map, 8.3874964, 47.3884769, false);
+        TestUtils.clickAwayTip(device, context); 
         assertTrue(TestUtils.clickText(device, false, "node", false, false)); // the first node in the list
         assertTrue(TestUtils.clickMenuButton(device, context.getString(R.string.menu_merge), false, true));
 
@@ -187,6 +190,7 @@ public class NodeTest {
         assertEquals(apiNodeCount + 3, delegator.getApiNodeCount());
 
         TestUtils.clickAtCoordinates(device, map, 8.3866386, 47.3904394, false);
+        TestUtils.clickAwayTip(device, context); 
         assertTrue(TestUtils.clickText(device, false, "node", false, false)); // the first node in the list
         assertTrue(TestUtils.clickMenuButton(device, context.getString(R.string.menu_merge), false, true));
 

--- a/src/androidTest/java/de/blau/android/easyedit/RelationTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/RelationTest.java
@@ -98,6 +98,7 @@ public class RelationTest {
         TestUtils.unlock(device);
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
+        TestUtils.clickAwayTip(device, context);
         assertTrue(TestUtils.clickText(device, false, "Hiking", false, false));
         List<Relation> rels = App.getLogic().getSelectedRelations();
         assertNotNull(rels);
@@ -114,7 +115,7 @@ public class RelationTest {
         assertEquals(OsmElement.STATE_DELETED, relation.getState());
         assertTrue(TestUtils.clickMenuButton(device, context.getString(R.string.undo), false, false));
         assertEquals(OsmElement.STATE_UNCHANGED, relation.getState());
-        TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // for the tip alert
+        TestUtils.clickAwayTip(device, context);
         assertNotNull(relation.getMember(Way.NAME, 104148456L));
         List<RelationMember> members = relation.getMembers();
         assertEquals(origMembers.size(), members.size());
@@ -133,6 +134,7 @@ public class RelationTest {
         TestUtils.unlock(device);
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
+        TestUtils.clickAwayTip(device, context);
         assertTrue(TestUtils.findText(device, false, "Path", 2000));
         assertTrue(TestUtils.clickText(device, false, "Path", false, false));
         Way way = App.getLogic().getSelectedWay();
@@ -185,8 +187,8 @@ public class RelationTest {
         TestUtils.clickAtCoordinates(device, map, 8.3882060, 47.3885768, true);
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_wayselect)));
         assertTrue(TestUtils.clickMenuButton(device, "Split", false, true));
+        TestUtils.clickAwayTip(device, context);
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_closed_way_split_1)));
-        TestUtils.clickText(device, false, context.getString(R.string.okay), true, false); // TIP
         TestUtils.clickAtCoordinates(device, map, 8.3881251, 47.3885077, true);
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_closed_way_split_2)));
         TestUtils.clickAtCoordinates(device, map, 8.3881577, 47.3886924, true);

--- a/src/androidTest/java/de/blau/android/easyedit/SaveResumeTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/SaveResumeTest.java
@@ -109,6 +109,7 @@ public class SaveResumeTest {
         TestUtils.unlock(device);
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
+        TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
         assertTrue(TestUtils.clickText(device, false, "Path", false, false));
         Way way = App.getLogic().getSelectedWay();
         assertNotNull(way);
@@ -169,6 +170,7 @@ public class SaveResumeTest {
         TestUtils.unlock(device);
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
+        TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
         TestUtils.clickText(device, false, "Path", false, false);
         Way way = App.getLogic().getSelectedWay();
         assertNotNull(way);

--- a/src/androidTest/java/de/blau/android/easyedit/SimpleActionsTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/SimpleActionsTest.java
@@ -344,6 +344,7 @@ public class SimpleActionsTest {
         TestUtils.drag(device, map, 8.3890736, 47.3896628, 8.3893, 47.3899, true, 20);
 
         TestUtils.clickAtCoordinates(device, map, 8.3893, 47.3899, true);
+        TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
         assertTrue(TestUtils.findText(device, false, "test"));
         assertTrue(TestUtils.clickText(device, true, context.getString(R.string.cancel), true, false));
     }

--- a/src/androidTest/java/de/blau/android/easyedit/WayActionsTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/WayActionsTest.java
@@ -151,6 +151,7 @@ public class WayActionsTest {
         TestUtils.unlock(device);
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
+        TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
         assertTrue(TestUtils.clickText(device, false, "Path", false, false));
         Way way = App.getLogic().getSelectedWay();
         List<Node> origWayNodes = new ArrayList<>(way.getNodes());
@@ -195,6 +196,7 @@ public class WayActionsTest {
         TestUtils.unlock(device);
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
+        TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
         assertTrue(TestUtils.clickText(device, false, "Path", false, false));
         Way way = App.getLogic().getSelectedWay();
         assertNotNull(way);
@@ -245,6 +247,7 @@ public class WayActionsTest {
         TestUtils.unlock(device);
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3884403, 47.3884988, true);
+        TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
         assertTrue(TestUtils.clickText(device, false, "Bergstrasse", true, false));
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_wayselect)));
         Way way = App.getLogic().getSelectedWay();
@@ -307,6 +310,7 @@ public class WayActionsTest {
         TestUtils.unlock(device);
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3884403, 47.3884988, true);
+        TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
         assertTrue(TestUtils.clickText(device, false, "Bergstrasse", false, false));
         Way way = App.getLogic().getSelectedWay();
         assertNotNull(way);
@@ -457,6 +461,7 @@ public class WayActionsTest {
             TestUtils.unlock(device);
             TestUtils.zoomToLevel(device, main, 21);
             TestUtils.clickAtCoordinates(device, map, 8.3884403, 47.3884988, true);
+            TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
             assertTrue(TestUtils.clickText(device, false, "Bergstrasse", false, false));
             Way way = App.getLogic().getSelectedWay();
             assertNotNull(way);

--- a/src/androidTest/java/de/blau/android/easyedit/WayTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/WayTest.java
@@ -100,6 +100,7 @@ public class WayTest {
         TestUtils.unlock(device);
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
+        TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
         assertTrue(TestUtils.clickText(device, false, "Path", false, false));
         Way way = App.getLogic().getSelectedWay();
         assertNotNull(way);
@@ -159,6 +160,7 @@ public class WayTest {
         TestUtils.unlock(device);
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
+        TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
         assertTrue(TestUtils.clickText(device, false, "Path", false, false));
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_wayselect)));
         Way way = App.getLogic().getSelectedWay();
@@ -185,7 +187,7 @@ public class WayTest {
         assertNotNull(way);
         assertTrue(way.hasNode(node));
     }
-    
+
     /**
      * Select, split selecting part
      */
@@ -196,6 +198,7 @@ public class WayTest {
         TestUtils.unlock(device);
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
+        TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
         assertTrue(TestUtils.clickText(device, false, "Path", false, false));
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_wayselect)));
         Way way = App.getLogic().getSelectedWay();
@@ -227,6 +230,7 @@ public class WayTest {
         TestUtils.unlock(device);
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
+        TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
         assertTrue(TestUtils.clickText(device, false, "Path", false, false));
         Way way = App.getLogic().getSelectedWay();
         assertNotNull(way);
@@ -258,6 +262,7 @@ public class WayTest {
         TestUtils.unlock(device);
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
+        TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
         assertTrue(TestUtils.clickText(device, false, "Path", false, false));
         Way way = App.getLogic().getSelectedWay();
         assertNotNull(way);
@@ -293,6 +298,7 @@ public class WayTest {
         TestUtils.unlock(device);
         TestUtils.zoomToLevel(device, main, 22);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
+        TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
         assertTrue(TestUtils.clickText(device, false, "Path", false, false));
         Way way = App.getLogic().getSelectedWay();
         List<Node> origWayNodes = new ArrayList<>(way.getNodes());
@@ -337,7 +343,8 @@ public class WayTest {
         TestUtils.unlock(device);
         TestUtils.zoomToLevel(device, main, 22);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
-        assertTrue(TestUtils.clickText(device, false, "Path", false, false));
+        TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
+        assertTrue(TestUtils.clickText(device, false, "Path", false, false)); 
         Way way = App.getLogic().getSelectedWay();
         assertNotNull(way);
         assertEquals(104148456L, way.getOsmId());
@@ -390,6 +397,7 @@ public class WayTest {
         TestUtils.unlock(device);
         TestUtils.zoomToLevel(device, main, 22);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
+        TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
         assertTrue(TestUtils.clickText(device, false, "Path", false, false));
         Way way = App.getLogic().getSelectedWay();
         assertNotNull(way);

--- a/src/androidTest/java/de/blau/android/layer/LayerDialogTest.java
+++ b/src/androidTest/java/de/blau/android/layer/LayerDialogTest.java
@@ -148,6 +148,7 @@ public class LayerDialogTest {
         assertFalse(map.getDataLayer().isVisible());
         TestUtils.unlock(device);
         TestUtils.clickAtCoordinates(device, map, 8.38782, 47.390339, false);
+        TestUtils.clickText(device, true, main.getString(R.string.okay), true, false); // Tip
         assertFalse(TestUtils.clickText(device, false, "Toilets", false, false)); // nothing should happen
         visibleButton = TestUtils.getLayerButton(device, dataLayerName, VISIBLE_BUTTON);
         visibleButton.click();

--- a/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
+++ b/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
@@ -548,6 +548,7 @@ public class PropertyEditorTest {
         TestUtils.unlock(device);
         TestUtils.zoomToLevel(device, main, 22);
         TestUtils.clickAtCoordinates(device, main.getMap(), 8.3848461, 47.3899166, true);
+        TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
         assertTrue(TestUtils.clickText(device, false, "Kindhauserstrasse", false, false));
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_wayselect)));
         Way w = App.getLogic().getSelectedWay();
@@ -684,6 +685,7 @@ public class PropertyEditorTest {
         TestUtils.unlock(device);
         TestUtils.zoomToLevel(device, main, 22);
         TestUtils.clickAtCoordinates(device, main.getMap(), 8.3848461, 47.3899166, true);
+        TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
         assertTrue(TestUtils.clickText(device, false, "Kindhauserstrasse", false, false));
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_wayselect)));
         Way w = App.getLogic().getSelectedWay();

--- a/src/androidTest/java/de/blau/android/tasks/TodoTest.java
+++ b/src/androidTest/java/de/blau/android/tasks/TodoTest.java
@@ -95,6 +95,7 @@ public class TodoTest {
     @Test
     public void addAndCloseTodo() {
         TestUtils.clickAtCoordinates(device, map, 8.38782, 47.390339, true);
+        TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
         assertTrue(TestUtils.clickText(device, false, "Toilets", true, false, 5000));
         Node node = App.getLogic().getSelectedNode();
         assertNotNull(node);

--- a/src/main/java/de/blau/android/Map.java
+++ b/src/main/java/de/blau/android/Map.java
@@ -30,6 +30,8 @@ import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
+import androidx.fragment.app.FragmentActivity;
+import de.blau.android.dialogs.Tip;
 import de.blau.android.exception.OsmException;
 import de.blau.android.imageryoffset.ImageryOffsetUtils;
 import de.blau.android.imageryoffset.Offset;
@@ -1297,5 +1299,13 @@ public class Map extends View implements IMapView {
     @Nullable
     public TrackerService getTracker() {
         return this.tracker;
+    }
+    
+    @Override
+    public boolean showContextMenu() {
+        if (context instanceof FragmentActivity) {
+            Tip.showDialog((FragmentActivity) context, R.string.tip_disambiguation_menu_key, R.string.tip_disambiguation_menu);
+        }
+        return super.showContextMenu();
     }
 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -469,6 +469,7 @@
     <string name="tip_no_redo">This mode currently doesn\'t support redoing node additions.</string>
     <string name="tip_way_splitting">Touch a highlighted node to determine the split position. A long touch will allow you to select which part is used for the new way in a further step.</string>
     <string name="tip_closed_way_splitting">A closed way has to be split in two places. Touch a highlighted node to determine the 1st split position, the next step will ask you to select the 2nd position.</string>
+    <string name="tip_disambiguation_menu">When multiple OSM elements or other objects are very close together or elements are members of relations the disambiguation menu will be displayed. You can then select the specific element from the list.&lt;p&gt;If an element is currently already selcted it will be highlighted.</string>
     <!--  NumberPicker -->
     <string name="plus_sign">+</string>
     <string name="minus_sign">-</string>

--- a/src/main/res/values/tipkeys.xml
+++ b/src/main/res/values/tipkeys.xml
@@ -20,4 +20,5 @@
     <string name="tip_no_redo_key">noRedo</string>
     <string name="tip_way_splitting_key">waySplitting</string>
     <string name="tip_closed_way_splitting_key">closedWaySplitting</string>
+    <string name="tip_disambiguation_menu_key">disambiguationMenu</string>
 </resources>


### PR DESCRIPTION
Instead of adding a title to the menu, that just costs screen real estate, this adds a tip on the 1st display of the disambiguation menu.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/1716