### PR TITLE
Stop saveEditingState from overwriting non-loaded state

### DIFF
--- a/src/androidTest/java/de/blau/android/tasks/TodoTest.java
+++ b/src/androidTest/java/de/blau/android/tasks/TodoTest.java
@@ -113,7 +113,7 @@ public class TodoTest {
             fail(e.getMessage());
         }
         // assertTrue(TestUtils.clickText(device, false, context.getString(R.string.add), false, false));
-        assertTrue(TestUtils.clickResource(device, false, "android:id/button1", false));
+        assertTrue(TestUtils.clickResource(device, false, "android:id/button1", true));
         List<Todo> todos = App.getTaskStorage().getTodosForElement(node);
         assertEquals(1, todos.size());
         TestUtils.clickAtCoordinates(device, map, 8.38782, 47.390339, true);

--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -3810,7 +3810,7 @@ public class Logic {
      * @param main instance of main to setup
      * @param setViewBox set the view box if true
      */
-    synchronized void loadEditingState(@NonNull Main main, boolean setViewBox) {
+    void loadEditingState(@NonNull Main main, boolean setViewBox) {
         EditState editState = new SavingHelper<EditState>().load(main, EDITSTATE_FILENAME, false, false, true);
         if (editState != null) { //
             editState.setMiscState(main, this);
@@ -3891,7 +3891,9 @@ public class Logic {
                         }
                         DataStyle.updateStrokes(STROKE_FACTOR / viewBox.getWidth()); // safety measure if not done in
                                                                                      // loadEiditngState
-                        loadEditingState((Main) activity, true);
+                        synchronized (Logic.this) {
+                            loadEditingState((Main) activity, true);
+                        }
                     } else {
                         Log.e(DEBUG_TAG, "loadFromFile map is null");
                     }

--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -330,6 +330,8 @@ public class Logic {
     private ExecutorService executorService;
     private Handler         uiHandler;
 
+    private boolean editingStateRead = false; // set to true after we have read the editing state
+
     /**
      * Initiate all needed values. Starts Tracker and delegate the first values for the map.
      * 
@@ -3793,9 +3795,13 @@ public class Logic {
      * @param main the current Main instance
      */
     synchronized void saveEditingState(@NonNull Main main) {
-        EditState editState = new EditState(main, this, main.getImageFileName(), viewBox, main.getFollowGPS(), prefs.getServer().getOpenChangeset());
-        new SavingHelper<EditState>().save(main, EDITSTATE_FILENAME, editState, false, true);
-        main.getEasyEditManager().saveState();
+        if (editingStateRead) {
+            EditState editState = new EditState(main, this, main.getImageFileName(), viewBox, main.getFollowGPS(), prefs.getServer().getOpenChangeset());
+            new SavingHelper<EditState>().save(main, EDITSTATE_FILENAME, editState, false, true);
+            main.getEasyEditManager().saveState();
+        } else {
+            Log.w(DEBUG_TAG, "EditingState not loaded skipping save");
+        }
     }
 
     /**
@@ -3804,7 +3810,7 @@ public class Logic {
      * @param main instance of main to setup
      * @param setViewBox set the view box if true
      */
-    void loadEditingState(@NonNull Main main, boolean setViewBox) {
+    synchronized void loadEditingState(@NonNull Main main, boolean setViewBox) {
         EditState editState = new SavingHelper<EditState>().load(main, EDITSTATE_FILENAME, false, false, true);
         if (editState != null) { //
             editState.setMiscState(main, this);
@@ -3813,6 +3819,7 @@ public class Logic {
                 editState.setViewBox(this, main.getMap());
             }
         }
+        editingStateRead = true;
     }
 
     /**


### PR DESCRIPTION
In situation in which loading the data state takes a long time the saved editing state could be overwritten by the main activity pausing and saving the state before it had been read for the 1st time.

Probably fixes https://github.com/MarcusWolschon/osmeditor4android/issues/1719 and other similar glitches 