### PR TITLE
Add monochromatic icons

### DIFF
--- a/src/main/res/mipmap-anydpi-v26/vespucci_help_logo.xml
+++ b/src/main/res/mipmap-anydpi-v26/vespucci_help_logo.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/vespucci_logo_background"/>
     <foreground android:drawable="@drawable/vespucci_logo_foreground"/>
+    <monochrome android:drawable="@drawable/vespucci_logo_foreground"/>
 </adaptive-icon>

--- a/src/main/res/mipmap-anydpi-v26/vespucci_logo.xml
+++ b/src/main/res/mipmap-anydpi-v26/vespucci_logo.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/vespucci_logo_background"/>
     <foreground android:drawable="@drawable/vespucci_logo_foreground"/>
+    <monochrome android:drawable="@drawable/vespucci_logo_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
This change adds support for Android 13's monochromatic icons.