### PR TITLE
Allow increments larger than 2 when predicting addresses

### DIFF
--- a/documentation/docs/help/en/Advanced preferences.md
+++ b/documentation/docs/help/en/Advanced preferences.md
@@ -142,6 +142,10 @@ When using address prediction only add the tags configured here.
 
 Automatically apply the best matching preset when the property editor is invoked. This will add keys for all non-optional tags. Default: _on_.
 
+### Distance between neighbour addresses
+
+The distance in meters up to which two addresses are considered to be potential neighbours, this is useful for fine tuning how the increment used for predicting addresses is calculated. Default: _50 meters_.
+
 ### Enable name suggestions
 
 Support special handling of name tags with canonical name suggestions. Default: _on_.

--- a/src/main/assets/help/en/Advanced preferences.html
+++ b/src/main/assets/help/en/Advanced preferences.html
@@ -77,6 +77,8 @@
 <p>When using address prediction only add the tags configured here.</p>
 <h3>Enable auto-apply of preset</h3>
 <p>Automatically apply the best matching preset when the property editor is invoked. This will add keys for all non-optional tags. Default: <em>on</em>.</p>
+<h3>Distance between neighbour addresses</h3>
+<p>The distance in meters up to which two addresses are considered to be potential neighbours, this is useful for fine tuning how the increment used for predicting addresses is calculated. Default: <em>50 meters</em>.</p>
 <h3>Enable name suggestions</h3>
 <p>Support special handling of name tags with canonical name suggestions. Default: <em>on</em>.</p>
 <h3>Enable name suggestion presets</h3>

--- a/src/main/java/de/blau/android/prefs/Preferences.java
+++ b/src/main/java/de/blau/android/prefs/Preferences.java
@@ -86,6 +86,7 @@ public class Preferences {
     private final boolean     lightThemeEnabled;
     private final boolean     overrideCountryAddressTags;
     private final Set<String> addressTags;
+    private final int         neighbourDistance;
     private final boolean     voiceCommandsEnabled;
     private final boolean     leaveGpsDisabled;
     private final boolean     allowFallbackToNetworkLocation;
@@ -223,6 +224,8 @@ public class Preferences {
 
         addressTags = prefs.getStringSet(r.getString(R.string.config_addressTags_key),
                 new HashSet<>(Arrays.asList(r.getStringArray(R.array.address_tags_defaults))));
+
+        neighbourDistance = getIntPref(R.string.config_neighbourDistance_key, 50);
 
         voiceCommandsEnabled = prefs.getBoolean(r.getString(R.string.config_voiceCommandsEnabled_key), false);
 
@@ -917,6 +920,15 @@ public class Preferences {
      */
     public Set<String> addressTags() {
         return addressTags;
+    }
+
+    /**
+     * Get the distance in meters up to which two addresses are considered neighbours
+     * 
+     * @return a distance in meters
+     */
+    public int getNeighbourDistance() {
+        return neighbourDistance;
     }
 
     /**

--- a/src/main/res/values/prefkeys.xml
+++ b/src/main/res/values/prefkeys.xml
@@ -122,6 +122,7 @@
     <string name="config_beepVolume_key">beepVolume</string>
     <string name="config_maxOffsetDistance_key">maxOffsetDistance</string>
     <string name="config_mapillary_min_zoom_key">mapillaryMinZoom</string>
+    <string name="config_neighbourDistance_key">neighbourDistance</string>
     <string name="gps_source_internal">internal</string>
     <string name="gps_source_nmea">nmea</string>
     <string name="gps_source_tcpclient">tcpclient</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1182,6 +1182,9 @@
     <string name="config_overrideRegionAddressTags_summary">Use our address tag configuration over any region specific values</string>             
     <string name="config_address_tags">Address tags</string>
     <string name="config_address_tags_summary">Tags used for address prediction.</string>
+    <string name="config_neighbourDistance_title">Distance between neighbour addresses</string>
+    <string name="config_neighbourDistance_summary">The distance up to which two addresses are considered to be potential neighbours</string>
+    <string name="config_neighbourDistance_current">%1$d meter(s)</string>
     <string name="config_enableNameSuggestions_title">Enable name suggestions</string>
     <string name="config_enableNameSuggestions_summary">Turn on suggestions for the name tag.</string>
     <string name="config_enableNameSuggestionsPresets_title">Enable name suggestion presets</string>

--- a/src/main/res/xml-v19/advancedpreferences.xml
+++ b/src/main/res/xml-v19/advancedpreferences.xml
@@ -244,6 +244,18 @@
             android:key="@string/config_autoApplyPreset_key"
             android:summary="@string/config_autoApplyPreset_summary"
             android:title="@string/config_autoApplyPreset_title" />
+        <ch.poole.android.numberpickerpreference.NumberPickerPreference
+            android:defaultValue="50"
+            android:dialogTitle="@string/config_neighbourDistance_title"
+            android:key="@string/config_neighbourDistance_key"
+            android:numeric="integer"
+            android:summary="@string/config_neighbourDistance_summary"
+            android:title="@string/config_neighbourDistance_title"
+            app:spt_maxValue="100"
+            app:spt_minValue="0"
+            app:spt_increment="5"
+            app:spt_currentValueText="@string/config_neighbourDistance_current"
+            app:spt_setWrapSelectorWheel="false" />
         <androidx.preference.CheckBoxPreference
             android:defaultValue="true"
             android:key="@string/config_enableNameSuggestions_key"

--- a/src/main/res/xml-v24/advancedpreferences.xml
+++ b/src/main/res/xml-v24/advancedpreferences.xml
@@ -244,6 +244,18 @@
             android:key="@string/config_autoApplyPreset_key"
             android:summary="@string/config_autoApplyPreset_summary"
             android:title="@string/config_autoApplyPreset_title" />
+        <ch.poole.android.numberpickerpreference.NumberPickerPreference
+            android:defaultValue="50"
+            android:dialogTitle="@string/config_neighbourDistance_title"
+            android:key="@string/config_neighbourDistance_key"
+            android:numeric="integer"
+            android:summary="@string/config_neighbourDistance_summary"
+            android:title="@string/config_neighbourDistance_title"
+            app:spt_maxValue="100"
+            app:spt_minValue="0"
+            app:spt_increment="5"
+            app:spt_currentValueText="@string/config_neighbourDistance_current"
+            app:spt_setWrapSelectorWheel="false" />
         <androidx.preference.CheckBoxPreference
             android:defaultValue="true"
             android:key="@string/config_enableNameSuggestions_key"

--- a/src/main/res/xml/advancedpreferences.xml
+++ b/src/main/res/xml/advancedpreferences.xml
@@ -239,6 +239,18 @@
             android:entries="@array/address_tags_entries"
             android:entryValues="@array/address_tags_values"
             android:defaultValue="@array/address_tags_defaults" />
+        <ch.poole.android.numberpickerpreference.NumberPickerPreference
+            android:defaultValue="50"
+            android:dialogTitle="@string/config_neighbourDistance_title"
+            android:key="@string/config_neighbourDistance_key"
+            android:numeric="integer"
+            android:summary="@string/config_neighbourDistance_summary"
+            android:title="@string/config_neighbourDistance_title"
+            app:spt_maxValue="100"
+            app:spt_minValue="0"
+            app:spt_increment="5"
+            app:spt_currentValueText="@string/config_neighbourDistance_current"
+            app:spt_setWrapSelectorWheel="false" />
         <androidx.preference.CheckBoxPreference
             android:defaultValue="true"
             android:key="@string/config_autoApplyPreset_key"


### PR DESCRIPTION
This modifies how we calculate house number increments when predicting addresses to allow increments larger than 2 if the addresses are closer together than a pre-defined value. Default 50m, setting the value to 0 will "nearly" replicate the previous behaviour.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/1998