### PR TITLE
Fix missing membership in relation membership display

### DIFF
--- a/src/main/java/de/blau/android/osm/RelationMember.java
+++ b/src/main/java/de/blau/android/osm/RelationMember.java
@@ -112,7 +112,7 @@ public class RelationMember implements Serializable {
      * 
      * @param e the OsmElement
      */
-    public synchronized void setElement(final OsmElement e) {
+    public synchronized void setElement(@Nullable final OsmElement e) {
         element = e;
     }
 

--- a/src/main/java/de/blau/android/osm/RelationMemberPosition.java
+++ b/src/main/java/de/blau/android/osm/RelationMemberPosition.java
@@ -71,6 +71,17 @@ public class RelationMemberPosition implements Serializable {
         this.position = postiion;
     }
 
+    /**
+     * Copy the provided ReplationMemberPosition but with keeping the OSMElement reference
+     * 
+     * @param rmp the RelationMemberPosition to copy
+     * @return a copy
+     */
+    public static RelationMemberPosition copyWithoutElement(@NonNull RelationMemberPosition rmp) {
+        RelationMember rm = rmp.getRelationMember();
+        return new RelationMemberPosition(new RelationMember(rm.getType(), rm.getRef(), rm.getRole()), rmp.getPosition());
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;

--- a/src/main/java/de/blau/android/propertyeditor/PropertyEditorData.java
+++ b/src/main/java/de/blau/android/propertyeditor/PropertyEditorData.java
@@ -4,8 +4,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Set;
 
 import android.util.Log;
 import androidx.annotation.NonNull;
@@ -52,14 +50,11 @@ public class PropertyEditorData implements Serializable {
         originalTags = tags;
         MultiHashMap<Long, RelationMemberPosition> tempParents = new MultiHashMap<>(false, true);
         if (selectedElement.getParentRelations() != null) {
-            Set<Relation> uniqueRelations = new HashSet<>(selectedElement.getParentRelations());
-            for (Relation r : uniqueRelations) {
-                List<RelationMember> allMembers = r.getAllMembers(selectedElement);
-                for (RelationMember rm : allMembers) {
-                    if (rm != null) {
-                        // we don't need to actually reference the member
-                        RelationMemberPosition rmp = new RelationMemberPosition(new RelationMember(rm.getType(), rm.getRef(), rm.getRole()), r.getPosition(rm));
-                        tempParents.add(r.getOsmId(), rmp);
+            for (Relation r : new HashSet<>(selectedElement.getParentRelations())) {
+                for (RelationMemberPosition rmp : r.getAllMembersWithPosition(selectedElement)) {
+                    if (rmp != null) {
+                        // we don't need to actually reference the member element, so we create a new RelationMember
+                        tempParents.add(r.getOsmId(), RelationMemberPosition.copyWithoutElement(rmp));
                     } else {
                         Log.e(DEBUG_TAG, "inconsistency in relation membership");
                         ACRAHelper.nocrashReport(null, "inconsistency in relation membership");

--- a/src/main/java/de/blau/android/propertyeditor/RelationMembershipFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/RelationMembershipFragment.java
@@ -86,7 +86,7 @@ public class RelationMembershipFragment extends BaseFragment implements Property
      * @return a new RelationMembershipFragment instance
      */
     @NonNull
-    public static RelationMembershipFragment newInstance(MultiHashMap<Long, RelationMemberPosition> parents, String type) {
+    public static RelationMembershipFragment newInstance(@Nullable MultiHashMap<Long, RelationMemberPosition> parents, @NonNull String type) {
         RelationMembershipFragment f = new RelationMembershipFragment();
 
         Bundle args = new Bundle();
@@ -137,7 +137,7 @@ public class RelationMembershipFragment extends BaseFragment implements Property
             parents = (MultiHashMap<Long, RelationMemberPosition>) getArguments().getSerializable(PARENTS_KEY);
             elementType = getArguments().getString(ELEMENT_TYPE_KEY);
         }
-
+        
         Preferences prefs = App.getLogic().getPrefs();
         Server server = prefs.getServer();
         maxStringLength = server.getCachedCapabilities().getMaxStringLength();

--- a/src/test/java/de/blau/android/propertyeditor/PropertyEditorDataTest.java
+++ b/src/test/java/de/blau/android/propertyeditor/PropertyEditorDataTest.java
@@ -1,0 +1,65 @@
+package de.blau.android.propertyeditor;
+
+import static de.blau.android.osm.DelegatorUtil.toE7;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import androidx.test.filters.LargeTest;
+import de.blau.android.App;
+import de.blau.android.Logic;
+import de.blau.android.osm.Node;
+import de.blau.android.osm.OsmElementFactory;
+import de.blau.android.osm.Relation;
+import de.blau.android.osm.RelationMember;
+import de.blau.android.osm.RelationMemberPosition;
+import de.blau.android.osm.StorageDelegator;
+import de.blau.android.osm.Way;
+
+@RunWith(RobolectricTestRunner.class)
+@LargeTest
+public class PropertyEditorDataTest {
+
+    /**
+     * Test that parent relations are handled properly
+     */
+    @Test
+    public void sameRoleInParents() {
+        StorageDelegator d = new StorageDelegator();
+        OsmElementFactory factory = d.getFactory();
+        Node n1 = factory.createNodeWithNewId(toE7(51.476), toE7(0.006));
+        d.insertElementSafe(n1);
+        Node n2 = factory.createNodeWithNewId(toE7(51.476), toE7(0.006));
+        d.insertElementSafe(n2);
+
+        Relation r = factory.createRelationWithNewId();
+        RelationMember member1 = new RelationMember("", n1);
+        List<RelationMember> members = new ArrayList<>();
+        members.add(member1);
+        RelationMember member2 = new RelationMember("test2", n2);
+        members.add(member2);
+        RelationMember member3 = new RelationMember(Way.NAME, 1234567L, "test3");
+        members.add(member3);
+        RelationMember member4 = new RelationMember("", n1);
+        members.add(member4);
+        App.newLogic();
+        Logic logic = App.getLogic();
+        logic.addRelationMembers(null, r, members);
+
+        PropertyEditorData pd = new PropertyEditorData(n1, null);
+
+        Set<RelationMemberPosition> rmds = pd.parents.get(r.getOsmId());
+        assertNotNull(rmds);
+        assertEquals(2, rmds.size());
+        List<RelationMemberPosition> rmdList = new ArrayList<>(rmds);
+        assertEquals(0, rmdList.get(0).getPosition());
+        assertEquals(3, rmdList.get(1).getPosition());
+    }
+}


### PR DESCRIPTION
If a multiple relation memberships of the same element had the same (or no role) the relation membership tab in the property editor would only show one.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/2007