### PR TITLE
Support selection of segment for the new way when splitting in all modes

### DIFF
--- a/src/main/java/de/blau/android/Main.java
+++ b/src/main/java/de/blau/android/Main.java
@@ -3539,7 +3539,7 @@ public class Main extends FullScreenAppCompatActivity
                 return true;
             }
             if (logic.isInEditZoomRange()) {
-                if (prefs.areSimpleActionsEnabled()) {
+                if (prefs.areSimpleActionsEnabled() || getEasyEditManager().usesLongClick()) {
                     if (elementCount == 1 && getEasyEditManager().handleLongClick(v, clickedNodesAndWays.get(0))) {
                         return true;
                     }

--- a/src/main/java/de/blau/android/easyedit/EasyEditActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/EasyEditActionModeCallback.java
@@ -164,6 +164,15 @@ public abstract class EasyEditActionModeCallback implements ActionMode.Callback 
     public boolean handleElementLongClick(@NonNull OsmElement element) {
         return false;
     }
+    
+    /**
+     * Indicate if the mode uses long clicks internally
+     * 
+     * @return true if the mode uses long click
+     */
+    public boolean usesLongClick() {
+        return false;
+    }
 
     /**
      * Check if the mode only supports selection of OSM elements

--- a/src/main/java/de/blau/android/easyedit/EasyEditManager.java
+++ b/src/main/java/de/blau/android/easyedit/EasyEditManager.java
@@ -393,7 +393,18 @@ public class EasyEditManager {
     }
 
     /**
-     * This gets called when the map is long-clciked in easy-edit mode
+     * Indicate if the current mode uses long click internally, that is not for new nodes and ways
+     * 
+     * @return true if the current mode uses long click
+     */
+    public boolean usesLongClick() {
+        synchronized (actionModeCallbackLock) {
+            return currentActionModeCallback != null && currentActionModeCallback.usesLongClick();
+        }
+    }
+
+    /**
+     * This gets called when the map is long-clicked in easy-edit mode and a element is the target
      * 
      * @param v the View that was long clicked
      * @param e an OsmElement
@@ -412,7 +423,7 @@ public class EasyEditManager {
     }
 
     /**
-     * This gets called when the map is long-clciked in easy-edit mode
+     * This gets called when the map is long-clicked in easy-edit mode
      * 
      * @param v the View that was long clicked
      * @param x screen X coordinate

--- a/src/main/java/de/blau/android/easyedit/WaySplittingActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/WaySplittingActionModeCallback.java
@@ -96,6 +96,11 @@ public class WaySplittingActionModeCallback extends NonSimpleActionModeCallback 
         }
         return true;
     }
+    
+    @Override
+    public boolean usesLongClick() {
+        return true;
+    }
 
     @Override
     public void onDestroyActionMode(ActionMode mode) {


### PR DESCRIPTION
In the "non-simple" mode that uses long-click to create nodes and ways, it wasn't possible to use the new function to select which way segment was used for the new way when splitting an existing one.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/2017