### PR TITLE
Don't delete GPX recording layer automatically on layer setup

### DIFF
--- a/src/main/java/de/blau/android/Main.java
+++ b/src/main/java/de/blau/android/Main.java
@@ -1251,7 +1251,7 @@ public class Main extends FullScreenAppCompatActivity
             de.blau.android.layer.Util.addLayer(this, LayerType.GPX, uri.toString());
             map.setUpLayers(this);
             gpxLayer = (de.blau.android.layer.gpx.MapOverlay) map.getLayer(LayerType.GPX, uri.toString());
-            if (gpxLayer == null) { // still null 
+            if (gpxLayer == null) { // still null
                 Snack.toastTopError(this, getString(R.string.toast_error_reading, uri.toString()));
                 return;
             }
@@ -4085,9 +4085,14 @@ public class Main extends FullScreenAppCompatActivity
     public void onServiceConnected(ComponentName name, IBinder service) {
         Log.i(DEBUG_TAG, "Service " + name.getClassName() + " connected");
         if (TrackerService.class.getCanonicalName().equals(name.getClassName())) {
-            Log.i(DEBUG_TAG, "Tracker service connected");
             setTracker((((TrackerBinder) service).getService()));
             map.setTracker(getTracker());
+            de.blau.android.layer.gpx.MapOverlay layer = (de.blau.android.layer.gpx.MapOverlay) map.getLayer(LayerType.GPX,
+                    getString(R.string.layer_gpx_recording));
+            if (layer != null) {
+                Log.i(DEBUG_TAG, "Setting track in GPX layer");
+                layer.setTrack(getTracker().getTrack());
+            }
             getTracker().setListener(this);
             getTracker().setListenerNeedsGPS(wantLocationUpdates);
             startStopAutoDownload();

--- a/src/main/java/de/blau/android/Map.java
+++ b/src/main/java/de/blau/android/Map.java
@@ -250,14 +250,11 @@ public class Map extends View implements IMapView {
                         case GPX:
                             layer = new de.blau.android.layer.gpx.MapOverlay(this, contentId); // NOSONAR
                             if (ctx.getString(R.string.layer_gpx_recording).equals(contentId)) {
+                                ((de.blau.android.layer.gpx.MapOverlay) layer).setName(contentId);
                                 if (getTracker() != null) {
+                                    // if the tracker isn't running we can't do this, but the tracker will when
+                                    // connected
                                     ((de.blau.android.layer.gpx.MapOverlay) layer).setTrack(getTracker().getTrack());
-                                    ((de.blau.android.layer.gpx.MapOverlay) layer).setName(contentId);
-                                } else {
-                                    // we don't want to display the recording layer if the service isn't running
-                                    // for consistency reasons this implies that we need to delete the layer
-                                    db.deleteLayer(LayerType.GPX, contentId);
-                                    continue;
                                 }
                             } else if (!((de.blau.android.layer.gpx.MapOverlay) layer).fromFile(ctx, Uri.parse(contentId), true, null)) {
                                 db.deleteLayer(LayerType.GPX, contentId);


### PR DESCRIPTION
We were removing the GPX recording layer on layer setup if the tracker service wasn't running. On app startup this led to the counter-intuitive behaviour that tracking had to be resumed to re-display the track.

Fixes: https://github.com/MarcusWolschon/osmeditor4android/issues/2051