### PR TITLE
Protect against no elements being provided for centroid calculation

### DIFF
--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -5395,6 +5395,10 @@ public class Logic {
      */
     @Nullable
     int[] calcCentroid(@NonNull List<OsmElement> elements) {
+        if (elements.isEmpty()) {
+            Log.e(DEBUG_TAG, "empty element list for for centroid");
+            return null;
+        }
         long latE7 = 0;
         long lonE7 = 0;
         for (OsmElement e : elements) {
@@ -5415,7 +5419,8 @@ public class Logic {
                 return null;
             }
         }
-        return new int[] { (int) (latE7 / elements.size()), (int) (lonE7 / elements.size()) };
+        final int size = elements.size();
+        return new int[] { (int) (latE7 / size), (int) (lonE7 / size) };
     }
 
     /**


### PR DESCRIPTION
This shouldn't be able to happen from an UI pov, but has.