### PR TITLE
Combo translation context fixes

### DIFF
--- a/src/main/java/de/blau/android/presets/PresetComboField.java
+++ b/src/main/java/de/blau/android/presets/PresetComboField.java
@@ -82,6 +82,8 @@ public class PresetComboField extends PresetField implements PresetFieldJavaScri
         this.setEditable(field.isEditable());
         this.setSortValues(field.getSortValues());
         this.setValuesSearchable(field.getValuesSearchable());
+        this.valueCountKey = field.valueCountKey;
+        this.valuesContext = field.valuesContext;
     }
 
     /**
@@ -89,7 +91,7 @@ public class PresetComboField extends PresetField implements PresetFieldJavaScri
      * 
      * @param field PresetComboField to copy
      */
-    public PresetComboField(PresetComboField field) {
+    public PresetComboField(@NonNull PresetComboField field) {
         super(field);
         this.values = field.values;
         this.multiSelect = field.multiSelect;
@@ -97,6 +99,8 @@ public class PresetComboField extends PresetField implements PresetFieldJavaScri
         this.setEditable(field.isEditable());
         this.setSortValues(field.getSortValues());
         this.setValuesSearchable(field.getValuesSearchable());
+        this.valueCountKey = field.valueCountKey;
+        this.valuesContext = field.valuesContext;
         this.useImages = field.useImages;
     }
 

--- a/src/main/java/de/blau/android/presets/PresetField.java
+++ b/src/main/java/de/blau/android/presets/PresetField.java
@@ -75,7 +75,7 @@ public abstract class PresetField {
      * 
      * @param field PresetField to copy
      */
-    protected PresetField(PresetField field) {
+    protected PresetField(@NonNull PresetField field) {
         this.key = field.key;
         this.hint = field.hint;
         this.defaultValue = field.defaultValue;

--- a/src/main/java/de/blau/android/presets/PresetParser.java
+++ b/src/main/java/de/blau/android/presets/PresetParser.java
@@ -476,8 +476,6 @@ public class PresetParser {
                         break;
                     }
 
-                    ((PresetComboField) field).setValuesContext(attr.getValue(VALUES_CONTEXT));
-
                     defaultValue = attr.getValue(DEFAULT);
                     if (defaultValue != null) {
                         field.setDefaultValue(defaultValue);
@@ -489,6 +487,12 @@ public class PresetParser {
                     textContext = attr.getValue(TEXT_CONTEXT);
                     if (textContext != null) {
                         field.setTextContext(textContext);
+                    }
+
+                    String valuesContext = attr.getValue(VALUES_CONTEXT);
+                    ((PresetComboField) field).setValuesContext(valuesContext);
+                    if (textContext == null && valuesContext != null) {
+                        field.setTextContext(valuesContext);
                     }
 
                     String sort = attr.getValue(VALUES_SORT);

--- a/src/test/java/de/blau/android/presets/PresetTest.java
+++ b/src/test/java/de/blau/android/presets/PresetTest.java
@@ -400,4 +400,17 @@ public class PresetTest {
         assertFalse(path.hasKey("mtb:scale", false));
         assertTrue(path.hasKey("mtb:scale", true));
     }
+    
+    /**
+     * Check that translation contextes are maintained for combos in chunks
+     */
+    @Test
+    public void chunkTranslationContext() {
+        PresetItem p = presets[0].getItemByName("Primary", null);
+        assertNotNull(p);
+        PresetField field = p.getField("bus_bay");
+        assertNotNull(field);
+        assertEquals("bus_bay", field.getTextContext());
+        assertEquals("bus_bay", ((PresetComboField)field).getValuesContext());
+    }
 }


### PR DESCRIPTION
This fixes two issues with translation contextes with combo/multiselect fields in presets.

- if the combo/multiselect was used in a chunk due to an issue in the copy constructor the translation context wasn't copied.
- due to the way we construct the translation files from the preset, if just values_context was set, the translation of the field name wasn't found.