### PR TITLE
Improve nav with back key in WebViews

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -280,6 +280,7 @@
             android:theme="@style/Theme.IssueReporter" />
         <activity
             android:name=".util.DownloadActivity"
+            android:configChanges="orientation|screenSize|keyboardHidden|density|screenLayout|uiMode|fontScale" />
             android:launchMode="singleTask"
             android:theme="@style/Theme.AppCompat" />
 

--- a/src/main/java/de/blau/android/Authorize.java
+++ b/src/main/java/de/blau/android/Authorize.java
@@ -11,6 +11,7 @@ import android.os.Bundle;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.View;
+import android.view.View.OnKeyListener;
 import android.view.ViewGroup;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
@@ -39,7 +40,7 @@ import oauth.signpost.exception.OAuthException;
  * @author simon
  *
  */
-public class Authorize extends FullScreenAppCompatActivity {
+public class Authorize extends FullScreenAppCompatActivity implements OnKeyListener {
 
     private static final String DEBUG_TAG = "Authorize";
 
@@ -182,20 +183,21 @@ public class Authorize extends FullScreenAppCompatActivity {
             oAuthWebView.getLayoutParams().height = android.view.ViewGroup.LayoutParams.MATCH_PARENT;
             oAuthWebView.getLayoutParams().width = android.view.ViewGroup.LayoutParams.MATCH_PARENT;
             oAuthWebView.requestFocus(View.FOCUS_DOWN);
-            oAuthWebView.setOnKeyListener((v, keyCode, event) -> {
-                if (keyCode == KeyEvent.KEYCODE_BACK) {
-                    if (oAuthWebView != null && oAuthWebView.canGoBack()) {
-                        oAuthWebView.goBack();
-                    } else {
-                        finishOAuth();
-                    }
-                    return true;
-                }
-                return false;
-            });
+            oAuthWebView.setOnKeyListener(this);
             oAuthWebView.setWebViewClient(new OAuthWebViewClient());
             oAuthWebView.loadUrl(authUrl);
         }
+    }
+
+    @Override
+    public boolean onKey(View v, int keyCode, KeyEvent event) {
+        if (keyCode == KeyEvent.KEYCODE_BACK) {
+            if (oAuthWebView != null && !oAuthWebView.canGoBack()) {
+                finishOAuth();
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/de/blau/android/HelpViewer.java
+++ b/src/main/java/de/blau/android/HelpViewer.java
@@ -24,10 +24,12 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
+import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.View.OnKeyListener;
 import android.view.ViewGroup;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
@@ -61,7 +63,7 @@ import de.blau.android.util.Util;
  * @author Simon Poole
  *
  */
-public class HelpViewer extends LocaleAwareCompatActivity {
+public class HelpViewer extends LocaleAwareCompatActivity implements OnKeyListener {
     private static final String DEBUG_TAG = HelpViewer.class.getName();
 
     private static final String HTML_SUFFIX = "." + FileExtensions.HTML;
@@ -168,6 +170,7 @@ public class HelpViewer extends LocaleAwareCompatActivity {
         helpSettings.setBuiltInZoomControls(true);
         helpSettings.setDisplayZoomControls(false); // don't display +-
         helpView.setWebViewClient(new HelpViewWebViewClient());
+        helpView.setOnKeyListener(this);
         fl.addView(helpView);
 
         // set up the drawer
@@ -290,6 +293,34 @@ public class HelpViewer extends LocaleAwareCompatActivity {
             }
         }
         return helpFile;
+    }
+
+    @Override
+    public boolean onKey(View v, int keyCode, KeyEvent event) {
+        if (keyCode == KeyEvent.KEYCODE_BACK) {
+            if (helpView != null && !helpView.canGoBack()) {
+                onBackPressed();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * potentially do some special stuff for exiting
+     */
+    @Override
+    public void onBackPressed() {
+        Log.d(DEBUG_TAG, "onBackPressed()");
+        synchronized (helpView) {
+            if (helpView != null && helpView.canGoBack()) {
+                // we are displaying the oAuthWebView and somebody might want to
+                // navigate back
+                helpView.goBack();
+                return;
+            }
+        }
+        super.onBackPressed();
     }
 
     @Override

--- a/src/main/java/de/blau/android/util/DownloadActivity.java
+++ b/src/main/java/de/blau/android/util/DownloadActivity.java
@@ -16,6 +16,7 @@ import android.util.Log;
 import android.view.KeyEvent;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.View.OnKeyListener;
 import android.view.ViewGroup;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
@@ -44,7 +45,7 @@ import de.blau.android.prefs.Preferences;
  * @author simon
  *
  */
-public class DownloadActivity extends FullScreenAppCompatActivity {
+public class DownloadActivity extends FullScreenAppCompatActivity implements OnKeyListener {
 
     private static final String DEBUG_TAG = DownloadActivity.class.getSimpleName();
 
@@ -240,20 +241,21 @@ public class DownloadActivity extends FullScreenAppCompatActivity {
             downloadWebView.getLayoutParams().height = android.view.ViewGroup.LayoutParams.MATCH_PARENT;
             downloadWebView.getLayoutParams().width = android.view.ViewGroup.LayoutParams.MATCH_PARENT;
             downloadWebView.requestFocus(View.FOCUS_DOWN);
-            downloadWebView.setOnKeyListener((v, keyCode, event) -> {
-                if (keyCode == KeyEvent.KEYCODE_BACK) {
-                    if (downloadWebView != null && downloadWebView.canGoBack()) {
-                        downloadWebView.goBack();
-                    } else {
-                        finishSelection();
-                    }
-                    return true;
-                }
-                return false;
-            });
+            downloadWebView.setOnKeyListener(this);
             downloadWebView.setWebViewClient(new DownloadWebViewClient());
             downloadWebView.loadUrl(url);
         }
+    }
+
+    @Override
+    public boolean onKey(View v, int keyCode, KeyEvent event) {
+        if (keyCode == KeyEvent.KEYCODE_BACK) {
+            if (downloadWebView != null && !downloadWebView.canGoBack()) {
+                finishSelection();
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/de/blau/android/util/DownloadActivity.java
+++ b/src/main/java/de/blau/android/util/DownloadActivity.java
@@ -13,24 +13,17 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
 import android.util.Log;
-import android.view.KeyEvent;
 import android.view.MenuItem;
-import android.view.View;
-import android.view.View.OnKeyListener;
-import android.view.ViewGroup;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.widget.CheckBox;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.fragment.app.FragmentActivity;
-import de.blau.android.App;
-import de.blau.android.ErrorCodes;
 import de.blau.android.R;
 import de.blau.android.contract.FileExtensions;
 import de.blau.android.contract.MimeTypes;
 import de.blau.android.contract.Paths;
-import de.blau.android.dialogs.ErrorAlert;
 import de.blau.android.prefs.API;
 import de.blau.android.prefs.AdvancedPrefDatabase;
 import de.blau.android.prefs.Preferences;
@@ -45,14 +38,11 @@ import de.blau.android.prefs.Preferences;
  * @author simon
  *
  */
-public class DownloadActivity extends FullScreenAppCompatActivity implements OnKeyListener {
+public class DownloadActivity extends WebViewActivity {
 
     private static final String DEBUG_TAG = DownloadActivity.class.getSimpleName();
 
     static final String DOWNLOAD_SITE_KEY = "downloadSite";
-
-    private WebView downloadWebView;
-    private Object  downloadWebViewLock = new Object();
 
     private DownloadManager mgr          = null;
     private long            lastDownload = -1L;
@@ -67,8 +57,7 @@ public class DownloadActivity extends FullScreenAppCompatActivity implements OnK
      */
     public static void start(@NonNull FragmentActivity activity, @NonNull String downloadSite) {
         Log.d(DEBUG_TAG, "start");
-        if (!Util.supportsWebView(activity)) {
-            ErrorAlert.showDialog(activity, ErrorCodes.REQUIRED_FEATURE_MISSING, "WebView");
+        if (!hasWebView(activity)) {
             return;
         }
         Intent intent = new Intent(activity, DownloadActivity.class);
@@ -105,7 +94,7 @@ public class DownloadActivity extends FullScreenAppCompatActivity implements OnK
                     request.setAllowedNetworkTypes(DownloadManager.Request.NETWORK_WIFI);
                 }
                 lastDownload = mgr.enqueue(request);
-                downloadWebView.postDelayed(() -> checkStatus(mgr, lastDownload, filename), 5000);
+                webView.postDelayed(() -> checkStatus(mgr, lastDownload, filename), 5000);
 
                 Log.i(DEBUG_TAG, "Download id: " + lastDownload);
                 return true;
@@ -123,7 +112,7 @@ public class DownloadActivity extends FullScreenAppCompatActivity implements OnK
 
         @Override
         public void receivedError(WebView view, int errorCode, String description, String failingUrl) {
-            finishSelection();
+            exit();
             Snack.toastTopError(view.getContext(), description);
         }
 
@@ -213,17 +202,10 @@ public class DownloadActivity extends FullScreenAppCompatActivity implements OnK
 
         if (savedInstanceState == null) {
             url = getIntent().getStringExtra(DOWNLOAD_SITE_KEY);
-        } else {
-            url = savedInstanceState.getString(DOWNLOAD_SITE_KEY);
-        }
-        if (url == null) {
-            Log.e(DEBUG_TAG, "No download site found");
-            finish();
-            return;
         }
 
         setContentView(R.layout.download);
-        downloadWebView = (WebView) findViewById(R.id.downloadSiteWebView);
+        webView = (WebView) findViewById(R.id.downloadSiteWebView);
 
         CheckBox networks = (CheckBox) findViewById(R.id.allowAllNetworks);
         networks.setOnCheckedChangeListener((buttonView, isChecked) -> {
@@ -235,72 +217,10 @@ public class DownloadActivity extends FullScreenAppCompatActivity implements OnK
         mgr = (DownloadManager) getSystemService(DOWNLOAD_SERVICE);
         registerReceiver(onNotificationClick, new IntentFilter(DownloadManager.ACTION_NOTIFICATION_CLICKED));
 
-        synchronized (downloadWebViewLock) {
-            downloadWebView.getSettings().setUserAgentString(App.getUserAgent());
-            downloadWebView.getSettings().setAllowContentAccess(true);
-            downloadWebView.getLayoutParams().height = android.view.ViewGroup.LayoutParams.MATCH_PARENT;
-            downloadWebView.getLayoutParams().width = android.view.ViewGroup.LayoutParams.MATCH_PARENT;
-            downloadWebView.requestFocus(View.FOCUS_DOWN);
-            downloadWebView.setOnKeyListener(this);
-            downloadWebView.setWebViewClient(new DownloadWebViewClient());
-            downloadWebView.loadUrl(url);
+        synchronized (webViewLock) {
+            webView.setWebViewClient(new DownloadWebViewClient());
+            loadUrlOrRestore(savedInstanceState, url);
         }
-    }
-
-    @Override
-    public boolean onKey(View v, int keyCode, KeyEvent event) {
-        if (keyCode == KeyEvent.KEYCODE_BACK) {
-            if (downloadWebView != null && !downloadWebView.canGoBack()) {
-                finishSelection();
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Remove the webview
-     */
-    public void finishSelection() {
-        Log.d(DEBUG_TAG, "finish download selection");
-        synchronized (downloadWebViewLock) {
-            if (downloadWebView != null) {
-                ViewGroup contentView = (ViewGroup) findViewById(android.R.id.content);
-                contentView.removeView(downloadWebView);
-                try {
-                    // the below loadUrl, even though the "official" way to do
-                    // it, seems to be prone to crash on some devices.
-                    downloadWebView.loadUrl("about:blank"); // workaround clearView
-                    // issues
-                    downloadWebView.setVisibility(View.GONE);
-                    downloadWebView.removeAllViews();
-                    downloadWebView.destroy();
-                    downloadWebView = null;
-                    Intent intent = new Intent();
-                    setResult(RESULT_OK, intent);
-                    finish();
-                } catch (Exception ex) {
-                    ACRAHelper.nocrashReport(ex, ex.getMessage());
-                }
-            }
-        }
-    }
-
-    /**
-     * potentially do some special stuff for exiting
-     */
-    @Override
-    public void onBackPressed() {
-        Log.d(DEBUG_TAG, "onBackPressed()");
-        synchronized (downloadWebViewLock) {
-            if (downloadWebView != null && downloadWebView.canGoBack()) {
-                // we are displaying a WebView and somebody might want to
-                // navigate back
-                downloadWebView.goBack();
-                return;
-            }
-        }
-        super.onBackPressed();
     }
 
     @Override
@@ -310,13 +230,6 @@ public class DownloadActivity extends FullScreenAppCompatActivity implements OnK
             return true;
         }
         return super.onOptionsItemSelected(item);
-    }
-
-    @Override
-    protected void onSaveInstanceState(final Bundle outState) {
-        Log.d(DEBUG_TAG, "onSaveInstanceState");
-        super.onSaveInstanceState(outState);
-        outState.putString(DOWNLOAD_SITE_KEY, url);
     }
 
     @Override

--- a/src/main/java/de/blau/android/util/WebViewActivity.java
+++ b/src/main/java/de/blau/android/util/WebViewActivity.java
@@ -1,0 +1,124 @@
+package de.blau.android.util;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.KeyEvent;
+import android.view.View;
+import android.view.View.OnKeyListener;
+import android.view.ViewGroup;
+import android.webkit.WebView;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.FragmentActivity;
+import de.blau.android.App;
+import de.blau.android.ErrorCodes;
+import de.blau.android.dialogs.ErrorAlert;
+
+/**
+ * Common code for activities that display a navigable WebView
+ * 
+ * @author simon
+ *
+ */
+public abstract class WebViewActivity extends FullScreenAppCompatActivity implements OnKeyListener {
+
+    private static final String DEBUG_TAG = WebViewActivity.class.getSimpleName();
+
+    protected WebView webView;
+    protected Object  webViewLock = new Object();
+
+    /**
+     * Check if we have a working WebView, if not toast
+     * 
+     * @param activity the current activity
+     * @return true if we have a WebView
+     */
+    protected static boolean hasWebView(@NonNull FragmentActivity activity) {
+        if (!Util.supportsWebView(activity)) {
+            ErrorAlert.showDialog(activity, ErrorCodes.REQUIRED_FEATURE_MISSING, "WebView");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean onKey(View v, int keyCode, KeyEvent event) {
+        if (keyCode == KeyEvent.KEYCODE_BACK && event.getAction() == KeyEvent.ACTION_UP && webView != null && !webView.canGoBack()) {
+            exit();
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * potentially do some special stuff for exiting
+     */
+    @Override
+    public void onBackPressed() {
+        Log.d(DEBUG_TAG, "onBackPressed()");
+        synchronized (webViewLock) {
+            if (webView != null && webView.canGoBack()) {
+                webView.goBack();
+                return;
+            }
+        }
+        exit();
+    }
+
+    /**
+     * Do what ever clean up is necessary and finish the activity
+     * 
+     * This version assumes that the caller wants a result
+     */
+    protected void exit() {
+        Log.d(DEBUG_TAG, "exit");
+        synchronized (webViewLock) {
+            if (webView != null) {
+                ViewGroup contentView = (ViewGroup) findViewById(android.R.id.content);
+                contentView.removeView(webView);
+                try {
+                    // the below loadUrl, even though the "official" way to do
+                    // it, seems to be prone to crash on some devices.
+                    webView.loadUrl("about:blank"); // workaround clearView
+                                                    // issues
+                    webView.setVisibility(View.GONE);
+                    webView.removeAllViews();
+                    webView.destroy();
+                    webView = null;
+                } catch (Exception ex) {
+                    ACRAHelper.nocrashReport(ex, ex.getMessage());
+                }
+                Intent intent = new Intent();
+                setResult(RESULT_OK, intent);
+                finish();
+            }
+        }
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        webView.saveState(outState);
+    }
+
+    /**
+     * Load a url in the WebView or restore its previous state Does some further common configuration
+     * 
+     * @param savedInstanceState the state, possibly null
+     * @param url the URL
+     */
+    protected void loadUrlOrRestore(@Nullable Bundle savedInstanceState, @NonNull String url) {
+        webView.setOnKeyListener(this);
+        webView.getSettings().setUserAgentString(App.getUserAgent());
+        webView.getSettings().setAllowContentAccess(true);
+        webView.getLayoutParams().height = android.view.ViewGroup.LayoutParams.MATCH_PARENT;
+        webView.getLayoutParams().width = android.view.ViewGroup.LayoutParams.MATCH_PARENT;
+        webView.requestFocus(View.FOCUS_DOWN);
+        if (savedInstanceState != null) {
+            webView.restoreState(savedInstanceState);
+        } else {
+            webView.loadUrl(url);
+        }
+    }
+}


### PR DESCRIPTION
Pressing the back key exited the corresponding activities completely, now the back yes can be used to navigate back in the WebViews.

Additionally this ignores some config changes in the DownloadActivity.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/2123