### PR TITLE
Add support for an adjustable "nearby" POI display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ libs/**
 /project.properties
 /databases/
 /marathon1/
+/test.gpx

--- a/src/androidTest/java/de/blau/android/PoiDisplayTest.java
+++ b/src/androidTest/java/de/blau/android/PoiDisplayTest.java
@@ -1,0 +1,109 @@
+package de.blau.android;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import android.content.Context;
+import android.view.View;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.uiautomator.UiDevice;
+import de.blau.android.exception.OsmException;
+import de.blau.android.osm.BoundingBox;
+import de.blau.android.prefs.AdvancedPrefDatabase;
+import de.blau.android.prefs.Preferences;
+import de.blau.android.util.GeoMath;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class PoiDisplayTest {
+
+    Context              context = null;
+    AdvancedPrefDatabase prefDB  = null;
+    Main                 main    = null;
+    UiDevice             device  = null;
+    Map                  map     = null;
+    Logic                logic   = null;
+
+    @Rule
+    public ActivityTestRule<Main> mActivityRule = new ActivityTestRule<>(Main.class);
+
+    /**
+     * Pre-test setup
+     */
+    @Before
+    public void setup() {
+        device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+        context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        main = mActivityRule.getActivity();
+        Preferences prefs = new Preferences(context);
+        LayerUtils.removeImageryLayers(context);
+        map = main.getMap();
+        map.setPrefs(main, prefs);
+        TestUtils.grantPermissons(device);
+        TestUtils.dismissStartUpDialogs(device, main);
+        TestUtils.stopEasyEdit(main);
+        TestUtils.zoomToLevel(device, main, 19);
+        TestUtils.loadTestData(main, "test1.osm");
+    }
+
+    /**
+     * Post-test teardown
+     */
+    @After
+    public void teardown() {
+        TestUtils.stopEasyEdit(main);
+        TestUtils.zoomToNullIsland(App.getLogic(), map);
+    }
+
+    /**
+     * Open the POI display while locked and click on POI
+     */
+    @Test
+    public void locked() {
+        TestUtils.lock(device);
+        map.getDataLayer().setVisible(true);
+
+        View mainMap = main.findViewById(R.id.mainMap);
+        int[] pos = new int[2];
+        mainMap.getLocationOnScreen(pos);
+        int h = mainMap.getHeight();
+        int w = mainMap.getWidth();
+        final int startX = pos[0] + w / 2;
+        final int startY = pos[1] + h;
+        TestUtils.longClickAt(device, startX, startY);
+        TestUtils.drag(device, startX, startY, startX, startY - 200, 100);
+        assertTrue(TestUtils.clickText(device, false, "Excrement bags", true));
+        assertTrue(TestUtils.findText(device, false, main.getString(R.string.element_information)));
+        assertTrue(TestUtils.clickText(device, false, main.getString(R.string.done), true));
+    }
+
+    /**
+     * Open the POI display while unlocked and click on POI
+     */
+    @Test
+    public void unlocked() {
+        TestUtils.unlock(device);
+        map.getDataLayer().setVisible(true);
+
+        View mainMap = main.findViewById(R.id.mainMap);
+        int[] pos = new int[2];
+        mainMap.getLocationOnScreen(pos);
+        int h = mainMap.getHeight();
+        int w = mainMap.getWidth();
+        final int startX = pos[0] + w / 2;
+        final int startY = pos[1] + h;
+        TestUtils.longClickAt(device, startX, startY);
+        TestUtils.drag(device, startX, startY, startX, startY - 200, 100);
+        assertTrue(TestUtils.clickText(device, false, "Excrement bags", true));
+        assertTrue(TestUtils.findText(device, false, main.getString(R.string.actionmode_nodeselect)));
+    }
+}

--- a/src/androidTest/java/de/blau/android/TestUtils.java
+++ b/src/androidTest/java/de/blau/android/TestUtils.java
@@ -558,14 +558,34 @@ public final class TestUtils {
      */
     public static void unlock(@NonNull UiDevice device) {
         if (App.getLogic().isLocked()) {
-            UiObject lock = device.findObject(new UiSelector().resourceId(device.getCurrentPackageName() + ":id/floatingLock"));
-            try {
-                lock.click();
-                device.waitForWindowUpdate(null, 1000);
-                clickText(device, false, "OK", false);
-            } catch (UiObjectNotFoundException e) {
-                Assert.fail(e.getMessage());
-            }
+            clickOnLock(device);
+        }
+    }
+
+    /**
+     * Click on the lock button
+     * 
+     * @param device the UiDevice
+     */
+    private static void clickOnLock(@NonNull UiDevice device) {
+        UiObject lock = device.findObject(new UiSelector().resourceId(device.getCurrentPackageName() + ":id/floatingLock"));
+        try {
+            lock.click();
+            device.waitForWindowUpdate(null, 1000);
+            clickText(device, false, "OK", false);
+        } catch (UiObjectNotFoundException e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    /**
+     * Unlock the screen if locked
+     * 
+     * @param device the UiDevice
+     */
+    public static void lock(@NonNull UiDevice device) {
+        if (!App.getLogic().isLocked()) {
+            clickOnLock(device);
         }
     }
 

--- a/src/androidTest/java/de/blau/android/dialogs/BookmarkDialogsTest.java
+++ b/src/androidTest/java/de/blau/android/dialogs/BookmarkDialogsTest.java
@@ -1,9 +1,11 @@
 package de.blau.android.dialogs;
 
-
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -33,13 +35,13 @@ import de.blau.android.osm.ViewBox;
 @RunWith(AndroidJUnit4.class)
 public class BookmarkDialogsTest {
 
-    Instrumentation instrumentation = null;
+    Instrumentation             instrumentation   = null;
     ArrayList<BookmarksStorage> bookmarksStorages = null;
-    ViewBox viewBoxtest = null;
-    ActivityMonitor monitor = null;
-    UiDevice device = null;
-    Main main = null;
-    Map map = null;
+    ViewBox                     viewBoxtest       = null;
+    ActivityMonitor             monitor           = null;
+    UiDevice                    device            = null;
+    Main                        main              = null;
+    Map                         map               = null;
 
     @Rule
     public ActivityTestRule<Main> mActivityRule = new ActivityTestRule<>(Main.class, false, false);
@@ -65,11 +67,11 @@ public class BookmarkDialogsTest {
         TestUtils.sleep();
         bookmarksStorages = new ArrayList<>();
         try {
-            //India
+            // India
             bookmarksStorages.add(new BookmarksStorage("TestLocation0", new ViewBox(68.1766451354, 7.96553477623, 97.4025614766, 35.4940095078)));
-            //Netherlands
+            // Netherlands
             bookmarksStorages.add(new BookmarksStorage("TestLocation1", new ViewBox(3.31497114423, 50.803721015, 7.09205325687, 53.5104033474)));
-            //Serbia
+            // Serbia
             bookmarksStorages.add(new BookmarksStorage("TestLocation2", new ViewBox(18.82982, 42.2452243971, 22.9860185076, 46.1717298447)));
         } catch (OsmException osmex) {
             osmex.printStackTrace();
@@ -81,12 +83,12 @@ public class BookmarkDialogsTest {
      */
     @Test
     public void addRemoveTest() {
-        //Add Dialog
+        // Add Dialog
         for (int i = 0; i < 3; i++) {
             map.getViewBox().fitToBoundingBox(map, bookmarksStorages.get(i).getViewBox());
             map.invalidate();
-            Assert.assertTrue(TestUtils.clickResource(device, true, device.getCurrentPackageName() + ":id/menu_gps", true));
-            Assert.assertTrue(TestUtils.clickText(device, false, main.getString(R.string.add_bookmark), true, false));
+            assertTrue(TestUtils.clickResource(device, true, device.getCurrentPackageName() + ":id/menu_gps", true));
+            assertTrue(TestUtils.clickText(device, false, main.getString(R.string.add_bookmark), true, false));
             UiObject comments = device.findObject(new UiSelector().clickable(true).resourceId(device.getCurrentPackageName() + ":id/text_line_edit"));
             try {
                 comments.click();
@@ -96,15 +98,18 @@ public class BookmarkDialogsTest {
             }
             TestUtils.clickButton(device, "android:id/button1", true);
         }
-        //Show Dialog
+
+        List<BookmarksStorage> rereadStorages = new BookmarkIO().readList(main);
+        // Show Dialog
         for (int i = 0; i < 3; i++) {
             TestUtils.clickMenuButton(device, main.getString(R.string.menu_gps), false, true);
             TestUtils.clickText(device, false, main.getString(R.string.show_bookmarks), true, false);
-            TestUtils.clickResource(device, true, (device.getCurrentPackageName() + ":id/adapterlayout"), true);
-            viewBoxtest = map.getViewBox();
-            // dividing by 100 to accomodate slight change in map.getviewbox()
-            Assert.assertEquals((bookmarksStorages.get(i).getViewBox().getLeft()) / 100, viewBoxtest.getLeft() / 100);
-            Assert.assertEquals((bookmarksStorages.get(i).getViewBox().getRight()) / 100, viewBoxtest.getRight() / 100);
+            assertTrue(TestUtils.clickText(device, false, "TestLocation" + i, true, false));
+            TestUtils.sleep(5000);
+            ViewBox bookMarkBox = rereadStorages.get(i).getViewBox();
+            ViewBox viewBoxtest = map.getViewBox();
+            assertEquals(bookMarkBox.getLeft() / 1E7D, viewBoxtest.getLeft() / 1E7D, 0.01);
+            assertEquals(bookMarkBox.getRight() / 1E7D, viewBoxtest.getRight() / 1E7D, 0.01);
             TestUtils.clickMenuButton(device, main.getString(R.string.menu_gps), false, true);
             TestUtils.clickText(device, false, main.getString(R.string.show_bookmarks), true, false);
             TestUtils.clickText(device, false, "⋮", true, false);

--- a/src/androidTest/java/de/blau/android/easyedit/WayActionsTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/WayActionsTest.java
@@ -127,7 +127,7 @@ public class WayActionsTest {
         Coordinates v2 = coords[2].subtract(coords[1]);
         double theta = Math.toDegrees(Math.acos(Coordinates.dotproduct(v1, v2) / (v1.length() * v2.length())));
         System.out.println("Original angle " + theta);
-        assertEquals(92.33, theta, 0.1);
+        assertEquals(92.33, theta, 0.2);
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_wayselect)));
         TestUtils.clickOverflowButton(device);
         TestUtils.clickText(device, false, context.getString(R.string.menu_straighten), false, false);

--- a/src/androidTest/java/de/blau/android/easyedit/WayActionsTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/WayActionsTest.java
@@ -127,7 +127,7 @@ public class WayActionsTest {
         Coordinates v2 = coords[2].subtract(coords[1]);
         double theta = Math.toDegrees(Math.acos(Coordinates.dotproduct(v1, v2) / (v1.length() * v2.length())));
         System.out.println("Original angle " + theta);
-        assertEquals(92.33, theta, 0.2);
+        assertEquals(92.33, theta, 0.25);
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_wayselect)));
         TestUtils.clickOverflowButton(device);
         TestUtils.clickText(device, false, context.getString(R.string.menu_straighten), false, false);

--- a/src/androidTest/java/de/blau/android/tasks/TodoTest.java
+++ b/src/androidTest/java/de/blau/android/tasks/TodoTest.java
@@ -62,6 +62,7 @@ public class TodoTest {
         filter.add(Todo.FILTER_KEY);
         prefs.setTaskFilter(filter);
         LayerUtils.removeImageryLayers(context);
+        LayerUtils.addTaskLayer(main);
         map = main.getMap();
         map.setPrefs(main, prefs);
         TestUtils.grantPermissons(device);

--- a/src/main/assets/styles/Color-round-no-mp.xml
+++ b/src/main/assets/styles/Color-round-no-mp.xml
@@ -48,7 +48,10 @@
     <!--  UNTAGGED             = 0x00000200 -->
     <!--  UNCONNECTED_END_NODE = 0x00000400 -->
     <!--  DEGENERATE_WAY       = 0x00000800 -->
-    <feature type="validation" code="2" updateWidth="true" widthFactor="1.5" color="ffffe000" style="STROKE" cap="BUTT" join="MITER" labelKey="name" />
+    <feature type="validation" code="2" updateWidth="true" widthFactor="1.5" color="ffffe000" style="STROKE" cap="BUTT" join="MITER" labelKey="name" textColor="ff000000"/>
+    <feature type="validation" code="4" updateWidth="true" widthFactor="1.5" color="ffff00ff" style="STROKE" cap="BUTT" join="MITER" labelKey="name" textColor="ffffffff"/>
+    <feature type="validation" code="8" updateWidth="true" widthFactor="1.5" color="ffff00ff" style="STROKE" cap="BUTT" join="MITER" labelKey="name" textColor="ffffffff"/> 
+    <feature type="validation" code="10" updateWidth="true" widthFactor="1.5" color="ffff00ff" style="STROKE" cap="BUTT" join="MITER" labelKey="name" textColor="ffffffff"/>   
     
     <!-- Arrow styles -->
     <feature type="oneway_direction" updateWidth="true" widthFactor="0.5" color="ffb9121b" style="STROKE" cap="SQUARE" join="MITER" oneway="true" />

--- a/src/main/assets/styles/Color-round.xml
+++ b/src/main/assets/styles/Color-round.xml
@@ -48,7 +48,10 @@
     <!--  UNTAGGED             = 0x00000200 -->
     <!--  UNCONNECTED_END_NODE = 0x00000400 -->
     <!--  DEGENERATE_WAY       = 0x00000800 -->
-    <feature type="validation" code="2" updateWidth="true" widthFactor="1.5" color="ffffe000" style="STROKE" cap="BUTT" join="MITER" labelKey="name" />
+    <feature type="validation" code="2" updateWidth="true" widthFactor="1.5" color="ffffe000" style="STROKE" cap="BUTT" join="MITER" labelKey="name" textColor="ff000000"/>
+    <feature type="validation" code="4" updateWidth="true" widthFactor="1.5" color="ffff00ff" style="STROKE" cap="BUTT" join="MITER" labelKey="name" textColor="ffffffff"/>
+    <feature type="validation" code="8" updateWidth="true" widthFactor="1.5" color="ffff00ff" style="STROKE" cap="BUTT" join="MITER" labelKey="name" textColor="ffffffff"/> 
+    <feature type="validation" code="10" updateWidth="true" widthFactor="1.5" color="ffff00ff" style="STROKE" cap="BUTT" join="MITER" labelKey="name" textColor="ffffffff"/>   
     
     <!-- Arrow styles -->
     <feature type="oneway_direction" updateWidth="true" widthFactor="0.5" color="ffb9121b" style="STROKE" cap="SQUARE" join="MITER" oneway="true" />

--- a/src/main/assets/styles/Pen-round.xml
+++ b/src/main/assets/styles/Pen-round.xml
@@ -48,7 +48,10 @@
     <!--  UNTAGGED             = 0x00000200 -->
     <!--  UNCONNECTED_END_NODE = 0x00000400 -->
     <!--  DEGENERATE_WAY       = 0x00000800 -->
-    <feature type="validation" code="2" updateWidth="true" widthFactor="1.5" color="ffffe000" style="STROKE" cap="BUTT" join="MITER" labelKey="name" />
+    <feature type="validation" code="2" updateWidth="true" widthFactor="1.5" color="ffffe000" style="STROKE" cap="BUTT" join="MITER" labelKey="name" textColor="ff000000"/>
+    <feature type="validation" code="4" updateWidth="true" widthFactor="1.5" color="ffff00ff" style="STROKE" cap="BUTT" join="MITER" labelKey="name" textColor="ffffffff"/>
+    <feature type="validation" code="8" updateWidth="true" widthFactor="1.5" color="ffff00ff" style="STROKE" cap="BUTT" join="MITER" labelKey="name" textColor="ffffffff"/> 
+    <feature type="validation" code="10" updateWidth="true" widthFactor="1.5" color="ffff00ff" style="STROKE" cap="BUTT" join="MITER" labelKey="name" textColor="ffffffff"/>   
     
     <!-- Arrow styles -->
     <feature type="oneway_direction" updateWidth="true" widthFactor="0.5" color="ffb9121b" style="STROKE" cap="SQUARE" join="MITER" oneway="true" />

--- a/src/main/java/de/blau/android/EqualSpacingDecoration.java
+++ b/src/main/java/de/blau/android/EqualSpacingDecoration.java
@@ -1,0 +1,50 @@
+package de.blau.android;
+
+import android.graphics.Rect;
+import android.view.View;
+import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+/**
+ * Add equal spacing around an item in a RecyclerView with the GridLayoutManager
+ * 
+ * Inspired by https://gist.github.com/UweTrottmann/c6344c32aa61d1bec5a6
+ * 
+ * @author simon
+ *
+ */
+public class EqualSpacingDecoration extends RecyclerView.ItemDecoration {
+
+    private final int inset;
+    private int       spans = -1;
+
+    /**
+     * Decoration that adds a margin of inset width around all items
+     * 
+     * @param inset width of the margin
+     */
+    public EqualSpacingDecoration(int inset) {
+        this.inset = inset;
+    }
+
+    @Override
+    public void getItemOffsets(Rect outRect, View view, RecyclerView parent, RecyclerView.State state) {
+        GridLayoutManager.LayoutParams layoutParams = (GridLayoutManager.LayoutParams) view.getLayoutParams();
+
+        int position = layoutParams.getViewLayoutPosition();
+        if (position == RecyclerView.NO_POSITION) {
+            outRect.set(0, 0, 0, 0);
+            return;
+        }
+
+        if (spans == -1) {
+            spans = ((GridLayoutManager) parent.getLayoutManager()).getSpanCount();
+        }
+
+        final int spanIndex = layoutParams.getSpanIndex();
+        outRect.left = inset;
+        outRect.top = position >= 0 && position < spans ? inset : 0;
+        outRect.right = spanIndex == spans - 1 ? inset : 0;
+        outRect.bottom = inset;
+    }
+}

--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -2869,7 +2869,7 @@ public class Logic {
                 if (mainMap != null) {
                     DataStyle.updateStrokes(strokeWidth(viewBox.getWidth()));
                     // this is always a manual download so make the layer visible
-                    de.blau.android.layer.data.MapOverlay dataLayer = mainMap.getDataLayer();
+                    de.blau.android.layer.data.MapOverlay<OsmElement> dataLayer = mainMap.getDataLayer();
                     if (dataLayer != null) {
                         dataLayer.setVisible(true);
                     }

--- a/src/main/java/de/blau/android/Main.java
+++ b/src/main/java/de/blau/android/Main.java
@@ -3271,6 +3271,7 @@ public class Main extends FullScreenAppCompatActivity
      */
     public void performTagEdit(final List<OsmElement> selection, boolean applyLastAddressTags, boolean showPresets) {
         descheduleAutoLock();
+        unlock();
         ArrayList<PropertyEditorData> multiple = new ArrayList<>();
         StorageDelegator storageDelegator = App.getDelegator();
         for (OsmElement e : selection) {

--- a/src/main/java/de/blau/android/Main.java
+++ b/src/main/java/de/blau/android/Main.java
@@ -2047,13 +2047,15 @@ public class Main extends FullScreenAppCompatActivity
             toggleFollowGPS();
             return true;
         case R.id.menu_gps_add_bookmark:
+            // the soft keyboard will potentially change the current view box
+            final ViewBox bookmarkViewBox = new ViewBox(map.getViewBox());
             BookmarkHandler.get(this, new BookmarkHandler.HandleResult() {
                 @Override
                 public void onSuccess(String message, FragmentActivity activity) {
                     if (message.trim().isEmpty()) {
                         return;
                     }
-                    new BookmarkIO().writer(getApplicationContext(), message, map.getViewBox());
+                    new BookmarkIO().writer(getApplicationContext(), message, bookmarkViewBox);
                 }
 
                 @Override

--- a/src/main/java/de/blau/android/Main.java
+++ b/src/main/java/de/blau/android/Main.java
@@ -4342,8 +4342,8 @@ public class Main extends FullScreenAppCompatActivity
      * 
      * @return the current position
      */
-    public int getSplitterPosition() {
-        return ((SplitPaneLayout) findViewById(R.id.pane_layout)).getSplitterPosition();
+    public float getSplitterPosition() {
+        return ((SplitPaneLayout) findViewById(R.id.pane_layout)).getSplitterPositionPercent();
     }
 
     /**
@@ -4351,8 +4351,8 @@ public class Main extends FullScreenAppCompatActivity
      * 
      * @param the new position
      */
-    public void setSplitterPosition(int pos) {
-        ((SplitPaneLayout) findViewById(R.id.pane_layout)).setSplitterPosition(pos);
+    public void setSplitterPosition(float pos) {
+        ((SplitPaneLayout) findViewById(R.id.pane_layout)).setSplitterPositionPercent(pos);
     }
 
     /**

--- a/src/main/java/de/blau/android/Main.java
+++ b/src/main/java/de/blau/android/Main.java
@@ -66,6 +66,7 @@ import android.view.View.OnKeyListener;
 import android.view.View.OnLongClickListener;
 import android.view.View.OnTouchListener;
 import android.view.ViewGroup;
+import android.view.ViewStub;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.RelativeLayout.LayoutParams;
@@ -82,6 +83,7 @@ import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
 import androidx.core.view.MenuCompat;
 import androidx.fragment.app.FragmentActivity;
+import androidx.recyclerview.widget.RecyclerView;
 import androidx.work.PeriodicWorkRequest;
 import androidx.work.WorkManager;
 import de.blau.android.Logic.CursorPaddirection;
@@ -188,6 +190,7 @@ import de.blau.android.util.ThemeUtils;
 import de.blau.android.util.UploadChecker;
 import de.blau.android.util.Util;
 import de.blau.android.util.Version;
+import de.blau.android.views.SplitPaneLayout;
 import de.blau.android.views.ZoomControls;
 import de.blau.android.views.layers.MapTilesLayer;
 
@@ -469,6 +472,8 @@ public class Main extends FullScreenAppCompatActivity
 
     private Bundle shortcutExtras;
 
+    private RecyclerView nearByPois;
+
     private static final float LARGE_FAB_ELEVATION = 16; // used for re-enabling elevation on the FABs
 
     /**
@@ -581,6 +586,14 @@ public class Main extends FullScreenAppCompatActivity
                                             // setContentView
 
         setContentView(ml);
+
+        View pane2 = findViewById(R.id.pane2);
+        if (pane2 instanceof ViewStub) { // only need to inflate once
+            ViewStub stub = (ViewStub) pane2;
+            stub.setLayoutResource(R.layout.nearest_pois);
+            stub.setInflatedId(R.id.pane2);
+            nearByPois = (RecyclerView) stub.inflate();
+        }
 
         // Find the toolbar view inside the activity layout
         Toolbar toolbar = (Toolbar) findViewById(R.id.mainToolbar);
@@ -727,6 +740,7 @@ public class Main extends FullScreenAppCompatActivity
 
         haveCamera = checkForCamera();
 
+        @SuppressWarnings("unchecked")
         PostAsyncActionHandler postLoadData = () -> {
             updateActionbarEditMode();
             Mode mode = logic.getMode();
@@ -757,6 +771,11 @@ public class Main extends FullScreenAppCompatActivity
                     scheduleAutoLock();
                 });
                 logic.getFilter().showControls();
+            }
+
+            de.blau.android.layer.data.MapOverlay<OsmElement> dataLayer = map.getDataLayer();
+            if (dataLayer != null) {
+                dataLayer.setOnUpdateListener(new NearbyPoiUpdateListener<>(Main.this, map, nearByPois));
             }
         };
         PostAsyncActionHandler postLoadTasks = () -> {
@@ -4316,6 +4335,24 @@ public class Main extends FullScreenAppCompatActivity
     // currently this is only called by the task UI
     public void update() {
         map.invalidate();
+    }
+
+    /**
+     * Get the current position of the splitter in pixels
+     * 
+     * @return the current position
+     */
+    public int getSplitterPosition() {
+        return ((SplitPaneLayout) findViewById(R.id.pane_layout)).getSplitterPosition();
+    }
+
+    /**
+     * Set the position of the splitter in pixels
+     * 
+     * @param the new position
+     */
+    public void setSplitterPosition(int pos) {
+        ((SplitPaneLayout) findViewById(R.id.pane_layout)).setSplitterPosition(pos);
     }
 
     /**

--- a/src/main/java/de/blau/android/Map.java
+++ b/src/main/java/de/blau/android/Map.java
@@ -42,6 +42,7 @@ import de.blau.android.osm.BoundingBox;
 import de.blau.android.osm.GeoPoint;
 import de.blau.android.osm.GeoPoint.InterruptibleGeoPoint;
 import de.blau.android.osm.Node;
+import de.blau.android.osm.OsmElement;
 import de.blau.android.osm.StorageDelegator;
 import de.blau.android.osm.ViewBox;
 import de.blau.android.osm.Way;
@@ -245,7 +246,7 @@ public class Map extends View implements IMapView {
                             layer = new de.blau.android.layer.grid.MapOverlay(this);
                             break;
                         case OSMDATA:
-                            layer = new de.blau.android.layer.data.MapOverlay(this);
+                            layer = new de.blau.android.layer.data.MapOverlay<OsmElement>(this);
                             break;
                         case GPX:
                             layer = new de.blau.android.layer.gpx.MapOverlay(this, contentId); // NOSONAR
@@ -509,9 +510,10 @@ public class Map extends View implements IMapView {
      * 
      * @return the current data layer or null if none is configured
      */
+    @SuppressWarnings("unchecked")
     @Nullable
-    public de.blau.android.layer.data.MapOverlay getDataLayer() {
-        return (de.blau.android.layer.data.MapOverlay) getLayer(LayerType.OSMDATA);
+    public de.blau.android.layer.data.MapOverlay<OsmElement> getDataLayer() {
+        return (de.blau.android.layer.data.MapOverlay<OsmElement>) getLayer(LayerType.OSMDATA);
     }
 
     /**
@@ -980,7 +982,7 @@ public class Map extends View implements IMapView {
      * @param aSelectedNodes the currently selected nodes to edit.
      */
     void setSelectedNodes(@Nullable final List<Node> aSelectedNodes) {
-        de.blau.android.layer.data.MapOverlay dataLayer = getDataLayer();
+        de.blau.android.layer.data.MapOverlay<OsmElement> dataLayer = getDataLayer();
         if (dataLayer != null) {
             dataLayer.setSelectedNodes(aSelectedNodes);
         }
@@ -991,7 +993,7 @@ public class Map extends View implements IMapView {
      * @param aSelectedWays the currently selected ways to edit.
      */
     void setSelectedWays(@Nullable final List<Way> aSelectedWays) {
-        de.blau.android.layer.data.MapOverlay dataLayer = getDataLayer();
+        de.blau.android.layer.data.MapOverlay<OsmElement> dataLayer = getDataLayer();
         if (dataLayer != null) {
             dataLayer.setSelectedWays(aSelectedWays);
         }

--- a/src/main/java/de/blau/android/NearbyPoiUpdateListener.java
+++ b/src/main/java/de/blau/android/NearbyPoiUpdateListener.java
@@ -1,0 +1,141 @@
+package de.blau.android;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import android.app.Activity;
+import android.content.Context;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import de.blau.android.filter.Filter;
+import de.blau.android.layer.UpdateInterface;
+import de.blau.android.osm.Node;
+import de.blau.android.osm.OsmElement;
+import de.blau.android.osm.Relation;
+import de.blau.android.osm.Tags;
+import de.blau.android.osm.Way;
+import de.blau.android.util.Screen;
+import de.blau.android.util.collections.LowAllocArrayList;
+
+public class NearbyPoiUpdateListener<E> implements UpdateInterface.OnUpdateListener<E> {
+
+    private static final int UPDATE_MIN_INTERVAL   = 100; // minimum interval between updates in ms
+    private static final int POI_LAYOUT_MIN_HEIGHT = 5;
+    private static final int ROW_PADDING           = 5;
+    private static final int LANDSCAPE_COLS        = 4;
+    private static final int PORTRAIT_COLS         = 2;
+
+    private static final String[] DEFAULT_POI_KEYS = new String[] { Tags.KEY_SHOP, Tags.KEY_AMENITY, Tags.KEY_LEISURE, Tags.KEY_TOURISM, Tags.KEY_CRAFT,
+            Tags.KEY_OFFICE, Tags.KEY_EMERGENCY };
+
+    List<Node>       nodes     = new LowAllocArrayList<>();
+    List<Way>        ways      = new LowAllocArrayList<>();
+    List<Relation>   relations = new LowAllocArrayList<>();
+    List<OsmElement> all       = new LowAllocArrayList<>();
+
+    private final Map          map;
+    private final Runnable     display;
+    private final RecyclerView layout;
+
+    private int updates = 0; // count of update requests since last update
+
+    /**
+     * Construct a new listener for nearby POI updates
+     * 
+     * @param ctx an Android Context
+     * @param map the current Map instance
+     * @param layout the layout we will add the POIs to
+     */
+    NearbyPoiUpdateListener(@NonNull Context ctx, @NonNull Map map, @NonNull RecyclerView layout) {
+        this.map = map;
+        this.layout = layout;
+        layout.setPadding(0, ROW_PADDING, 0, 0);
+        GridLayoutManager layoutManager = new GridLayoutManager(ctx,
+                ctx instanceof Activity && Screen.isLandscape((Activity) ctx) ? LANDSCAPE_COLS : PORTRAIT_COLS);
+        layout.setLayoutManager(layoutManager);
+        layout.setAdapter(new PoiListAdapter(ctx, map, layout, all));
+        if (layout.getItemDecorationCount() == 0) {
+            layout.addItemDecoration(new EqualSpacingDecoration(PoiListAdapter.ROW_MARGIN));
+        }
+        display = () -> {
+            all.clear();
+            final Filter filter = App.getLogic().getFilter();
+            filterElements(all, nodes, filter);
+            filterElements(all, ways, filter != null);
+            filterElements(all, relations, filter != null);
+            final double[] center = map.getViewBox().getCenter();
+            final int[] loc = new int[] { (int) (center[1] * 1E7), (int) (center[0] * 1E7) };
+            Collections.sort(all, (OsmElement e1, OsmElement e2) -> Double.compare(e1.getMinDistance(loc), e2.getMinDistance(loc)));
+            layout.getAdapter().notifyDataSetChanged();
+            updates = 0;
+        };
+    }
+
+    private interface PoiFilter {
+        /**
+         * "Accept" a POI for display
+         * 
+         * @param e the OsmElement for the POI
+         * @param filter any Filter that needs to be pre-applied
+         * @return true if we should display the POI
+         */
+        boolean accept(@NonNull OsmElement e, @Nullable Filter filter);
+    }
+
+    private static final PoiFilter WITHOUT_FILTER = (OsmElement e, Filter filter) -> e.hasTagKey(DEFAULT_POI_KEYS);
+    private static final PoiFilter WITH_FILTER    = (OsmElement e, Filter filter) -> filter.include(e, false);
+
+    /**
+     * Add Nodes that we want to display
+     * 
+     * @param result List containing the filtered Nodes
+     * @param elements the input Nodes
+     * @param filter a Filter to apply
+     */
+    private static void filterElements(@NonNull List<OsmElement> result, @NonNull List<Node> elements, @Nullable Filter filter) {
+        PoiFilter poiFilter = filter == null ? WITHOUT_FILTER : WITH_FILTER;
+        for (OsmElement e : elements) {
+            if (poiFilter.accept(e, filter)) {
+                result.add(e);
+            }
+        }
+    }
+
+    /**
+     * Add OsmElements that we want to display
+     * 
+     * @param result List containing the filtered OsmElements
+     * @param elements the input OsmElements
+     * @param preFiltered true if the input was already filtered
+     */
+    private static <O extends OsmElement> void filterElements(@NonNull List<OsmElement> result, @NonNull List<O> elements, boolean preFiltered) {
+        for (OsmElement e : elements) {
+            if (preFiltered || WITHOUT_FILTER.accept(e, null)) {
+                result.add(e);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <C extends Collection<E>> void onUpdate(C... objects) {
+        if (layout.getHeight() <= POI_LAYOUT_MIN_HEIGHT) {
+            return;
+        }
+        // this is sync with onDraw
+        nodes.clear();
+        nodes.addAll((Collection<Node>) objects[0]);
+        ways.clear();
+        ways.addAll((Collection<Way>) objects[1]);
+        relations.clear();
+        relations.addAll((Collection<Relation>) objects[2]);
+
+        if (updates == 0) {
+            map.postDelayed(display, UPDATE_MIN_INTERVAL);
+        }
+        updates++;
+    }
+}

--- a/src/main/java/de/blau/android/PoiListAdapter.java
+++ b/src/main/java/de/blau/android/PoiListAdapter.java
@@ -1,0 +1,144 @@
+package de.blau.android;
+
+import java.util.List;
+import java.util.WeakHashMap;
+
+import android.content.Context;
+import android.graphics.drawable.BitmapDrawable;
+import android.view.Gravity;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import de.blau.android.dialogs.ElementInfo;
+import de.blau.android.osm.OsmElement;
+import de.blau.android.osm.ViewBox;
+import de.blau.android.presets.Preset;
+import de.blau.android.presets.PresetItem;
+import de.blau.android.resources.DataStyle;
+import de.blau.android.resources.DataStyle.FeatureStyle;
+import de.blau.android.util.ThemeUtils;
+import de.blau.android.validation.Validator;
+
+public class PoiListAdapter extends RecyclerView.Adapter<PoiListAdapter.PoiViewHolder> {
+
+    private static final int ICON_SIZE   = 36;
+    static final int         ROW_MARGIN  = 20;
+    private static final int ROW_PADDING = 5;
+
+    private final Context          ctx;
+    private final List<OsmElement> elements;
+
+    private final WeakHashMap<java.util.Map<String, String>, BitmapDrawable> iconCache        = new WeakHashMap<>();
+    private final WeakHashMap<java.util.Map<String, String>, String>         descriptionCache = new WeakHashMap<>();
+
+    private int                   width;
+    private final OnClickListener onClickListener;
+    private int                   defaultTextColor;
+    private int                   defaultBackgroundColor;
+
+    public static class PoiViewHolder extends RecyclerView.ViewHolder {
+        TextView tv;
+
+        /**
+         * Create a new ViewHolder
+         *
+         * @param v the RadioButton that will be displayed
+         */
+        public PoiViewHolder(@NonNull View v) {
+            super(v);
+            tv = (TextView) v;
+        }
+    }
+
+    /**
+     * Create a new adapter
+     * 
+     * @param ctx an Android Context
+     * @param map the current Map instance
+     * @param layout the RecyclerView we are adding Pois to
+     * @param elements a List of OsmElements to display
+     */
+    public PoiListAdapter(@NonNull final Context ctx, @NonNull final Map map, @NonNull final RecyclerView layout, @NonNull final List<OsmElement> elements) {
+        this.ctx = ctx;
+        this.elements = elements;
+
+        int spans = ((GridLayoutManager) layout.getLayoutManager()).getSpanCount();
+        width = (layout.getWidth() - ROW_MARGIN) / spans - ROW_MARGIN;
+
+        defaultTextColor = ThemeUtils.getStyleAttribColorValue(ctx, R.attr.textColor, R.color.black);
+        defaultBackgroundColor = ThemeUtils.getStyleAttribColorValue(ctx, R.attr.colorSecondary, R.color.ccc_white);
+
+        onClickListener = clickedView -> {
+            OsmElement element = (OsmElement) clickedView.getTag();
+            ViewBox box = new ViewBox(element.getBounds());
+            double[] elementCenter = box.getCenter();
+            // the following maintains the zoom level
+            map.getViewBox().moveTo(map, (int) (elementCenter[0] * 1E7D), (int) (elementCenter[1] * 1E7D));
+            if (ctx instanceof Main) {
+                final Main main = (Main) ctx;
+                if (App.getLogic().isLocked()) {
+                    map.invalidate();
+                    ElementInfo.showDialog(main, element);
+                } else {
+                    main.edit(element);
+                }
+            }
+            layout.scrollToPosition(0);
+        };
+    }
+
+    @Override
+    public PoiListAdapter.PoiViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        TextView tv = new TextView(ctx);
+        tv.setMaxLines(1);
+        tv.setPadding(ROW_PADDING, ROW_PADDING, ROW_PADDING, ROW_PADDING);
+        tv.setMaxWidth(width);
+        tv.setMinWidth(width);
+        tv.setMinHeight(ICON_SIZE + 2 * ROW_PADDING);
+        tv.setGravity(Gravity.CENTER_VERTICAL);
+        tv.setCompoundDrawablePadding(ROW_MARGIN);
+        tv.setOnClickListener(onClickListener);
+        return new PoiViewHolder(tv);
+    }
+
+    @Override
+    public void onBindViewHolder(PoiViewHolder holder, int position) {
+        final OsmElement e = elements.get(position);
+        holder.tv.setTag(e);
+
+        if (e.hasProblem(ctx, App.getDefaultValidator(ctx)) != Validator.OK) {
+            final FeatureStyle validationStyle = DataStyle.getValidationStyle(e.getCachedProblems());
+            int validationColor = validationStyle.getPaint().getColor();
+            holder.tv.setBackgroundColor(validationColor);
+            holder.tv.setTextColor(validationStyle.getTextColor());
+        } else {
+            holder.tv.setBackgroundColor(defaultBackgroundColor);
+            holder.tv.setTextColor(defaultTextColor);
+        }
+        BitmapDrawable icon = e.getFromCache(iconCache);
+        if (icon == null) {
+            PresetItem item = Preset.findBestMatch(App.getCurrentPresets(ctx), e.getTags(), null, null);
+            if (item != null) {
+                icon = (BitmapDrawable) item.getIcon(ctx, ICON_SIZE);
+                e.addToCache(iconCache, icon);
+            }
+        }
+        holder.tv.setCompoundDrawables(icon, null, null, null);
+
+        String description = e.getFromCache(descriptionCache);
+        if (description == null) {
+            description = e.getDescription(ctx);
+            e.addToCache(descriptionCache, description);
+        }
+        holder.tv.setText(description);
+    }
+
+    @Override
+    public int getItemCount() {
+        return elements.size();
+    }
+}

--- a/src/main/java/de/blau/android/easyedit/EasyEditActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/EasyEditActionModeCallback.java
@@ -89,6 +89,7 @@ public abstract class EasyEditActionModeCallback implements ActionMode.Callback 
         Log.d(DEBUG_TAG, "onCreateActionMode");
         manager.setCallBack(mode, this);
         this.mode = mode;
+        main.unlock();
         main.hideLock();
         main.hideLayersControl();
 

--- a/src/main/java/de/blau/android/layer/UpdateInterface.java
+++ b/src/main/java/de/blau/android/layer/UpdateInterface.java
@@ -1,0 +1,27 @@
+package de.blau.android.layer;
+
+import java.util.Collection;
+
+import androidx.annotation.Nullable;
+
+public interface UpdateInterface<V> {
+
+    interface OnUpdateListener<W> {
+        /**
+         * Call this with the current displayed objects
+         * 
+         * @param <C>
+         * 
+         * @param objects Collections of W
+         */
+        @SuppressWarnings("unchecked")
+        <C extends Collection<W>> void onUpdate(C... objects);
+    }
+
+    /**
+     * Set a listener to be called on updates
+     * 
+     * @param listener the OnUpdateListener
+     */
+    void setOnUpdateListener(@Nullable OnUpdateListener<V> listener);
+}

--- a/src/main/java/de/blau/android/osm/OsmElement.java
+++ b/src/main/java/de/blau/android/osm/OsmElement.java
@@ -28,7 +28,7 @@ public abstract class OsmElement implements Serializable, XmlSerializable, JosmX
     /**
      * 
      */
-    private static final long serialVersionUID = 7711945069147743673L;
+    private static final long serialVersionUID = 7711945069147743674L;
 
     public static final long NEW_OSM_ID = -1;
 
@@ -252,11 +252,13 @@ public abstract class OsmElement implements Serializable, XmlSerializable, JosmX
     }
 
     /**
+     * Check if we have a tag with a specific key-value combination
+     * 
      * @param key the key to search for (case sensitive)
      * @param value the value to search for (case sensitive)
      * @return true if the element has a tag with this key and value.
      */
-    public boolean hasTag(final String key, final String value) {
+    public boolean hasTag(@NonNull final String key, @Nullable final String value) {
         if (tags == null) {
             return false;
         }
@@ -265,12 +267,16 @@ public abstract class OsmElement implements Serializable, XmlSerializable, JosmX
     }
 
     /**
+     * Check if we have a tag with a specific key-value combination
+     * 
+     * Note TreeMap doesn't implement Map
+     * 
      * @param tags tags to use instead of the standard ones
      * @param key the key to search for (case sensitive)
      * @param value the value to search for (case sensitive)
      * @return true if the element has a tag with this key and value.
      */
-    static boolean hasTag(final Map<String, String> tags, final String key, final String value) {
+    static boolean hasTag(@Nullable final Map<String, String> tags, @NonNull final String key, @Nullable final String value) {
         if (tags == null) {
             return false;
         }
@@ -293,23 +299,42 @@ public abstract class OsmElement implements Serializable, XmlSerializable, JosmX
     }
 
     /**
+     * Get the value of a tag with key
+     * 
      * @param key the key to search for (case sensitive)
      * @return the value of this key.
      */
     @Nullable
     public String getTagWithKey(@NonNull final String key) {
-        if (tags == null) {
-            return null;
-        }
-        return tags.get(key);
+        return tags != null ? tags.get(key) : null;
     }
 
     /**
+     * Check if the tags contain an entry for key
+     * 
      * @param key the key to search for (case sensitive)
      * @return true if the element has a tag with this key.
      */
     public boolean hasTagKey(@NonNull final String key) {
-        return getTagWithKey(key) != null;
+        return tags != null && tags.containsKey(key);
+    }
+
+    /**
+     * Check if the tags contain any of the keys
+     * 
+     * @param keys the keys to search for (case sensitive)
+     * @return true if the element has a tag with one of the keys.
+     */
+    public boolean hasTagKey(@NonNull final String... keys) {
+        if (tags == null) {
+            return false;
+        }
+        for (String key : keys) {
+            if (tags.containsKey(key)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -753,7 +778,7 @@ public abstract class OsmElement implements Serializable, XmlSerializable, JosmX
      * 
      * Note this is only useful for sorting given that the result is returned in WGS84 °*1E7 or so
      * 
-     * @param location a coordinate tupel in WGS84*1E7 degrees
+     * @param location a coordinate tupel - lat / lon - in WGS84*1E7 degrees
      * @return the planar geom distance in degrees
      */
     public abstract double getMinDistance(final int[] location);

--- a/src/main/java/de/blau/android/presets/PresetElement.java
+++ b/src/main/java/de/blau/android/presets/PresetElement.java
@@ -140,6 +140,8 @@ public abstract class PresetElement {
     /**
      * Return the icon for the preset or a place holder
      * 
+     * The icon is cached in the preset
+     * 
      * @param context an Android Context
      * @return a Drawable with the icon or a place holder for it
      */
@@ -149,6 +151,18 @@ public abstract class PresetElement {
             icon = getIcon(context, iconpath, (int) (ICON_SIZE_DP * App.getConfiguration().fontScale));
         }
         return icon;
+    }
+
+    /**
+     * Return the icon for the preset or a place holder in a specific size
+     * 
+     * @param context an Android Context
+     * @param size in DIP
+     * @return a Drawable with the icon or a place holder for it
+     */
+    @NonNull
+    public Drawable getIcon(@NonNull Context context, int size) {
+        return getIcon(context, iconpath, (int) (size * App.getConfiguration().fontScale));
     }
 
     /**

--- a/src/main/java/de/blau/android/resources/DataStyle.java
+++ b/src/main/java/de/blau/android/resources/DataStyle.java
@@ -168,6 +168,7 @@ public final class DataStyle extends DefaultHandler {
     private static final String ICON_PATH_ATTR        = "iconPath";
     private static final String PRESET                = "preset";
     private static final String OFFSET_ATTR           = "offset";
+    private static final String TEXT_COLOR_ATTR       = "textColor";
 
     private static final int DEFAULT_MIN_VISIBLE_ZOOM = 15;
 
@@ -191,6 +192,7 @@ public final class DataStyle extends DefaultHandler {
         private String            labelKey       = null;
         private String            iconPath       = null;
         private int               labelZoomLimit = Integer.MAX_VALUE;
+        private int               textColor;
 
         List<FeatureStyle> cascadedStyles = null;
 
@@ -224,6 +226,7 @@ public final class DataStyle extends DefaultHandler {
             } else {
                 paint = new Paint();
             }
+            textColor = paint.getColor();
             widthFactor = 1.0f;
         }
 
@@ -267,6 +270,7 @@ public final class DataStyle extends DefaultHandler {
             setLabelZoomLimit(fp.getLabelZoomLimit());
             iconPath = fp.iconPath;
             cascadedStyles = null;
+            textColor = fp.textColor;
         }
 
         /**
@@ -633,6 +637,24 @@ public final class DataStyle extends DefaultHandler {
         @Nullable
         public String getIconPath() {
             return iconPath;
+        }
+
+        /**
+         * Set a color for text only
+         * 
+         * @param textColor the color
+         */
+        public void setTextColor(int textColor) {
+            this.textColor = textColor;
+        }
+
+        /**
+         * Get a color for text only
+         * 
+         * @return the color
+         */
+        public int getTextColor() {
+            return textColor;
         }
 
         /**
@@ -1637,6 +1659,11 @@ public final class DataStyle extends DefaultHandler {
                 String codeString = atts.getValue(CODE_ATTR);
                 if (codeString != null) {
                     validationCode = Integer.parseInt(codeString);
+                }
+
+                String textColorString = atts.getValue(TEXT_COLOR_ATTR);
+                if (textColorString != null) {
+                    tempFeatureStyle.setTextColor((int) Long.parseLong(textColorString, 16));
                 }
             } else if (element.equals(DASH_ELEMENT)) {
                 tempPhase = Float.parseFloat(atts.getValue(PHASE_ATTR));

--- a/src/main/java/de/blau/android/util/EditState.java
+++ b/src/main/java/de/blau/android/util/EditState.java
@@ -29,7 +29,7 @@ import de.blau.android.resources.DataStyle;
  *
  */
 public class EditState implements Serializable {
-    private static final long         serialVersionUID = 27L;
+    private static final long         serialVersionUID = 28L;
     private final boolean             savedLocked;
     private final Mode                savedMode;
     private final List<Selection.Ids> savedSelection;
@@ -46,6 +46,7 @@ public class EditState implements Serializable {
     private final long                savedChangesetId;
     private final List<String>        savedLastObjectSearches;
     private final String              savedEasyEditActionModeCallback;
+    private final int                 savedNearbyPoiSplitterPos;
 
     /**
      * Construct a new EditState instance
@@ -77,6 +78,7 @@ public class EditState implements Serializable {
         savedChangesetId = changesetId;
         savedLastObjectSearches = logic.getLastObjectSearches();
         savedEasyEditActionModeCallback = main.getEasyEditManager().getActionModeCallbackName();
+        savedNearbyPoiSplitterPos = main.getSplitterPosition();
     }
 
     /**
@@ -129,6 +131,7 @@ public class EditState implements Serializable {
      */
     public void setMiscState(@NonNull Main main, @NonNull Logic logic) {
         main.setImageFileName(savedImageFileName);
+        main.setSplitterPosition(savedNearbyPoiSplitterPos);
         logic.setLastComments(savedLastComments);
         logic.setDraftComment(savedCommentDraft);
         logic.setLastSources(savedLastSources);

--- a/src/main/java/de/blau/android/util/EditState.java
+++ b/src/main/java/de/blau/android/util/EditState.java
@@ -29,7 +29,7 @@ import de.blau.android.resources.DataStyle;
  *
  */
 public class EditState implements Serializable {
-    private static final long         serialVersionUID = 28L;
+    private static final long         serialVersionUID = 29L;
     private final boolean             savedLocked;
     private final Mode                savedMode;
     private final List<Selection.Ids> savedSelection;
@@ -46,7 +46,7 @@ public class EditState implements Serializable {
     private final long                savedChangesetId;
     private final List<String>        savedLastObjectSearches;
     private final String              savedEasyEditActionModeCallback;
-    private final int                 savedNearbyPoiSplitterPos;
+    private final float               savedNearbyPoiSplitterPos;
 
     /**
      * Construct a new EditState instance

--- a/src/main/java/de/blau/android/util/Util.java
+++ b/src/main/java/de/blau/android/util/Util.java
@@ -452,7 +452,7 @@ public final class Util {
         if (logic != null) {
             de.blau.android.Map map = logic.getMap();
             if (map != null) {
-                de.blau.android.layer.data.MapOverlay dataLayer = map.getDataLayer();
+                de.blau.android.layer.data.MapOverlay<OsmElement> dataLayer = map.getDataLayer();
                 if (dataLayer != null) {
                     dataLayer.clearIconCaches();
                     dataLayer.invalidate();

--- a/src/main/java/de/blau/android/views/SplitPaneLayout.java
+++ b/src/main/java/de/blau/android/views/SplitPaneLayout.java
@@ -303,9 +303,9 @@ public class SplitPaneLayout extends ViewGroup {
                 if (isDragging) {
                     isDragging = false;
                     if (mOrientation == ORIENTATION_HORIZONTAL) {
-                        mSplitterPosition = x;
+                        mSplitterPosition = Math.max(0, Math.min(getWidth(), x));
                     } else if (mOrientation == ORIENTATION_VERTICAL) {
-                        mSplitterPosition = y;
+                        mSplitterPosition = Math.max(0, Math.min(getHeight(), y));
                     }
                     mSplitterPositionPercent = -1;
                     remeasure();

--- a/src/main/java/de/blau/android/views/SplitPaneLayout.java
+++ b/src/main/java/de/blau/android/views/SplitPaneLayout.java
@@ -160,7 +160,6 @@ public class SplitPaneLayout extends ViewGroup {
                 mSplitterPosition = Integer.MIN_VALUE;
                 mSplitterPositionPercent = 0.5f;
             }
-
             value = a.peekValue(R.styleable.SplitPaneLayout_splitterBackground);
             if (value != null) {
                 if (value.type == TypedValue.TYPE_REFERENCE || value.type == TypedValue.TYPE_STRING) {
@@ -211,35 +210,37 @@ public class SplitPaneLayout extends ViewGroup {
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
         int widthSize = MeasureSpec.getSize(widthMeasureSpec);
+        int widthMode = MeasureSpec.getMode(widthMeasureSpec);
         int heightSize = MeasureSpec.getSize(heightMeasureSpec);
+        int heightMode = MeasureSpec.getMode(heightMeasureSpec);
 
         check();
-
         if (widthSize > 0 && heightSize > 0) {
+            final int halfOfSplitter = mSplitterSize / 2;
             if (mOrientation == ORIENTATION_HORIZONTAL) {
                 if (mSplitterPosition == Integer.MIN_VALUE && mSplitterPositionPercent < 0) {
                     mSplitterPosition = widthSize / 2;
-                } else if (mSplitterPosition == Integer.MIN_VALUE && mSplitterPositionPercent >= 0) {
+                } else if (mSplitterPositionPercent >= 0) {
                     mSplitterPosition = (int) (widthSize * mSplitterPositionPercent);
                 } else if (mSplitterPosition != Integer.MIN_VALUE && mSplitterPositionPercent < 0) {
-                    mSplitterPositionPercent = (float) mSplitterPosition / (float) widthSize;
+                    calcPercent(mSplitterPosition, widthSize);
                 }
-                getChildAt(0).measure(MeasureSpec.makeMeasureSpec(mSplitterPosition - (mSplitterSize / 2), MeasureSpec.EXACTLY),
-                        MeasureSpec.makeMeasureSpec(heightSize, MeasureSpec.EXACTLY));
-                getChildAt(1).measure(MeasureSpec.makeMeasureSpec(widthSize - (mSplitterSize / 2) - mSplitterPosition, MeasureSpec.EXACTLY),
-                        MeasureSpec.makeMeasureSpec(heightSize, MeasureSpec.EXACTLY));
+                getChildAt(0).measure(MeasureSpec.makeMeasureSpec(mSplitterPosition - halfOfSplitter, widthMode),
+                        MeasureSpec.makeMeasureSpec(heightSize, heightMode));
+                getChildAt(1).measure(MeasureSpec.makeMeasureSpec(widthSize - halfOfSplitter - mSplitterPosition, widthMode),
+                        MeasureSpec.makeMeasureSpec(heightSize, heightMode));
             } else if (mOrientation == ORIENTATION_VERTICAL) {
                 if (mSplitterPosition == Integer.MIN_VALUE && mSplitterPositionPercent < 0) {
                     mSplitterPosition = heightSize / 2;
-                } else if (mSplitterPosition == Integer.MIN_VALUE && mSplitterPositionPercent >= 0) {
+                } else if (mSplitterPositionPercent >= 0) {
                     mSplitterPosition = (int) (heightSize * mSplitterPositionPercent);
                 } else if (mSplitterPosition != Integer.MIN_VALUE && mSplitterPositionPercent < 0) {
-                    mSplitterPositionPercent = (float) mSplitterPosition / (float) heightSize;
+                    calcPercent(mSplitterPosition, heightSize);
                 }
-                getChildAt(0).measure(MeasureSpec.makeMeasureSpec(widthSize, MeasureSpec.EXACTLY),
-                        MeasureSpec.makeMeasureSpec(mSplitterPosition - (mSplitterSize / 2), MeasureSpec.EXACTLY));
-                getChildAt(1).measure(MeasureSpec.makeMeasureSpec(widthSize, MeasureSpec.EXACTLY),
-                        MeasureSpec.makeMeasureSpec(heightSize - (mSplitterSize / 2) - mSplitterPosition, MeasureSpec.EXACTLY));
+                getChildAt(0).measure(MeasureSpec.makeMeasureSpec(widthSize, widthMode),
+                        MeasureSpec.makeMeasureSpec(mSplitterPosition - halfOfSplitter, heightMode));
+                getChildAt(1).measure(MeasureSpec.makeMeasureSpec(widthSize, widthMode),
+                        MeasureSpec.makeMeasureSpec(heightSize - halfOfSplitter - mSplitterPosition, heightMode));
             }
         }
     }
@@ -248,14 +249,15 @@ public class SplitPaneLayout extends ViewGroup {
     protected void onLayout(boolean changed, int l, int t, int r, int b) {
         int w = r - l;
         int h = b - t;
+        final int halfOfSplitter = mSplitterSize / 2;
         if (mOrientation == ORIENTATION_HORIZONTAL) {
-            getChildAt(0).layout(0, 0, mSplitterPosition - (mSplitterSize / 2), h);
-            mSplitterRect.set(mSplitterPosition - (mSplitterSize / 2), 0, mSplitterPosition + (mSplitterSize / 2), h);
-            getChildAt(1).layout(mSplitterPosition + (mSplitterSize / 2), 0, r, h);
+            getChildAt(0).layout(0, 0, mSplitterPosition - halfOfSplitter, h);
+            mSplitterRect.set(mSplitterPosition - halfOfSplitter, 0, mSplitterPosition + halfOfSplitter, h);
+            getChildAt(1).layout(mSplitterPosition + halfOfSplitter, 0, r, h);
         } else if (mOrientation == ORIENTATION_VERTICAL) {
-            getChildAt(0).layout(0, 0, w, mSplitterPosition - (mSplitterSize / 2));
-            mSplitterRect.set(0, mSplitterPosition - (mSplitterSize / 2), w, mSplitterPosition + (mSplitterSize / 2));
-            getChildAt(1).layout(0, mSplitterPosition + (mSplitterSize / 2), w, h);
+            getChildAt(0).layout(0, 0, w, mSplitterPosition - halfOfSplitter);
+            mSplitterRect.set(0, mSplitterPosition - halfOfSplitter, w, mSplitterPosition + halfOfSplitter);
+            getChildAt(1).layout(0, mSplitterPosition + halfOfSplitter, w, h);
         }
         int cX = mSplitterRect.centerX();
         int cY = mSplitterRect.centerY();
@@ -302,12 +304,12 @@ public class SplitPaneLayout extends ViewGroup {
             case MotionEvent.ACTION_UP:
                 if (isDragging) {
                     isDragging = false;
+                    // note that the relative pos has to be set here
                     if (mOrientation == ORIENTATION_HORIZONTAL) {
-                        mSplitterPosition = Math.max(0, Math.min(getWidth(), x));
+                        calcPercent(x, getWidth());
                     } else if (mOrientation == ORIENTATION_VERTICAL) {
-                        mSplitterPosition = Math.max(0, Math.min(getHeight(), y));
+                        calcPercent(y, getHeight());
                     }
-                    mSplitterPositionPercent = -1;
                     remeasure();
                     requestLayout();
                 }
@@ -318,6 +320,17 @@ public class SplitPaneLayout extends ViewGroup {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Calculate the relative position
+     * 
+     * @param absPos the position in pixels
+     * @param max the max value it can have
+     */
+    private void calcPercent(int absPos, int max) {
+        mSplitterPosition = Math.min(absPos, max);
+        mSplitterPositionPercent = (float) mSplitterPosition / (float) max;
     }
 
     @Override
@@ -522,7 +535,7 @@ public class SplitPaneLayout extends ViewGroup {
      *
      * @param position the desired position of the splitter
      */
-    private void setSplitterPositionPercent(float position) {
+    public void setSplitterPositionPercent(float position) {
         if (position < 0) {
             position = 0;
         }

--- a/src/main/res/drawable/splitter_handle_dragging_h.xml
+++ b/src/main/res/drawable/splitter_handle_dragging_h.xml
@@ -4,6 +4,6 @@
     android:shape="rectangle">
     <solid android:color="@color/splitter_dragging" />
     <size
-        android:width="32dip"
+        android:width="64dip"
         android:height="24dip" />
 </shape>

--- a/src/main/res/drawable/splitter_handle_dragging_v.xml
+++ b/src/main/res/drawable/splitter_handle_dragging_v.xml
@@ -4,6 +4,6 @@
     android:shape="rectangle">
     <solid android:color="@color/splitter_dragging" />
     <size
-        android:height="32dip"
+        android:height="64dip"
         android:width="24dip" />
 </shape>

--- a/src/main/res/drawable/splitter_handle_h_dark.xml
+++ b/src/main/res/drawable/splitter_handle_h_dark.xml
@@ -6,7 +6,7 @@
                 android:width="2dip"
                 android:color="@color/material_deep_teal_200" />
             <size
-                android:width="32dip"
+                android:width="64dip"
                 android:height="24dip" />
             <padding android:bottom="22dip" />
         </shape>
@@ -17,7 +17,7 @@
                 android:width="2dip"
                 android:color="@color/material_deep_teal_200" />
             <size
-                android:width="32dip"
+                android:width="64dip"
                 android:height="24dip" />
             <padding android:top="22dip" />
         </shape>

--- a/src/main/res/drawable/splitter_handle_h_light.xml
+++ b/src/main/res/drawable/splitter_handle_h_light.xml
@@ -6,7 +6,7 @@
                 android:width="2dip"
                 android:color="@color/material_deep_teal_500" />
             <size
-                android:width="32dip"
+                android:width="64dip"
                 android:height="24dip" />
             <padding android:bottom="22dip" />
         </shape>
@@ -17,7 +17,7 @@
                 android:width="2dip"
                 android:color="@color/material_deep_teal_500" />
             <size
-                android:width="32dip"
+                android:width="64dip"
                 android:height="24dip" />
             <padding android:top="22dip" />
         </shape>

--- a/src/main/res/drawable/splitter_handle_v_dark.xml
+++ b/src/main/res/drawable/splitter_handle_v_dark.xml
@@ -12,7 +12,7 @@
                     android:width="2dip"
                     android:color="@color/material_deep_teal_200" />
                 <size
-                    android:width="32dip"
+                    android:width="64dip"
                     android:height="24dip" />
                 <padding android:bottom="22dip" />
             </shape>
@@ -23,7 +23,7 @@
                     android:width="2dip"
                     android:color="@color/material_deep_teal_200" />
                 <size
-                    android:width="32dip"
+                    android:width="64dip"
                     android:height="24dip" />
                 <padding android:top="22dip" />
             </shape>

--- a/src/main/res/drawable/splitter_handle_v_light.xml
+++ b/src/main/res/drawable/splitter_handle_v_light.xml
@@ -12,7 +12,7 @@
                     android:width="2dip"
                     android:color="@color/material_deep_teal_500" />
                 <size
-                    android:width="32dip"
+                    android:width="64dip"
                     android:height="24dip" />
                 <padding android:bottom="22dip" />
             </shape>
@@ -23,7 +23,7 @@
                     android:width="2dip"
                     android:color="@color/material_deep_teal_500" />
                 <size
-                    android:width="32dip"
+                    android:width="64dip"
                     android:height="24dip" />
                 <padding android:top="22dip" />
             </shape>

--- a/src/main/res/layout/main.xml
+++ b/src/main/res/layout/main.xml
@@ -2,6 +2,7 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:spl="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -13,56 +14,71 @@
         android:background="?attr/colorPrimary"
         android:minHeight="?attr/actionBarSize">
     </androidx.appcompat.widget.Toolbar>
-    <RelativeLayout
-        android:id="@+id/mainMap"
-        android:layout_width="match_parent"
+    <de.blau.android.views.SplitPaneLayout
+        android:id="@+id/pane_layout"
+        android:layout_width="fill_parent"
         android:layout_height="fill_parent"
+        spl:orientation="vertical"
+        spl:splitterBackground="?attr/SplitterBGV"
+        spl:handleBackground="?attr/SplitterHandleH"
+        spl:handleDraggingBackground="@drawable/splitter_handle_dragging_h"
+        spl:splitterPosition="100%"
+        spl:splitterSize="5dip"
         android:layout_weight="99999">
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/floatingLock"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_gravity="top"
-            android:layout_margin="8dp"
-            android:clickable="true"
-            android:src="@drawable/lock_bi_state"
-            app:backgroundTint="?attr/colorAccent"
-            app:fabSize="mini"
-            app:useCompatPadding="true" />
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/layers"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentRight="true"
-            android:layout_gravity="top"
-            android:layout_margin="0dp"
-            android:clickable="true"
-            android:src="@drawable/ic_view_headline_black_36dp"
-            android:theme="@style/Theme.customMain"
-            app:backgroundTint="?attr/colorControlNormal"
-            app:fabSize="mini"
-            app:useCompatPadding="true" />
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/follow"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_centerVertical="true"
-            android:layout_gravity="top"
-            android:clickable="true"
-            android:src="@drawable/ic_gps_fixed_black_36dp"
-            android:theme="@style/Theme.customMain"
-            app:backgroundTint="?attr/colorControlNormal"
-            app:fabSize="mini"
-            app:useCompatPadding="true" />
-        <de.blau.android.views.ZoomControls
-            android:id="@+id/zoom_controls"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentRight="true"
-            android:layout_alignParentBottom="true" />
-    </RelativeLayout>
+        <RelativeLayout
+            android:id="@+id/mainMap"
+            android:layout_width="match_parent"
+            android:layout_height="fill_parent">
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/floatingLock"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:layout_gravity="top"
+                android:layout_margin="8dp"
+                android:clickable="true"
+                android:src="@drawable/lock_bi_state"
+                app:backgroundTint="?attr/colorAccent"
+                app:fabSize="mini"
+                app:useCompatPadding="true" />
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/layers"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentRight="true"
+                android:layout_gravity="top"
+                android:layout_margin="0dp"
+                android:clickable="true"
+                android:src="@drawable/ic_view_headline_black_36dp"
+                android:theme="@style/Theme.customMain"
+                app:backgroundTint="?attr/colorControlNormal"
+                app:fabSize="mini"
+                app:useCompatPadding="true" />
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/follow"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:layout_centerVertical="true"
+                android:layout_gravity="top"
+                android:clickable="true"
+                android:src="@drawable/ic_gps_fixed_black_36dp"
+                android:theme="@style/Theme.customMain"
+                app:backgroundTint="?attr/colorControlNormal"
+                app:fabSize="mini"
+                app:useCompatPadding="true" />
+            <de.blau.android.views.ZoomControls
+                android:id="@+id/zoom_controls"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentRight="true"
+                android:layout_alignParentBottom="true" />
+        </RelativeLayout>
+        <ViewStub
+            android:id="@+id/pane2"
+            android:layout_width="fill_parent"
+            android:layout_height="0dp" />
+    </de.blau.android.views.SplitPaneLayout>
     <FrameLayout
         android:id="@+id/bottomBar"
         android:layout_width="match_parent"

--- a/src/main/res/layout/main_fullscreen.xml
+++ b/src/main/res/layout/main_fullscreen.xml
@@ -2,6 +2,7 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:spl="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -17,56 +18,71 @@
         android:background="?attr/colorPrimary"
         android:minHeight="?attr/actionBarSize">
     </androidx.appcompat.widget.Toolbar>
-    <RelativeLayout
-        android:id="@+id/mainMap"
-        android:layout_width="match_parent"
+    <de.blau.android.views.SplitPaneLayout
+        android:id="@+id/pane_layout"
+        android:layout_width="fill_parent"
         android:layout_height="fill_parent"
+        spl:orientation="vertical"
+        spl:splitterBackground="?attr/SplitterBGV"
+        spl:handleBackground="?attr/SplitterHandleH"
+        spl:handleDraggingBackground="@drawable/splitter_handle_dragging_h"
+        spl:splitterPosition="100%"
+        spl:splitterSize="5dip"
         android:layout_weight="99999">
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/floatingLock"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_gravity="top"
-            android:layout_margin="8dp"
-            android:clickable="true"
-            android:src="@drawable/lock_bi_state"
-            app:backgroundTint="?attr/colorAccent"
-            app:fabSize="mini"
-            app:useCompatPadding="true" />
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/layers"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentRight="true"
-            android:layout_gravity="top"
-            android:layout_margin="0dp"
-            android:clickable="true"
-            android:src="@drawable/ic_view_headline_black_36dp"
-            android:theme="@style/Theme.customMain"
-            app:backgroundTint="?attr/colorControlNormal"
-            app:fabSize="mini"
-            app:useCompatPadding="true" />
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/follow"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_centerVertical="true"
-            android:layout_gravity="top"
-            android:clickable="true"
-            android:src="@drawable/ic_gps_fixed_black_36dp"
-            android:theme="@style/Theme.customMain"
-            app:backgroundTint="?attr/colorControlNormal"
-            app:fabSize="mini"
-            app:useCompatPadding="true" />
-        <de.blau.android.views.ZoomControls
-            android:id="@+id/zoom_controls"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentRight="true"
-            android:layout_alignParentBottom="true" />
-    </RelativeLayout>
+        <RelativeLayout
+            android:id="@+id/mainMap"
+            android:layout_width="match_parent"
+            android:layout_height="fill_parent">
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/floatingLock"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:layout_gravity="top"
+                android:layout_margin="8dp"
+                android:clickable="true"
+                android:src="@drawable/lock_bi_state"
+                app:backgroundTint="?attr/colorAccent"
+                app:fabSize="mini"
+                app:useCompatPadding="true" />
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/layers"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentRight="true"
+                android:layout_gravity="top"
+                android:layout_margin="0dp"
+                android:clickable="true"
+                android:src="@drawable/ic_view_headline_black_36dp"
+                android:theme="@style/Theme.customMain"
+                app:backgroundTint="?attr/colorControlNormal"
+                app:fabSize="mini"
+                app:useCompatPadding="true" />
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/follow"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:layout_centerVertical="true"
+                android:layout_gravity="top"
+                android:clickable="true"
+                android:src="@drawable/ic_gps_fixed_black_36dp"
+                android:theme="@style/Theme.customMain"
+                app:backgroundTint="?attr/colorControlNormal"
+                app:fabSize="mini"
+                app:useCompatPadding="true" />
+            <de.blau.android.views.ZoomControls
+                android:id="@+id/zoom_controls"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentRight="true"
+                android:layout_alignParentBottom="true" />
+        </RelativeLayout>
+        <ViewStub
+            android:id="@+id/pane2"
+            android:layout_width="fill_parent"
+            android:layout_height="0dp" />
+    </de.blau.android.views.SplitPaneLayout>
     <FrameLayout
         android:id="@+id/bottomBar"
         android:layout_width="match_parent"

--- a/src/main/res/layout/nearest_pois.xml
+++ b/src/main/res/layout/nearest_pois.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.recyclerview.widget.RecyclerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?colorAccent"
+    android:scrollbars="vertical" />

--- a/src/main/res/layout/pane_view_fullscreen.xml
+++ b/src/main/res/layout/pane_view_fullscreen.xml
@@ -53,7 +53,9 @@
             android:paddingLeft="5dp"
             android:paddingStart="5dp"
             spl:orientation="vertical"
-            spl:splitterBackground="@drawable/splitter_bg_v_dark"
+            spl:splitterBackground="?attr/SplitterBGV"
+            spl:handleBackground="?attr/SplitterHandleH"
+            spl:handleDraggingBackground="@drawable/splitter_handle_dragging_h"
             spl:splitterPosition="33%"
             spl:splitterSize="5dip" >
 

--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -179,6 +179,11 @@
 		<item name="snack_warning">@color/material_orange</item>
 		<item name="snack_error">@color/material_red</item>
         <item name="error">@color/material_red</item>
+        <!--  splitter -->
+        <item name="SplitterBGV">@drawable/splitter_bg_v_dark</item>
+        <item name="SplitterBGH">@drawable/splitter_bg_h_dark</item>
+        <item name="SplitterHandleV">@drawable/splitter_handle_v_dark</item>
+        <item name="SplitterHandleH">@drawable/splitter_handle_h_dark</item>
 	</style>
 	
 	   <style name="Theme.customMain.FullScreen" parent="Theme.customMain">
@@ -252,6 +257,11 @@
 		<item name="snack_warning">@color/material_orange</item>
 		<item name="snack_error">@color/material_red</item>
         <item name="error">@color/material_red</item>
+        <!--  splitter -->
+        <item name="SplitterBGV">@drawable/splitter_bg_v_light</item>
+        <item name="SplitterBGH">@drawable/splitter_bg_h_light</item>
+        <item name="SplitterHandleV">@drawable/splitter_handle_v_light</item>
+        <item name="SplitterHandleH">@drawable/splitter_handle_h_light</item>
 	</style>
 	
 	<style name="Theme.customMain.Light.FullScreen" parent="Theme.customMain.Light">


### PR DESCRIPTION
![Screenshot_1678285518](https://user-images.githubusercontent.com/1011860/223750305-83a6d997-473f-48ae-a4f4-a93765afd1a5.png)

This splits the map display in to the map and a scrollable display of POIs in view, ordered by the distance from the center of the map. All modes and filters continue to work, if no filter is set, either explicitly or by the mode (for example the _Indoor_ mode), the display is limited to a "reasonable" set of objects with keys that imply that they are POIs. If there is a validation issue with the object the entry is highlighted in the corresponding colour as is already the case with the map display.

Closing the display by draging the splitter bar to the bottom disables the feature and has no impact on overall performance. 

Selecting an object from the POI display will

- center the map on the object.
- if the screen is locked, open the information modal for the object.
- if the screen is unlocked and the app is in _Normal_ mode: select the object (selecting it again will start the property editor just as it would via the map .
-  if the screen is unlocked and the app is in _Tag only_ mode: start the property editor directly.

Editing via the map display continues to work as is. On small devices or with large POI display the area on the right will be quite tight in _Indoor_ mode, one workaround is to switch the GPS/GNSS _Follow_ button from the left to the right hand side in the preferences as is shown in the above image.

We are actively soliciting feedback on this feature, not the least as there are a number of aspects that are currently hardwired that could be moved to preferences if there is interest in having custom behaviour. 

If you want access to a development build, add a comment to this issue.