### PR TITLE
Deprecate vending=parcel_pickup and Add amenity=parcel_locker 

### DIFF
--- a/src/main/assets/preset.xml
+++ b/src/main/assets/preset.xml
@@ -11177,7 +11177,7 @@
         <preset_link preset_name="Payment Methods"/>
         <reference ref="optional_level"/>
     </item> <!-- Vending Machine -->
-        <item name="Parcel Locker" icon="icons/png/shopping_vending_machine.png" type="node,closedway" preset_name_label="true">
+    <item name="Parcel Locker" icon="icons/png/shopping_vending_machine.png" type="node,closedway" preset_name_label="true">
             <link wiki="Tag:amenity=parcel_locker"/>
             <space/>
             <key key="amenity" value="parcel_locker"/>
@@ -11187,8 +11187,8 @@
             <reference ref="colours"/>
             <combo key="collection_times" text="Collection times" delimiter="|" values="Mo-Sa 09:00|Mo-Fr 17:30; Sa 12:00|Mo-Fr 15:00,19:00; Sa 15:10; Su 10:30" values_no_i18n="true" match="none" editable="true"/>
             <reference ref="essential_wheelchair"/>
-        </item> <!-- Parcel Locker -->
-        <item name="Payment Methods" icon="icons/png/money_payment_methods.png" type="node,way,closedway,multipolygon,relation" preset_name_label="true">
+     </item> <!-- Parcel Locker -->
+     <item name="Payment Methods" icon="icons/png/money_payment_methods.png" type="node,way,closedway,multipolygon,relation" preset_name_label="true">
         <link wiki="Key:payment"/>
         <space/>
         <check key="payment:cash" text="Cash" match="keyvalue"/>

--- a/src/main/assets/preset.xml
+++ b/src/main/assets/preset.xml
@@ -11152,7 +11152,7 @@
             <list_entry value="milk" short_description="Milk"/>
             <list_entry value="newspapers" short_description="Newspapers"/>
             <list_entry value="parking_tickets" short_description="Parking tickets"/>
-            <list_entry value="parcel_pickup" short_description="Parcel pickup"/>
+            <list_entry value="parcel_pickup" short_description="Parcel pickup" deprecated="true" />
             <list_entry value="parcel_mail_in" short_description="Parcel mail in"/>
             <list_entry value="pet_food" short_description="Animal feed (domestic)"/>
             <list_entry value="pizza" short_description="Pizza"/>
@@ -11177,7 +11177,18 @@
         <preset_link preset_name="Payment Methods"/>
         <reference ref="optional_level"/>
     </item> <!-- Vending Machine -->
-    <item name="Payment Methods" icon="icons/png/money_payment_methods.png" type="node,way,closedway,multipolygon,relation" preset_name_label="true">
+        <item name="Parcel Locker" icon="icons/png/shopping_vending_machine.png" type="node,closedway" preset_name_label="true">
+            <link wiki="Tag:amenity=parcel_locker"/>
+            <space/>
+            <key key="amenity" value="parcel_locker"/>
+            <text key="brand" text="Parcel service brand"/>
+            <text key="operator" text="Machine operator"/>
+            <text key="ref" text="Reference number"/>
+            <reference ref="colours"/>
+            <combo key="collection_times" text="Collection times" delimiter="|" values="Mo-Sa 09:00|Mo-Fr 17:30; Sa 12:00|Mo-Fr 15:00,19:00; Sa 15:10; Su 10:30" values_no_i18n="true" match="none" editable="true"/>
+            <reference ref="essential_wheelchair"/>
+        </item> <!-- Parcel Locker -->
+        <item name="Payment Methods" icon="icons/png/money_payment_methods.png" type="node,way,closedway,multipolygon,relation" preset_name_label="true">
         <link wiki="Key:payment"/>
         <space/>
         <check key="payment:cash" text="Cash" match="keyvalue"/>


### PR DESCRIPTION
fixes #301

The tags have been added according to the tags mentioned in https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dparcel_locker.
I have added 5 tags which seemed necessary, while the wiki page shows 14 related tags. Please let me know if I need to add all 14 tags.