### PR TITLE
Reenable beep on long click

### DIFF
--- a/src/androidTest/java/de/blau/android/easyedit/SimpleActionsTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/SimpleActionsTest.java
@@ -38,6 +38,7 @@ import de.blau.android.Main;
 import de.blau.android.Map;
 import de.blau.android.R;
 import de.blau.android.TestUtils;
+import de.blau.android.dialogs.Tip;
 import de.blau.android.layer.LayerType;
 import de.blau.android.osm.Node;
 import de.blau.android.osm.Way;
@@ -347,5 +348,20 @@ public class SimpleActionsTest {
         TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
         assertTrue(TestUtils.findText(device, false, "test"));
         assertTrue(TestUtils.clickText(device, true, context.getString(R.string.cancel), true, false));
+    }
+    
+    /**
+     * long press and check that we get the tip
+     */
+    // @SdkSuppress(minSdkVersion = 26)
+    @Test
+    public void longClickTip() {
+        Tip.resetTip(main, R.string.tip_longpress_simple_mode_key);
+        map.getDataLayer().setVisible(true);
+        TestUtils.zoomToLevel(device, main, 21);
+        TestUtils.unlock(device);
+        TestUtils.longClickAtCoordinates(device, map, 8.3890736, 47.3896628, true);
+        assertTrue(TestUtils.findText(device, false, main.getString(R.string.tip_title)));
+        TestUtils.clickAwayTip(device, main);
     }
 }

--- a/src/main/java/de/blau/android/Main.java
+++ b/src/main/java/de/blau/android/Main.java
@@ -3578,15 +3578,17 @@ public class Main extends FullScreenAppCompatActivity
                 return true;
             }
             if (logic.isInEditZoomRange()) {
-                if (prefs.areSimpleActionsEnabled() || getEasyEditManager().usesLongClick()) {
-                    if (elementCount == 1 && getEasyEditManager().handleLongClick(v, clickedNodesAndWays.get(0))) {
-                        return true;
-                    }
-                    if (elementCount > 1) {
-                        longClick = true; // another ugly flag
-                        v.showContextMenu();
-                        return true;
-                    }
+                if (prefs.areSimpleActionsEnabled()) {
+                    if (getEasyEditManager().usesLongClick()) {
+                        if (elementCount == 1 && getEasyEditManager().handleLongClick(v, clickedNodesAndWays.get(0))) {
+                            return true;
+                        }
+                        if (elementCount > 1) {
+                            longClick = true; // another ugly flag
+                            v.showContextMenu();
+                            return true;
+                        }
+                    } // fall through to beep
                 } else if (getEasyEditManager().handleLongClick(v, x, y)) {
                     // editing with the screen moving under you is a pain
                     setFollowGPS(false);
@@ -4062,6 +4064,7 @@ public class Main extends FullScreenAppCompatActivity
             }
             return false;
         }
+
     }
 
     /**

--- a/src/main/java/de/blau/android/dialogs/Tip.java
+++ b/src/main/java/de/blau/android/dialogs/Tip.java
@@ -3,6 +3,7 @@ package de.blau.android.dialogs;
 import java.util.ArrayList;
 import java.util.List;
 
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.os.Bundle;
@@ -213,6 +214,16 @@ public class Tip extends ImmersiveDialogFragment {
             View checkContainer = layout.findViewById(R.id.tip_check_container);
             checkContainer.setVisibility(View.GONE);
         }
+    }
+
+    /**
+     * Reset the status of a specific tip
+     * 
+     * @param cxt
+     * @param tipId
+     */
+    public static void resetTip(@NonNull Context cxt, int tipId) {
+        PreferenceManager.getDefaultSharedPreferences(cxt).edit().putBoolean(cxt.getString(tipId), true).commit();
     }
 
     @Override


### PR DESCRIPTION
This fixes a small regression that led to the Tip and beep not being activated on a long click when the screen is unlocked.