### PR TITLE
Make more action modes restartable

### DIFF
--- a/src/main/java/de/blau/android/easyedit/EasyEditActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/EasyEditActionModeCallback.java
@@ -211,6 +211,7 @@ public abstract class EasyEditActionModeCallback implements ActionMode.Callback 
         Log.d(DEBUG_TAG, "onActionItemClicked");
         if (item.getItemId() == MENUITEM_HELP) {
             startHelp();
+            return true;
         }
         return false;
     }

--- a/src/main/java/de/blau/android/easyedit/EasyEditManager.java
+++ b/src/main/java/de/blau/android/easyedit/EasyEditManager.java
@@ -61,9 +61,11 @@ public class EasyEditManager {
 
     private boolean contextMenuEnabled;
 
-    private static final List<String> restartable = Collections.unmodifiableList(
-            Arrays.asList(RouteSegmentActionModeCallback.class.getCanonicalName(), RestartRouteSegmentActionModeCallback.class.getCanonicalName(),
-                    EditRelationMembersActionModeCallback.class.getCanonicalName(), PathCreationActionModeCallback.class.getCanonicalName()));
+    private static final List<String> restartable = Collections.unmodifiableList(Arrays.asList(RouteSegmentActionModeCallback.class.getCanonicalName(),
+            RestartRouteSegmentActionModeCallback.class.getCanonicalName(), EditRelationMembersActionModeCallback.class.getCanonicalName(),
+            PathCreationActionModeCallback.class.getCanonicalName(), WaySegmentModifyActionModeCallback.class.getCanonicalName(),
+            WaySegmentActionModeCallback.class.getCanonicalName(), WaySplittingActionModeCallback.class.getCanonicalName(),
+            ClosedWaySplittingActionModeCallback.class.getCanonicalName(), WaySelectPartActionModeCallback.class.getCanonicalName()));
 
     public static final String              FILENAME     = "easyeditmanager.res";
     private SavingHelper<SerializableState> savingHelper = new SavingHelper<>();
@@ -626,7 +628,6 @@ public class EasyEditManager {
             if (currentActionModeCallback != null) {
                 SerializableState state = new SerializableState();
                 currentActionModeCallback.saveState(state);
-                // FISME wrap in an async task?
                 savingHelper.save(main, FILENAME, state, false, true);
             }
         }

--- a/src/main/java/de/blau/android/easyedit/NonSimpleActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/NonSimpleActionModeCallback.java
@@ -6,7 +6,10 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.view.ActionMode;
 import de.blau.android.App;
 import de.blau.android.R;
+import de.blau.android.osm.Node;
+import de.blau.android.osm.Way;
 import de.blau.android.prefs.Preferences;
+import de.blau.android.util.SerializableState;
 import de.blau.android.util.ThemeUtils;
 
 /**
@@ -16,6 +19,9 @@ import de.blau.android.util.ThemeUtils;
  *
  */
 public class NonSimpleActionModeCallback extends EasyEditActionModeCallback implements android.view.MenuItem.OnMenuItemClickListener {
+
+    protected static final String WAY_ID_KEY  = "way id";
+    protected static final String NODE_ID_KEY = "node id";
 
     protected final Preferences prefs;
 
@@ -31,7 +37,7 @@ public class NonSimpleActionModeCallback extends EasyEditActionModeCallback impl
 
     @Override
     public boolean onCreateActionMode(ActionMode mode, Menu menu) {
-        super.onCreateActionMode(mode, menu); 
+        super.onCreateActionMode(mode, menu);
         return true;
     }
 
@@ -59,5 +65,33 @@ public class NonSimpleActionModeCallback extends EasyEditActionModeCallback impl
     @Override
     public boolean onMenuItemClick(MenuItem arg0) {
         return false;
+    }
+
+    /**
+     * Get a way from saved state
+     * 
+     * @param state the saved state
+     */
+    protected Way getSavedWay(@NonNull SerializableState state) {
+        Long wayId = state.getLong(WAY_ID_KEY);
+        if (wayId != null) {
+            return (Way) App.getDelegator().getOsmElement(Way.NAME, wayId);
+        } else {
+            throw new IllegalStateException("Failed to find way " + wayId);
+        }
+    }
+
+    /**
+     * Get a node from saved state
+     * 
+     * @param state the saved state
+     */
+    protected Node getSavedNode(SerializableState state) {
+        Long nodeId = state.getLong(NODE_ID_KEY);
+        if (nodeId != null) {
+            return (Node) App.getDelegator().getOsmElement(Node.NAME, nodeId);
+        } else {
+            throw new IllegalStateException("Failed to find node " + nodeId);
+        }
     }
 }

--- a/src/main/java/de/blau/android/easyedit/NonSimpleActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/NonSimpleActionModeCallback.java
@@ -31,15 +31,15 @@ public class NonSimpleActionModeCallback extends EasyEditActionModeCallback impl
 
     @Override
     public boolean onCreateActionMode(ActionMode mode, Menu menu) {
-        super.onCreateActionMode(mode, menu);
-        if (prefs.areSimpleActionsEnabled()) {
-            main.disableSimpleActionsButton();
-        }
+        super.onCreateActionMode(mode, menu); 
         return true;
     }
 
     @Override
     public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
+        if (prefs.areSimpleActionsEnabled()) {
+            main.disableSimpleActionsButton();
+        }
         menu = replaceMenu(menu, mode, this);
         super.onPrepareActionMode(mode, menu);
         menu.clear();

--- a/src/main/java/de/blau/android/easyedit/WaySegmentActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/WaySegmentActionModeCallback.java
@@ -17,6 +17,7 @@ import de.blau.android.osm.Result;
 import de.blau.android.osm.Tags;
 import de.blau.android.osm.Way;
 import de.blau.android.util.Geometry;
+import de.blau.android.util.SerializableState;
 import de.blau.android.util.Util;
 
 public class WaySegmentActionModeCallback extends NonSimpleActionModeCallback {
@@ -34,6 +35,17 @@ public class WaySegmentActionModeCallback extends NonSimpleActionModeCallback {
     public WaySegmentActionModeCallback(@NonNull EasyEditManager manager, @NonNull Way way) {
         super(manager);
         this.way = way;
+    }
+
+    /**
+     * Construct a new callback from saved state
+     * 
+     * @param manager the current EasyEditManager instance
+     * @param state the saved state
+     */
+    public WaySegmentActionModeCallback(@NonNull EasyEditManager manager, @NonNull SerializableState state) {
+        super(manager);
+        way = getSavedWay(state);
     }
 
     @Override
@@ -128,5 +140,10 @@ public class WaySegmentActionModeCallback extends NonSimpleActionModeCallback {
         logic.setClickableElements(null);
         logic.setReturnRelations(true);
         super.onDestroyActionMode(mode);
+    }
+
+    @Override
+    public void saveState(SerializableState state) {
+        state.putLong(WAY_ID_KEY, way.getOsmId());
     }
 }

--- a/src/main/java/de/blau/android/easyedit/WaySegmentModifyActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/WaySegmentModifyActionModeCallback.java
@@ -5,10 +5,12 @@ import java.util.HashMap;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
+import androidx.annotation.NonNull;
 import androidx.appcompat.view.ActionMode;
 import de.blau.android.R;
 import de.blau.android.osm.Tags;
 import de.blau.android.osm.Way;
+import de.blau.android.util.SerializableState;
 import de.blau.android.util.ThemeUtils;
 
 public class WaySegmentModifyActionModeCallback extends NonSimpleActionModeCallback {
@@ -31,6 +33,17 @@ public class WaySegmentModifyActionModeCallback extends NonSimpleActionModeCallb
         super(manager);
         Log.d(DEBUG_TAG, "constructor");
         this.way = way;
+    }
+
+    /**
+     * Construct a new callback from saved state
+     * 
+     * @param manager the current EasyEditManager instance
+     * @param state the saved state
+     */
+    public WaySegmentModifyActionModeCallback(@NonNull EasyEditManager manager, @NonNull SerializableState state) {
+        super(manager);
+        way = getSavedWay(state);
     }
 
     @Override
@@ -97,5 +110,10 @@ public class WaySegmentModifyActionModeCallback extends NonSimpleActionModeCallb
             }
         }
         return true;
+    }
+
+    @Override
+    public void saveState(SerializableState state) {
+        state.putLong(WAY_ID_KEY, way.getOsmId());
     }
 }

--- a/src/main/java/de/blau/android/easyedit/WaySelectPartActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/WaySelectPartActionModeCallback.java
@@ -14,6 +14,7 @@ import de.blau.android.osm.Node;
 import de.blau.android.osm.OsmElement;
 import de.blau.android.osm.Result;
 import de.blau.android.osm.Way;
+import de.blau.android.util.SerializableState;
 import de.blau.android.util.Util;
 
 public class WaySelectPartActionModeCallback extends NonSimpleActionModeCallback {
@@ -34,6 +35,18 @@ public class WaySelectPartActionModeCallback extends NonSimpleActionModeCallback
         super(manager);
         this.way = way;
         this.node = node;
+    }
+
+    /**
+     * Construct a new callback from saved state
+     * 
+     * @param manager the current EasyEditManager instance
+     * @param state the saved state
+     */
+    public WaySelectPartActionModeCallback(@NonNull EasyEditManager manager, @NonNull SerializableState state) {
+        super(manager);
+        way = getSavedWay(state);
+        node = getSavedNode(state);
     }
 
     @Override
@@ -78,6 +91,12 @@ public class WaySelectPartActionModeCallback extends NonSimpleActionModeCallback
         return true;
     }
 
+    @Override
+    public void saveState(SerializableState state) {
+        state.putLong(WAY_ID_KEY, way.getOsmId());
+        state.putLong(NODE_ID_KEY, node.getOsmId());
+    }
+    
     @Override
     public void onDestroyActionMode(ActionMode mode) {
         logic.setClickableElements(null);

--- a/src/main/java/de/blau/android/util/SerializableState.java
+++ b/src/main/java/de/blau/android/util/SerializableState.java
@@ -72,6 +72,16 @@ public class SerializableState implements Serializable {
     }
 
     /**
+     * Store a Boolean
+     * 
+     * @param key the key
+     * @param b the Boolean
+     */
+    public void putBoolean(@NonNull String key, @Nullable Boolean b) {
+        state.put(key, b);
+    }
+
+    /**
      * Get a serializable object
      * 
      * @param key the key
@@ -106,6 +116,21 @@ public class SerializableState implements Serializable {
     public Integer getInteger(String key) {
         try {
             return (Integer) state.get(key);
+        } catch (ClassCastException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Get a Boolean
+     * 
+     * @param key the key
+     * @return a Boolean or null if not found or not a Boolean
+     */
+    @Nullable
+    public Boolean getBoolean(@NonNull String key) {
+        try {
+            return (Boolean) state.get(key);
         } catch (ClassCastException e) {
             return null;
         }


### PR DESCRIPTION
This makes the way splitting, segment extraction and way part selection action modes restartable. If further fixes an issue that caused action modes to be terminated when help was selected that was actually the reason for the behaviour mentioned in the ticket. 

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/2223