### PR TITLE
Remove support for value type "conditional"

### DIFF
--- a/src/main/java/de/blau/android/presets/ValueType.java
+++ b/src/main/java/de/blau/android/presets/ValueType.java
@@ -5,7 +5,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 public enum ValueType {
-    OPENING_HOURS, OPENING_HOURS_MIXED, CONDITIONAL, DIMENSION_HORIZONTAL, DIMENSION_VERTICAL, INTEGER, WEBSITE, PHONE, WIKIPEDIA, WIKIDATA;
+    OPENING_HOURS, OPENING_HOURS_MIXED, DIMENSION_HORIZONTAL, DIMENSION_VERTICAL, INTEGER, WEBSITE, PHONE, WIKIPEDIA, WIKIDATA;
 
     /**
      * Get a ValueType corresponding to the input String
@@ -22,9 +22,6 @@ public enum ValueType {
             break;
         case "opening_hours_mixed":
             type = OPENING_HOURS_MIXED;
-            break;
-        case "conditional":
-            type = CONDITIONAL;
             break;
         case "dimension_horizontal":
             type = DIMENSION_HORIZONTAL;

--- a/src/main/java/de/blau/android/propertyeditor/tagform/TagFormFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/TagFormFragment.java
@@ -941,7 +941,7 @@ public class TagFormFragment extends BaseFragment implements FormUpdate {
                     if (field instanceof PresetTextField || key.startsWith(Tags.KEY_ADDR_BASE)
                             || (isComboField && ((PresetComboField) field).isEditable() && ValueType.OPENING_HOURS_MIXED != valueType)
                             || Tags.isConditional(key)) {
-                        if (Tags.isConditional(key) || ValueType.CONDITIONAL == valueType) {
+                        if (Tags.isConditional(key)) {
                             rowLayout.addView(getConditionalRestrictionDialogRow(rowLayout, preset, hint, key, value, values, allTags));
                         } else if (isOpeningHours(key, valueType)) {
                             rowLayout.addView(OpeningHoursDialogRow.getRow(this, inflater, rowLayout, preset, hint, key, value, null));


### PR DESCRIPTION
Preset schema 1.16 removes this value as it is misplaced and unused. Detection of conditional values via the ":conditional" suffix is currently not an issue.

Fixes: https://github.com/MarcusWolschon/osmeditor4android/issues/2250