### PR TITLE
Support bicycle_parking=safe_loops tag value

### DIFF
--- a/src/main/assets/preset.xml
+++ b/src/main/assets/preset.xml
@@ -4542,6 +4542,7 @@
                 <list_entry value="informal" display_value="Informal"/>
                 <list_entry value="lockers" display_value="Lockers"/>
                 <list_entry value="rack" display_value="Rack"/>
+		<list_entry value="safe_loops" display_value="Safe loops" short_description="Wall loops with frame locking support"/>
                 <list_entry value="shed" display_value="Shed"/>
                 <list_entry value="stands" display_value="Stands"/>
                 <list_entry value="wall_loops" display_value="Wall loops" short_description="Wheel benders"/>

--- a/taginfo.json
+++ b/taginfo.json
@@ -5819,6 +5819,7 @@
 {"description":"Transport/Bicycle/Parking","key": "bicycle_parking","value": "informal","object_types": ["node","way","area"]},
 {"description":"Transport/Bicycle/Parking","key": "bicycle_parking","value": "lockers","object_types": ["node","way","area"]},
 {"description":"Transport/Bicycle/Parking","key": "bicycle_parking","value": "rack","object_types": ["node","way","area"]},
+{"description":"Transport/Bicycle/Parking","key": "bicycle_parking","value": "safe_loops","object_types": ["node","way","area"]},
 {"description":"Transport/Bicycle/Parking","key": "bicycle_parking","value": "shed","object_types": ["node","way","area"]},
 {"description":"Transport/Bicycle/Parking","key": "bicycle_parking","value": "stands","object_types": ["node","way","area"]},
 {"description":"Transport/Bicycle/Parking","key": "bicycle_parking","value": "wall_loops","object_types": ["node","way","area"]},


### PR DESCRIPTION
bicycle_parking wiki page <https://wiki.openstreetmap.org/wiki/Key:bicycle_parking> has introduced safe_loops value to distinguish wall-loops with frame locking possibility from wall-loops without such possibility.