### PR TITLE
Compare Strings and not Editables

### DIFF
--- a/src/main/java/de/blau/android/tasks/NoteFragment.java
+++ b/src/main/java/de/blau/android/tasks/NoteFragment.java
@@ -130,11 +130,11 @@ public class NoteFragment extends TaskFragment {
     protected void onShowListener(Task task, Button save, Button upload, Button cancel, Spinner state) {
         super.onShowListener(task, save, upload, cancel, state);
         comment.addTextChangedListener(new TextWatcher() {
-            CharSequence original = comment.getText();
+            final String original = comment.getText().toString();
 
             @Override
             public void afterTextChanged(Editable edited) {
-                boolean changed = !original.equals(edited) || NoteFragment.super.changed(state.getSelectedItemPosition());
+                boolean changed = !original.equals(edited.toString()) || NoteFragment.super.changed(state.getSelectedItemPosition());
                 save.setEnabled(changed);
                 upload.setEnabled(changed);
                 if (changed && state.getSelectedItemPosition() != State.OPEN.ordinal()) {


### PR DESCRIPTION
Seems as if on Android 10 and higher the Editable returned by EditText.getText() is not a copy of the current state but is the current Editable. Converting to a String fixes the issue.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/2255