### PR TITLE
Protect against the view box changing during onDraw

### DIFF
--- a/src/main/java/de/blau/android/layer/data/MapOverlay.java
+++ b/src/main/java/de/blau/android/layer/data/MapOverlay.java
@@ -292,6 +292,7 @@ public class MapOverlay<O extends OsmElement> extends MapViewLayer
     private final List<Node>         nodesResult     = new LowAllocArrayList<>(1000);
     private final List<Way>          waysResult      = new LowAllocArrayList<>(1000);
     private final List<BoundingBox>  downloadedBoxes = new LowAllocArrayList<>();
+    private final ViewBox            viewBox         = new ViewBox();
 
     /**
      * Stuff for multipolygon support Instantiate these objects just once
@@ -447,7 +448,7 @@ public class MapOverlay<O extends OsmElement> extends MapViewLayer
         inNodeIconZoomRange = zoomLevel > DataStyle.getCurrent().getIconZoomLimit();
 
         downloadedBoxes.clear();
-        final ViewBox viewBox = map.getViewBox();
+        viewBox.set(map.getViewBox());
         for (BoundingBox box : delegator.getCurrentStorage().getBoundingBoxes()) {
             if (box.intersects(viewBox)) {
                 downloadedBoxes.add(box);
@@ -475,7 +476,6 @@ public class MapOverlay<O extends OsmElement> extends MapViewLayer
 
         int screenWidth = map.getWidth();
         int screenHeight = map.getHeight();
-        ViewBox viewBox = map.getViewBox();
 
         // first find all nodes and ways that we need to display
         nodesResult.clear();
@@ -1762,7 +1762,7 @@ public class MapOverlay<O extends OsmElement> extends MapViewLayer
 
     @Override
     public void prune() {
-        ViewBox pruneBox = new ViewBox(map.getViewBox());
+        ViewBox pruneBox = new ViewBox(viewBox);
         pruneBox.scale(1.6);
         delegator.prune(pruneBox);
     }

--- a/src/main/java/de/blau/android/layer/photos/MapOverlay.java
+++ b/src/main/java/de/blau/android/layer/photos/MapOverlay.java
@@ -54,16 +54,18 @@ import de.blau.android.views.IMapView;
  */
 public class MapOverlay extends MapViewLayer implements DiscardInterface, ClickableInterface<Photo> {
 
-    private static final String DEBUG_TAG = "PhotoOverlay";
+    private static final String DEBUG_TAG = MapOverlay.class.getSimpleName();
 
-    /** viewbox needs to be less wide than this for displaying bugs, just to avoid querying the whole world for bugs */
-    private static final int TOLERANCE_MIN_VIEWBOX_WIDTH = 40000 * 32;
+    /** viewbox needs to be less wide than this for displaying photos, just to avoid querying the whole world */
+    private static final int TOLERANCE_MAX_VIEWBOX_WIDTH = 40000 * 32;
 
     /** Map this is an overlay of. */
     private final Map map;
 
     /** Photos visible on the overlay. */
     private List<Photo> photos;
+
+    private final ViewBox bb = new ViewBox();
 
     /** have we already run a scan? */
     private boolean indexed = false;
@@ -182,8 +184,8 @@ public class MapOverlay extends MapViewLayer implements DiscardInterface, Clicka
                 return;
             }
 
-            ViewBox bb = osmv.getViewBox();
-            if ((bb.getWidth() > TOLERANCE_MIN_VIEWBOX_WIDTH) || (bb.getHeight() > TOLERANCE_MIN_VIEWBOX_WIDTH)) {
+            bb.set(osmv.getViewBox());
+            if ((bb.getWidth() > TOLERANCE_MAX_VIEWBOX_WIDTH) || (bb.getHeight() > TOLERANCE_MAX_VIEWBOX_WIDTH)) {
                 return;
             }
 

--- a/src/main/java/de/blau/android/layer/tasks/MapOverlay.java
+++ b/src/main/java/de/blau/android/layer/tasks/MapOverlay.java
@@ -94,6 +94,7 @@ public class MapOverlay extends MapViewLayer
 
     private List<Task>        taskList = new ArrayList<>();
     private List<BoundingBox> boxes    = new ArrayList<>();
+    private final ViewBox     bb       = new ViewBox();
 
     private Context context = null;
 
@@ -181,12 +182,12 @@ public class MapOverlay extends MapViewLayer
         int zoomLevel = map.getZoomLevel();
 
         if (isVisible && zoomLevel >= SHOW_TASKS_LIMIT) {
-            ViewBox bb = osmv.getViewBox();
+            bb.set(osmv.getViewBox());
             Location location = map.getLocation();
 
             if (zoomLevel >= panAndZoomLimit && panAndZoomDownLoad && (location == null || location.getSpeed() < maxDownloadSpeed)) {
                 map.getRootView().removeCallbacks(download);
-                download.setBox(map.getViewBox());
+                download.setBox(bb);
                 map.getRootView().postDelayed(download, 100);
             }
 

--- a/src/main/java/de/blau/android/views/layers/MapTilesLayer.java
+++ b/src/main/java/de/blau/android/views/layers/MapTilesLayer.java
@@ -114,6 +114,8 @@ public class MapTilesLayer<T> extends MapViewLayer implements ExtentInterface, L
 
     private final Context ctx;
 
+    private final BoundingBox viewBox = new BoundingBox();
+
     private final TileRenderer<T> mTileRenderer;
 
     // avoid creating new Rects in onDraw
@@ -371,7 +373,8 @@ public class MapTilesLayer<T> extends MapViewLayer implements ExtentInterface, L
         if (!isVisible) {
             return;
         }
-        BoundingBox viewBox = osmv.getViewBox();
+
+        viewBox.set(osmv.getViewBox());
         if (!myRendererInfo.covers(viewBox)) {
             if (!coverageWarningDisplayed) {
                 coverageWarningDisplayed = true;


### PR DESCRIPTION
There is no real indication that this can happen but it would seem to wise to protect against this as it might circumvent some of the protections against rendering too much data.