### PR TITLE
Fix changing the role of an element via the relations tab

### DIFF
--- a/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
+++ b/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
@@ -546,7 +546,7 @@ public class PropertyEditorTest {
         }
         main.getMap().getDataLayer().setVisible(true);
         TestUtils.unlock(device);
-        TestUtils.zoomToLevel(device, main, 22);
+        TestUtils.zoomToLevel(device, main, 23);
         TestUtils.clickAtCoordinates(device, main.getMap(), 8.3848461, 47.3899166, true);
         TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
         assertTrue(TestUtils.clickText(device, false, "Kindhauserstrasse", false, false));
@@ -612,9 +612,22 @@ public class PropertyEditorTest {
         List<Relation> parents = w.getParentRelations();
         assertNotNull(parents);
         assertTrue(findRole("platform", w, parents));
+        
+        // find the parent relation we modifed
+        Relation found = null;
+        for (Relation p:parents) {
+            if (p.getTagWithKey(Tags.KEY_NAME).startsWith("Bus 305: Kind")) {
+                found = p;
+                break;
+            }
+        }
+        assertNotNull(found);
+        assertTrue(App.getDelegator().getApiStorage().contains(found));
+        
         TestUtils.clickMenuButton(device, context.getString(R.string.undo), false, true);
         assertFalse(findRole("platform", w, parents));
-
+        assertFalse(App.getDelegator().getApiStorage().contains(found));
+        
         assertEquals(pos, determinePosition(w, "Bus 305: Kind"));
 
         //

--- a/src/main/java/de/blau/android/osm/StorageDelegator.java
+++ b/src/main/java/de/blau/android/osm/StorageDelegator.java
@@ -2066,6 +2066,9 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
                     for (RelationMemberPosition newMember : newMembers) {
                         if (!leftOvers.isEmpty()) {
                             RelationMemberPosition member = leftOvers.get(0);
+                            if (!member.getRole().equals(newMember.getRole())) {
+                                apiStorage.insertElementSafe(o);
+                            }
                             member.setRole(newMember.getRole());
                             leftOvers.remove(member);
                         } else {
@@ -2074,6 +2077,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
                     }
                     for (RelationMemberPosition rmp : leftOvers) { // these are no longer needed
                         o.removeMember(rmp.getRelationMember());
+                        apiStorage.insertElementSafe(o);
                     }
                 }
             }


### PR DESCRIPTION
Just changing the role of an element in a relation via the relations tab didn't add the affected parent relation to the API storage and as a consequence didn't add it to the upload.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/2287