### PR TITLE
Move populating changes view to onStart

### DIFF
--- a/src/main/java/de/blau/android/dialogs/AbstractReviewDialog.java
+++ b/src/main/java/de/blau/android/dialogs/AbstractReviewDialog.java
@@ -1,0 +1,262 @@
+package de.blau.android.dialogs;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.content.res.Resources;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.ListView;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.graphics.drawable.DrawableCompat;
+import androidx.fragment.app.FragmentActivity;
+import de.blau.android.App;
+import de.blau.android.Main;
+import de.blau.android.R;
+import de.blau.android.osm.Node;
+import de.blau.android.osm.OsmElement;
+import de.blau.android.osm.Relation;
+import de.blau.android.osm.Way;
+import de.blau.android.util.ImmersiveDialogFragment;
+import de.blau.android.util.ThemeUtils;
+import de.blau.android.validation.ExtendedValidator;
+import de.blau.android.validation.Validator;
+
+/**
+ * Common methods for review of changes
+ */
+public abstract class AbstractReviewDialog extends ImmersiveDialogFragment {
+
+    private static final String DEBUG_TAG = AbstractReviewDialog.class.getSimpleName();
+
+    protected static final String TAG_KEY      = "tag";
+    protected static final String ELEMENTS_KEY = "elements";
+
+    protected List<OsmElement> elements = null;
+
+    private static final Comparator<ChangedElement> DEFAULT_COMPARATOR = (ce0, ce1) -> {
+        OsmElement element0 = ce0.element;
+        OsmElement element1 = ce1.element;
+        int problems0 = element0.getCachedProblems();
+        int problems1 = element1.getCachedProblems();
+        if (problems0 > Validator.OK && problems1 <= Validator.OK) {
+            return -1;
+        }
+        if (problems0 <= Validator.OK && problems1 > Validator.OK) {
+            return 1;
+        }
+        if (element0.isTagged() && !element1.isTagged()) {
+            return -1;
+        }
+        if (!element0.isTagged() && element1.isTagged()) {
+            return 1;
+        }
+        byte ce0State = element0.getState();
+        byte ce1State = element1.getState();
+        if (ce0State == OsmElement.STATE_CREATED && ce1State != OsmElement.STATE_CREATED) {
+            return -1;
+        }
+        if (ce0State != OsmElement.STATE_CREATED && ce1State == OsmElement.STATE_CREATED) {
+            return 1;
+        }
+        if (ce0State == OsmElement.STATE_MODIFIED && ce1State == OsmElement.STATE_DELETED) {
+            return -1;
+        }
+        if (ce0State == OsmElement.STATE_DELETED && ce1State == OsmElement.STATE_MODIFIED) {
+            return 1;
+        }
+        String ce0Type = element0.getName();
+        String ce1Type = element1.getName();
+        if (Node.NAME.equals(ce0Type) && !Node.NAME.equals(ce1Type)) {
+            return -1;
+        }
+        if (Way.NAME.equals(ce0Type) && Relation.NAME.equals(ce1Type)) {
+            return -1;
+        }
+        if (Way.NAME.equals(ce0Type) && Node.NAME.equals(ce1Type)) {
+            return 1;
+        }
+        if (Relation.NAME.equals(ce0Type) && !Relation.NAME.equals(ce1Type)) {
+            return 1;
+        }
+        return 0;
+    };
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        Log.d(DEBUG_TAG, "onStart");
+        addChangesToView(getActivity(), (ListView) requireDialog().findViewById(R.id.upload_changes), elements, DEFAULT_COMPARATOR,
+                getArguments().getString(TAG_KEY));
+    }
+
+    /**
+     * Add changes to a ListView
+     * 
+     * @param activity the current Activity
+     * @param changesView the ListView used to hold the changes views
+     * @param elements a List of OsmElement or null
+     * @param comparator a Comparator for sorting the changes
+     * @param parentTag tag of parent dialog
+     */
+    private void addChangesToView(@NonNull final FragmentActivity activity, @NonNull final ListView changesView, @Nullable List<OsmElement> elements,
+            @NonNull Comparator<ChangedElement> comparator, @Nullable String parentTag) {
+        ExtendedValidator validator = new ExtendedValidator(activity, App.getDefaultValidator(activity));
+        final ChangedElement[] changes = getPendingChanges(activity.getResources(), elements == null ? App.getLogic().getPendingChangedElements() : elements);
+        revalidate(activity, validator, changes);
+        Arrays.sort(changes, comparator);
+
+        changesView.setAdapter(new ValidatorArrayAdapter(activity, R.layout.changes_list_item, changes, validator));
+        changesView.setOnItemClickListener((parent, view, position, id) -> {
+            ChangedElement clicked = changes[position];
+            OsmElement element = clicked.element;
+            byte elemenState = element.getState();
+            boolean deleted = elemenState == OsmElement.STATE_DELETED;
+            if (elemenState == OsmElement.STATE_MODIFIED || deleted) {
+                ElementInfo.showDialog(activity, 0, element, !deleted, parentTag);
+            } else {
+                ElementInfo.showDialog(activity, element, !deleted, parentTag);
+            }
+        });
+    }
+
+    /**
+     * Rerun validation on the changes
+     * 
+     * @param context an Android Context
+     * @param validator the Validator to use
+     * @param changes the list of changes
+     */
+    private void revalidate(@NonNull Context context, @NonNull Validator validator, @NonNull final ChangedElement[] changes) {
+        for (ChangedElement ce : changes) {
+            OsmElement element = ce.element;
+            element.resetHasProblem();
+            element.hasProblem(context, validator);
+        }
+        if (context instanceof Main) {
+            ((Main) context).invalidateMap();
+        }
+    }
+
+    static class ChangedElement {
+        final OsmElement element;
+        final String     description;
+
+        /**
+         * Construct a new instance
+         * 
+         * @param resources the current Resources
+         * @param element the OsmElement to wrap
+         */
+        ChangedElement(@NonNull Resources resources, @NonNull OsmElement element) {
+            this.element = element;
+            description = element.getStateDescription(resources);
+        }
+
+        @Override
+        public String toString() {
+            return description;
+        }
+    }
+
+    /**
+     * Get the pending changes
+     * 
+     * This will sort the result in a reasonable way: tagged elements first then untagged, newly created before modified
+     * and then deleted, then the convention node, way and relation ordering.
+     * 
+     * @param resources the current Resources
+     * @param changedElements the (unsorted) list of changed elements
+     * @return a List of all pending pending elements to upload
+     */
+    @NonNull
+    private static ChangedElement[] getPendingChanges(@NonNull Resources resources, @NonNull List<OsmElement> changedElements) {
+        List<ChangedElement> result = new ArrayList<>();
+        for (OsmElement e : changedElements) {
+            result.add(new ChangedElement(resources, e));
+        }
+        return result.toArray(new ChangedElement[result.size()]);
+    }
+
+    /**
+     * Highlight elements for upload that have a potential issue
+     * 
+     * @author Simon Poole
+     *
+     */
+    private static class ValidatorArrayAdapter extends ArrayAdapter<ChangedElement> {
+        final ChangedElement[] elements;
+        final Validator        validator;
+        final ColorStateList   colorStateList;
+
+        /**
+         * Construct a new instance
+         * 
+         * @param context Android Context
+         * @param resource the resource id of the per item layout
+         * @param elements the array holding the elements
+         * @param validator the Validator to use
+         */
+        public ValidatorArrayAdapter(@NonNull Context context, int resource, @NonNull ChangedElement[] elements, @NonNull Validator validator) {
+            super(context, resource, elements);
+            this.elements = elements;
+            this.validator = validator;
+            colorStateList = ColorStateList.valueOf(ThemeUtils.getStyleAttribColorValue(context, R.attr.snack_error, R.color.material_red));
+        }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup container) {
+            View v = super.getView(position, convertView, container);
+            TextView textView = (TextView) v.findViewById(R.id.text1);
+            if (textView != null) {
+                OsmElement element = elements[position].element;
+                if (OsmElement.STATE_DELETED != element.getState() && element.hasProblem(null, validator) != Validator.OK) {
+                    setTintList(textView, colorStateList);
+                } else {
+                    setTintList(textView, null);
+                }
+            } else {
+                Log.e("ValidatorAdapterView", "position " + position + " view is null");
+            }
+            return v;
+        }
+
+        /**
+         * Backwards compatible way of setting the a tint list on a TextView
+         * 
+         * @param textView the TextView
+         * @param stateList the ColorStateList
+         */
+        void setTintList(@NonNull TextView textView, @Nullable ColorStateList stateList) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                textView.setCompoundDrawableTintList(stateList);
+            } else {
+                for (Drawable d : textView.getCompoundDrawables()) {
+                    if (d != null) {
+                        DrawableCompat.setTintList(d, stateList);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        Log.d(DEBUG_TAG, "onSaveInstanceState");
+        if (elements != null) {
+            outState.putSerializable(ELEMENTS_KEY, new ArrayList<>(elements));
+        }
+    }
+}

--- a/src/main/java/de/blau/android/dialogs/Review.java
+++ b/src/main/java/de/blau/android/dialogs/Review.java
@@ -4,7 +4,6 @@ import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
-import android.widget.ListView;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AlertDialog.Builder;
@@ -13,14 +12,13 @@ import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import de.blau.android.R;
 import de.blau.android.util.ACRAHelper;
-import de.blau.android.util.ImmersiveDialogFragment;
 import de.blau.android.util.ThemeUtils;
 
 /**
  * Dialog for review of changes (cut down version of ReviewAndUpload
  *
  */
-public class Review extends ImmersiveDialogFragment {
+public class Review extends AbstractReviewDialog {
 
     private static final String DEBUG_TAG = Review.class.getSimpleName();
 
@@ -35,9 +33,9 @@ public class Review extends ImmersiveDialogFragment {
         dismissDialog(activity);
 
         FragmentManager fm = activity.getSupportFragmentManager();
-        Review confirmUploadDialogFragment = newInstance();
+        Review reviewDialogFragment = newInstance();
         try {
-            confirmUploadDialogFragment.show(fm, TAG);
+            reviewDialogFragment.show(fm, TAG);
         } catch (IllegalStateException isex) {
             Log.e(DEBUG_TAG, "showDialog", isex);
             ACRAHelper.nocrashReport(isex, isex.getMessage());
@@ -61,6 +59,9 @@ public class Review extends ImmersiveDialogFragment {
     @NonNull
     private static Review newInstance() {
         Review f = new Review();
+        Bundle args = new Bundle();
+        args.putString(TAG_KEY, TAG);
+        f.setArguments(args);
         f.setShowsDialog(true);
         return f;
     }
@@ -77,8 +78,6 @@ public class Review extends ImmersiveDialogFragment {
 
         final View layout = inflater.inflate(R.layout.review, null);
         builder.setView(layout);
-
-        ReviewAndUpload.addChangesToView(activity, (ListView) layout.findViewById(R.id.upload_changes), null, ReviewAndUpload.DEFAULT_COMPARATOR, Review.TAG);
 
         builder.setNegativeButton(R.string.Done, null);
 

--- a/src/main/java/de/blau/android/dialogs/ReviewAndUpload.java
+++ b/src/main/java/de/blau/android/dialogs/ReviewAndUpload.java
@@ -2,16 +2,11 @@ package de.blau.android.dialogs;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.DialogInterface;
-import android.content.res.ColorStateList;
-import android.content.res.Resources;
-import android.graphics.drawable.Drawable;
-import android.os.Build;
 import android.os.Bundle;
 import android.text.InputType;
 import android.util.Log;
@@ -20,49 +15,38 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.View.OnKeyListener;
-import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.ArrayAdapter;
 import android.widget.AutoCompleteTextView;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.ImageButton;
-import android.widget.ListView;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AlertDialog.Builder;
 import androidx.appcompat.app.AppCompatDialog;
-import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import androidx.viewpager.widget.PagerTabStrip;
 import de.blau.android.App;
 import de.blau.android.Logic;
-import de.blau.android.Main;
 import de.blau.android.R;
 import de.blau.android.listener.UploadListener;
-import de.blau.android.osm.Node;
 import de.blau.android.osm.OsmElement;
-import de.blau.android.osm.Relation;
 import de.blau.android.osm.Server;
-import de.blau.android.osm.Way;
 import de.blau.android.prefs.Preferences;
 import de.blau.android.propertyeditor.tagform.TextRow;
 import de.blau.android.util.ACRAHelper;
 import de.blau.android.util.FilterlessArrayAdapter;
-import de.blau.android.util.ImmersiveDialogFragment;
 import de.blau.android.util.LocaleUtils;
 import de.blau.android.util.OnPageSelectedListener;
 import de.blau.android.util.ThemeUtils;
 import de.blau.android.util.Util;
-import de.blau.android.validation.ExtendedValidator;
 import de.blau.android.validation.FormValidation;
 import de.blau.android.validation.NotEmptyValidator;
-import de.blau.android.validation.Validator;
 import de.blau.android.views.ExtendedViewPager;
 
 /**
@@ -70,12 +54,11 @@ import de.blau.android.views.ExtendedViewPager;
  * 
  *
  */
-public class ReviewAndUpload extends ImmersiveDialogFragment {
+public class ReviewAndUpload extends AbstractReviewDialog {
 
     private static final String DEBUG_TAG = ReviewAndUpload.class.getSimpleName();
 
-    public static final String  TAG          = "fragment_confirm_upload";
-    private static final String ELEMENTS_KEY = "elements";
+    public static final String TAG = "fragment_confirm_upload";
 
     private static final int NO_PAGE   = -1;
     public static final int  TAGS_PAGE = 1;
@@ -84,56 +67,6 @@ public class ReviewAndUpload extends ImmersiveDialogFragment {
 
     private AutoCompleteTextView comment;
     private AutoCompleteTextView source;
-
-    private List<OsmElement> elements = null;
-
-    static final Comparator<ChangedElement> DEFAULT_COMPARATOR = (ce0, ce1) -> {
-        OsmElement element0 = ce0.element;
-        OsmElement element1 = ce1.element;
-        int problems0 = element0.getCachedProblems();
-        int problems1 = element1.getCachedProblems();
-        if (problems0 > Validator.OK && problems1 <= Validator.OK) {
-            return -1;
-        }
-        if (problems0 <= Validator.OK && problems1 > Validator.OK) {
-            return 1;
-        }
-        if (element0.isTagged() && !element1.isTagged()) {
-            return -1;
-        }
-        if (!element0.isTagged() && element1.isTagged()) {
-            return 1;
-        }
-        byte ce0State = element0.getState();
-        byte ce1State = element1.getState();
-        if (ce0State == OsmElement.STATE_CREATED && ce1State != OsmElement.STATE_CREATED) {
-            return -1;
-        }
-        if (ce0State != OsmElement.STATE_CREATED && ce1State == OsmElement.STATE_CREATED) {
-            return 1;
-        }
-        if (ce0State == OsmElement.STATE_MODIFIED && ce1State == OsmElement.STATE_DELETED) {
-            return -1;
-        }
-        if (ce0State == OsmElement.STATE_DELETED && ce1State == OsmElement.STATE_MODIFIED) {
-            return 1;
-        }
-        String ce0Type = element0.getName();
-        String ce1Type = element1.getName();
-        if (Node.NAME.equals(ce0Type) && !Node.NAME.equals(ce1Type)) {
-            return -1;
-        }
-        if (Way.NAME.equals(ce0Type) && Relation.NAME.equals(ce1Type)) {
-            return -1;
-        }
-        if (Way.NAME.equals(ce0Type) && Node.NAME.equals(ce1Type)) {
-            return 1;
-        }
-        if (Relation.NAME.equals(ce0Type) && !Relation.NAME.equals(ce1Type)) {
-            return 1;
-        }
-        return 0;
-    };
 
     /**
      * Instantiate and show the dialog
@@ -173,6 +106,7 @@ public class ReviewAndUpload extends ImmersiveDialogFragment {
     private static ReviewAndUpload newInstance(@Nullable List<OsmElement> elements) {
         ReviewAndUpload f = new ReviewAndUpload();
         Bundle args = new Bundle();
+        args.putString(TAG_KEY, TAG);
         if (elements != null) {
             args.putSerializable(ELEMENTS_KEY, new ArrayList<>(elements));
         }
@@ -186,6 +120,7 @@ public class ReviewAndUpload extends ImmersiveDialogFragment {
     @SuppressLint("InflateParams")
     @Override
     public AppCompatDialog onCreateDialog(Bundle savedInstanceState) {
+        Log.d(DEBUG_TAG, "onCreateDialog");
         if (savedInstanceState != null) {
             Log.d(DEBUG_TAG, "restoring from saved state");
             elements = (List<OsmElement>) savedInstanceState.getSerializable(ELEMENTS_KEY);
@@ -226,8 +161,6 @@ public class ReviewAndUpload extends ImmersiveDialogFragment {
         TextView changesHeading = (TextView) layout.findViewById(R.id.review_heading);
         int changeCount = elements == null ? App.getDelegator().getApiElementCount() : elements.size();
         changesHeading.setText(getResources().getQuantityString(R.plurals.confirm_upload_text, changeCount, changeCount));
-
-        addChangesToView(activity, (ListView) layout.findViewById(R.id.upload_changes), elements, DEFAULT_COMPARATOR, ReviewAndUpload.TAG);
 
         // Comment and upload page
         Preferences prefs = App.getPreferences(activity);
@@ -300,54 +233,6 @@ public class ReviewAndUpload extends ImmersiveDialogFragment {
         }
     }
 
-    /**
-     * Add changes to a ListView
-     * 
-     * @param activity the current Activity
-     * @param changesView the ListView used to hold the changes views
-     * @param elements a List of OsmElement or null
-     * @param comparator a Comparator for sorting the changes
-     * @param parentTag tag of parent dialog
-     */
-    static void addChangesToView(@NonNull final FragmentActivity activity, @NonNull final ListView changesView, @Nullable List<OsmElement> elements,
-            @NonNull Comparator<ChangedElement> comparator, @Nullable String parentTag) {
-        ExtendedValidator validator = new ExtendedValidator(activity, App.getDefaultValidator(activity));
-        final ChangedElement[] changes = getPendingChanges(activity.getResources(), elements == null ? App.getLogic().getPendingChangedElements() : elements);
-        revalidate(activity, validator, changes);
-        Arrays.sort(changes, comparator);
-
-        changesView.setAdapter(new ValidatorArrayAdapter(activity, R.layout.changes_list_item, changes, validator));
-        changesView.setOnItemClickListener((parent, view, position, id) -> {
-            ChangedElement clicked = changes[position];
-            OsmElement element = clicked.element;
-            byte elemenState = element.getState();
-            boolean deleted = elemenState == OsmElement.STATE_DELETED;
-            if (elemenState == OsmElement.STATE_MODIFIED || deleted) {
-                ElementInfo.showDialog(activity, 0, element, !deleted, parentTag);
-            } else {
-                ElementInfo.showDialog(activity, element, !deleted, parentTag);
-            }
-        });
-    }
-
-    /**
-     * Rerun validation on the changes
-     * 
-     * @param context an Android Context
-     * @param validator the Validator to use
-     * @param changes the list of changes
-     */
-    private static void revalidate(@NonNull Context context, @NonNull Validator validator, @NonNull final ChangedElement[] changes) {
-        for (ChangedElement ce : changes) {
-            OsmElement element = ce.element;
-            element.resetHasProblem();
-            element.hasProblem(context, validator);
-        }
-        if (context instanceof Main) {
-            ((Main) context).invalidateMap();
-        }
-    }
-
     @Override
     public void onCancel(DialogInterface dialog) {
         super.onCancel(dialog);
@@ -401,46 +286,6 @@ public class ReviewAndUpload extends ImmersiveDialogFragment {
         return NO_PAGE;
     }
 
-    static class ChangedElement {
-        final OsmElement element;
-        final String     description;
-
-        /**
-         * Construct a new instance
-         * 
-         * @param resources the current Resources
-         * @param element the OsmElement to wrap
-         */
-        ChangedElement(@NonNull Resources resources, @NonNull OsmElement element) {
-            this.element = element;
-            description = element.getStateDescription(resources);
-        }
-
-        @Override
-        public String toString() {
-            return description;
-        }
-    }
-
-    /**
-     * Get the pending changes
-     * 
-     * This will sort the result in a reasonable way: tagged elements first then untagged, newly created before modified
-     * and then deleted, then the convention node, way and relation ordering.
-     * 
-     * @param resources the current Resources
-     * @param changedElements the (unsorted) list of changed elements
-     * @return a List of all pending pending elements to upload
-     */
-    @NonNull
-    private static ChangedElement[] getPendingChanges(@NonNull Resources resources, @NonNull List<OsmElement> changedElements) {
-        List<ChangedElement> result = new ArrayList<>();
-        for (OsmElement e : changedElements) {
-            result.add(new ChangedElement(resources, e));
-        }
-        return result.toArray(new ChangedElement[result.size()]);
-    }
-
     /**
      * For whatever reason the softkeyboard doesn't work as expected with AutoCompleteTextViews This listener simply
      * moves focus to the next view below on enter being pressed or dismisses the keyboard
@@ -471,76 +316,6 @@ public class ReviewAndUpload extends ImmersiveDialogFragment {
                 }
             }
             return false;
-        }
-    }
-
-    /**
-     * Highlight elements for upload that have a potential issue
-     * 
-     * @author Simon Poole
-     *
-     */
-    private static class ValidatorArrayAdapter extends ArrayAdapter<ChangedElement> {
-        final ChangedElement[] elements;
-        final Validator        validator;
-        final ColorStateList   colorStateList;
-
-        /**
-         * Construct a new instance
-         * 
-         * @param context Android Context
-         * @param resource the resource id of the per item layout
-         * @param elements the array holding the elements
-         * @param validator the Validator to use
-         */
-        public ValidatorArrayAdapter(@NonNull Context context, int resource, @NonNull ChangedElement[] elements, @NonNull Validator validator) {
-            super(context, resource, elements);
-            this.elements = elements;
-            this.validator = validator;
-            colorStateList = ColorStateList.valueOf(ThemeUtils.getStyleAttribColorValue(context, R.attr.snack_error, R.color.material_red));
-        }
-
-        @Override
-        public View getView(int position, View convertView, ViewGroup container) {
-            View v = super.getView(position, convertView, container);
-            TextView textView = (TextView) v.findViewById(R.id.text1);
-            if (textView != null) {
-                OsmElement element = elements[position].element;
-                if (OsmElement.STATE_DELETED != element.getState() && element.hasProblem(null, validator) != Validator.OK) {
-                    setTintList(textView, colorStateList);
-                } else {
-                    setTintList(textView, null);
-                }
-            } else {
-                Log.e("ValidatorAdapterView", "position " + position + " view is null");
-            }
-            return v;
-        }
-
-        /**
-         * Backwards compatible way of setting the a tint list on a TextView
-         * 
-         * @param textView the TextView
-         * @param stateList the ColorStateList
-         */
-        void setTintList(@NonNull TextView textView, @Nullable ColorStateList stateList) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                textView.setCompoundDrawableTintList(stateList);
-            } else {
-                for (Drawable d : textView.getCompoundDrawables()) {
-                    if (d != null) {
-                        DrawableCompat.setTintList(d, stateList);
-                    }
-                }
-            }
-        }
-    }
-
-    @Override
-    public void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
-        if (elements != null) {
-            outState.putSerializable(ELEMENTS_KEY, new ArrayList<>(elements));
         }
     }
 }


### PR DESCRIPTION
This makes changes to the objects visible for validation when the modal is "restarted" after tag editing.

Fixes: https://github.com/MarcusWolschon/osmeditor4android/issues/2291