### PR TITLE
Only join to ways

### DIFF
--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -2433,6 +2433,10 @@ public class Logic {
         if (!elements.isEmpty()) {
             createCheckpoint(activity, R.string.undo_action_join);
             for (OsmElement element : elements) {
+                if (!(element instanceof Way)) {
+                    // Note if no ways are in elements this will create an empty checkpoint
+                    continue;
+                }
                 nodeToJoin = (Node) (result != null ? result.get(0).getElement() : nodeToJoin);
                 Way way = (Way) element;
                 List<Node> wayNodes = way.getNodes();

--- a/src/test/java/de/blau/android/LogicTest.java
+++ b/src/test/java/de/blau/android/LogicTest.java
@@ -3,6 +3,9 @@ package de.blau.android;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -12,6 +15,7 @@ import org.robolectric.annotation.Config;
 
 import androidx.test.filters.LargeTest;
 import de.blau.android.osm.Node;
+import de.blau.android.osm.OsmElement;
 import de.blau.android.osm.Way;
 import de.blau.android.util.Util;
 
@@ -45,5 +49,26 @@ public class LogicTest {
         Node n = (Node) App.getDelegator().getOsmElement(Node.NAME, -8);
         App.getLogic().performJoinNodeToWays(null, Util.wrapInList(pan), n);
         assertEquals(5, pan.getNodes().indexOf(n));
+    }
+
+    /**
+     * Test if node gets merged and additional Node is ignored
+     * 
+     */
+    @Test
+    public void mergeNodeToWay() {
+        UnitTestUtils.loadTestData(getClass(), "join_to_way.osm");
+        Way way = (Way) App.getDelegator().getOsmElement(Way.NAME, -1);
+        assertNotNull(way);
+        main.zoomTo(way);
+        Node n1 = (Node) App.getDelegator().getOsmElement(Node.NAME, -3);
+        assertNotNull(n1);
+        Node n2 = (Node) App.getDelegator().getOsmElement(Node.NAME, -4);
+        assertNotNull(n2);
+        List<OsmElement> list = new ArrayList<>();
+        list.add(way);
+        list.add(n2);
+        App.getLogic().performJoinNodeToWays(null, list, n1);
+        assertEquals(1, way.getNodes().indexOf(n1));
     }
 }

--- a/src/test/resources/join_to_way.osm
+++ b/src/test/resources/join_to_way.osm
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<osm generator="Vespucci/19.0.0.0" version="0.6" upload="true">
+    <node id="-1" action="modify" version="1" timestamp="2023-06-01T06:41:06Z" visible="true" lat="47.389711" lon="8.385914" />
+    <node id="-2" action="modify" version="1" timestamp="2023-06-01T06:41:07Z" visible="true" lat="47.3896084" lon="8.3859956" />
+    <node id="-3" action="modify" version="1" timestamp="2023-06-01T06:41:25Z" visible="true" lat="47.3896624" lon="8.385954" />
+    <node id="-4" action="modify" version="1" timestamp="2023-06-01T06:41:51Z" visible="true" lat="47.3896003" lon="8.3858915">
+        <tag k="public_transport" v="stop_position" />
+    </node>
+    <way id="-1" action="modify" version="1" timestamp="2023-06-01T06:41:07Z" visible="true">
+        <nd ref="-1" />
+        <nd ref="-2" />
+   </way>
+</osm>


### PR DESCRIPTION
Protect against a ClassCastException when intersecting ways and further non-way elements are selected (for example a node).