### PR TITLE
Protect against ToneGenerator constructor failing

### DIFF
--- a/src/main/java/de/blau/android/util/Sound.java
+++ b/src/main/java/de/blau/android/util/Sound.java
@@ -4,13 +4,15 @@ import android.media.AudioManager;
 import android.media.ToneGenerator;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.Log;
 import de.blau.android.App;
 import de.blau.android.prefs.Preferences;
 
 public final class Sound {
+    private static final String DEBUG_TAG = Sound.class.getSimpleName();
 
-    private static final int BEEP_DURATION = 200;
-    public static final int BEEP_DEFAULT_VOLUME   = 50;
+    private static final int BEEP_DURATION       = 200;
+    public static final int  BEEP_DEFAULT_VOLUME = 50;
 
     /**
      * Private constructor to prevent instantiation
@@ -18,7 +20,7 @@ public final class Sound {
     private Sound() {
         // nothing
     }
-    
+
     /**
      * Beep
      */
@@ -28,13 +30,17 @@ public final class Sound {
         if (prefs != null) {
             volume = prefs.getBeepVolume();
         }
-        ToneGenerator toneGenerator = new ToneGenerator(AudioManager.STREAM_ALARM, volume);
-        toneGenerator.startTone(ToneGenerator.TONE_CDMA_ALERT_CALL_GUARD, BEEP_DURATION);
-        Handler handler = new Handler(Looper.getMainLooper());
-        handler.postDelayed(() -> {
-            if (toneGenerator != null) {
-                toneGenerator.release();
-            }
-        }, BEEP_DURATION + 50L);
+        try {
+            ToneGenerator toneGenerator = new ToneGenerator(AudioManager.STREAM_ALARM, volume);
+            toneGenerator.startTone(ToneGenerator.TONE_CDMA_ALERT_CALL_GUARD, BEEP_DURATION);
+            Handler handler = new Handler(Looper.getMainLooper());
+            handler.postDelayed(() -> {
+                if (toneGenerator != null) {
+                    toneGenerator.release();
+                }
+            }, BEEP_DURATION + 50L);
+        } catch (RuntimeException rex) { // NOSONAR
+            Log.e(DEBUG_TAG, "beep failed with " + rex.getMessage());
+        }
     }
 }


### PR DESCRIPTION
If a beep is already being played, the constructor may fail, 

A better solution might be to create the ToneGenerator instance in App and lock against concurrent use.