### PR TITLE
Add a "safe" shortcut

### DIFF
--- a/src/main/java/de/blau/android/Splash.java
+++ b/src/main/java/de/blau/android/Splash.java
@@ -20,6 +20,7 @@ import androidx.core.splashscreen.SplashScreen;
 import androidx.preference.PreferenceManager;
 import de.blau.android.contract.Paths;
 import de.blau.android.dialogs.Progress;
+import de.blau.android.resources.DataStyle;
 import de.blau.android.resources.KeyDatabaseHelper;
 import de.blau.android.resources.TileLayerDatabase;
 import de.blau.android.resources.TileLayerSource;
@@ -35,9 +36,11 @@ import de.blau.android.util.FileUtil;
  *
  */
 public class Splash extends AppCompatActivity {
+
     private static final String DEBUG_TAG = Splash.class.getSimpleName();
 
-    static final String SHORTCUT_EXTRAS_KEY = "shortcut_extras";
+    static final String         SHORTCUT_EXTRAS_KEY = "shortcut_extras";
+    private static final String SAFE                = "safe";
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -59,6 +62,15 @@ public class Splash extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
         Log.d(DEBUG_TAG, "onResume");
+        final Bundle shortcutExtras = getIntent().getExtras();
+        if (shortcutExtras != null && shortcutExtras.getBoolean(SAFE)) { 
+            // do anything here to make startup safe
+            // currently this is only setting the data style to the minimal built in version to avoid issues with Skia
+            Log.d(DEBUG_TAG, "Starting in safe mode!");
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+            prefs.edit().putString(getString(R.string.config_mapProfile_key), DataStyle.getBuiltinStyleName()).commit();
+        }
+
         new ExecutorTask<Void, Void, Void>() {
 
             boolean newInstall;
@@ -118,7 +130,7 @@ public class Splash extends AppCompatActivity {
                 App.getCurrentPresets(Splash.this);
                 //
                 Intent intent = new Intent(Splash.this, Main.class);
-                intent.putExtra(SHORTCUT_EXTRAS_KEY, getIntent().getExtras());
+                intent.putExtra(SHORTCUT_EXTRAS_KEY, shortcutExtras);
                 startActivity(intent);
                 return null;
             }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -9,6 +9,9 @@
     <string name="mode_address">Address</string>
     <string name="mode_voice">Voice</string>
     
+    <!--  additional short cuts -->
+    <string name="shortcut_safe">Safe</string>
+    
     <!-- Dialogs -->
     <string name="transfer_download_current_dialog_title">Caution!</string>
     <string name="transfer_download_current_dialog_message">You have made changes. Do you want to upload instead of discarding them?</string>

--- a/src/main/res/xml/shortcuts.xml
+++ b/src/main/res/xml/shortcuts.xml
@@ -12,17 +12,17 @@
     <categories android:name="android.shortcut.conversation" />
   </shortcut>
   <shortcut
-    android:shortcutId="indoor"
+    android:shortcutId="safe"
     android:enabled="true"
     android:icon="@drawable/vespucci_logo_foreground"
-    android:shortcutShortLabel="@string/mode_indoor"
-    android:shortcutLongLabel="@string/mode_indoor" >   
+    android:shortcutShortLabel="@string/shortcut_safe"
+    android:shortcutLongLabel="@string/shortcut_safe" >   
     <intent
       android:action="android.intent.action.MAIN"
       android:targetPackage="de.blau.android"
       android:targetClass="de.blau.android.Splash">
-        <extra android:name="mode" android:value="MODE_INDOOR" />
-      </intent>
+        <extra android:name="safe" android:value="true" />
+    </intent>
     <categories android:name="android.shortcut.conversation" />
   </shortcut>
   <shortcut
@@ -36,7 +36,7 @@
       android:targetPackage="de.blau.android"
       android:targetClass="de.blau.android.Splash">
         <extra android:name="mode" android:value="MODE_TAG_EDIT" />
-      </intent>
+    </intent>
     <categories android:name="android.shortcut.conversation" />
   </shortcut>
   <shortcut
@@ -50,7 +50,21 @@
       android:targetPackage="de.blau.android"
       android:targetClass="de.blau.android.Splash">
         <extra android:name="mode" android:value="MODE_ADDRESS" />
-      </intent>
+    </intent>
+    <categories android:name="android.shortcut.conversation" />
+  </shortcut>
+  <shortcut
+    android:shortcutId="indoor"
+    android:enabled="true"
+    android:icon="@drawable/vespucci_logo_foreground"
+    android:shortcutShortLabel="@string/mode_indoor"
+    android:shortcutLongLabel="@string/mode_indoor" >   
+    <intent
+      android:action="android.intent.action.MAIN"
+      android:targetPackage="de.blau.android"
+      android:targetClass="de.blau.android.Splash">
+        <extra android:name="mode" android:value="MODE_INDOOR" />
+    </intent>
     <categories android:name="android.shortcut.conversation" />
   </shortcut>
 </shortcuts>


### PR DESCRIPTION
Starting via the shortcut will set the data rendering style to the builtin minimal style to work around Skia issues on Android versions prior to Android 9. 

As Android launchers seem to only support 4 shortcuts this means the shortcut for indoor mode will not be available on standard launchers.

Workaround for https://github.com/MarcusWolschon/osmeditor4android/issues/2274

Workaround for https://github.com/MarcusWolschon/osmeditor4android/issues/2298
