### PR TITLE
Improve route and relation handling in split window property editor

### DIFF
--- a/documentation/docs/help/en/Property editor.md
+++ b/documentation/docs/help/en/Property editor.md
@@ -11,7 +11,7 @@ Depending on size and orientation of your device the layout will change to make 
  
 If the property editor is started with multiple elements selected only the _Details_ and _Presets_ tabs will be available. Tabs can be changed by swiping or by tapping the header.
 
-If the _Display tag form_ preference in the _Advanced preferences_ has been disabled pre-0.9.8 behaviour is enabled and the _Details_ tab will have the heading _Properties_.
+If the _Display tag form_ preference in the _[Advanced preferences](Advanced%20preferences.md)_ has been disabled pre-0.9.8 behaviour is enabled and the _Details_ tab will have the heading _Properties_.
 
 In the tabs tapping the checkbox in the header row will select/de-select all elements.
 
@@ -113,7 +113,7 @@ Start the on device help browser.
 
 This tab will only be displayed if you are editing a relation, it displays entries for all the members of the relation.
 
-Members with a dark object field and only a numeric id displayed have not been downloaded.
+Members with a dark object field and only a numeric id displayed have not been downloaded, member highlighted in blue can be clicked on and a new property editor will be opened for the element. Note: during such a drill down operation the property editors are stacked, if you close a stacked property editor you will be returned to the previous one and so on.
 
 The following operation can be performed on selected relation members.
 
@@ -159,3 +159,9 @@ Go up one level.
 ### ![Help](../images/menu_help.png) Help
 
 Start the on device help browser.
+
+## Split window mode
+
+On devices running Android 7 and later you can enable an __experimental__ split window mode in the [Experimental](Advanced%20preferences.md) section of the preferences. When this is enabled and the screen is split (on Android 12 and later this will happen automatically), the property editor will be displayed in parallel with the map display. If you click on a relation member in the _Member Tab_ the element will be selected and the map display will zoom to it. While this will work both on phones and tablets, the usefulness on the former is limited. 
+
+Changes to the data made in the map display will be reflected as far as possible in the property editor, for example changes if relation membership, deletions and so on, note however that currently later changes will override changes made in earlier property editor instances.

--- a/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
+++ b/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
@@ -1341,7 +1341,7 @@ public class PropertyEditorTest {
         if (!((PropertyEditorActivity) propertyEditor).usingPaneLayout()) {
             TestUtils.clickText(device, true, main.getString(R.string.menu_tags), false, false);
         }
-        PropertyEditorFragment f = PropertyEditorActivity.peekBackStack(((PropertyEditorActivity) propertyEditor).getSupportFragmentManager());
+        PropertyEditorFragment<?, ?, ?> f = ((PropertyEditorActivity<?, ?, ?>) propertyEditor).peekBackStack(((PropertyEditorActivity) propertyEditor).getSupportFragmentManager());
         assertNotNull(f);
         PresetItem presetItem = f.getBestPreset();
         assertNotNull(presetItem);

--- a/src/main/assets/help/en/Main map display.html
+++ b/src/main/assets/help/en/Main map display.html
@@ -146,8 +146,8 @@
 <ul>
 <li><strong>Show location</strong> - show arrow symbol at current position</li>
 <li><strong>Follow location</strong> - pan and center screen to follow the current position, will enable <em>Show location</em> too.</li>
-<li><strong>Add bookmark...</strong> - set a bookmark for the current viewbox</li>
 <li><strong>Bookmarks...</strong> - show current viewbox bookmarks</li>
+<li><strong>Add bookmark...</strong> - set a bookmark for the current viewbox</li>
 <li><strong>Go to the nearest todo...</strong> - go to the nearest open todo. If you are following the GPS position or it is in the current view this is relative to that position, otherwise it is relative to the center of the current view. If there are more than one active todo list you will be prompted to select one.</li>
 <li><strong>Go to current location</strong> - go to and zoom in to the current position. If location updates are not turned on, this will try to get a location without enabling continuous updates. Latitude, longitude, and height over the ellipsoid are shown, and you can create a new node at the coordinates including the height over the ellipsoid. You can also choose to share the position.</li>
 <li><strong>Go to coordinates...</strong> - go to and zoom in to coordinates (latitude longitude) or an open location code Supported formats are the following, with dots or optionally a comma as the decimal marker, variations on the units also accepted e.g. °, d, º, g, o.

--- a/src/main/assets/help/en/Property editor.html
+++ b/src/main/assets/help/en/Property editor.html
@@ -14,7 +14,7 @@
 <li>large devices in portrait orientation: multi pane layout with a pane for the tabs, one for the <em>Recently Used Presets</em> and for the <em>Presets</em> screen</li>
 </ul>
 <p>If the property editor is started with multiple elements selected only the <em>Details</em> and <em>Presets</em> tabs will be available. Tabs can be changed by swiping or by tapping the header.</p>
-<p>If the <em>Display tag form</em> preference in the <em>Advanced preferences</em> has been disabled pre-0.9.8 behaviour is enabled and the <em>Details</em> tab will have the heading <em>Properties</em>.</p>
+<p>If the <em>Display tag form</em> preference in the <em><a href="Advanced%20preferences.md">Advanced preferences</a></em> has been disabled pre-0.9.8 behaviour is enabled and the <em>Details</em> tab will have the heading <em>Properties</em>.</p>
 <p>In the tabs tapping the checkbox in the header row will select/de-select all elements.</p>
 <h2>Properties Tab</h2>
 <p>This tab gives a simplified, preset-driven, editing screen for the tags on the selected object on which the keys are represented by their description. To remove individual attributes you can simply remove or reset the value (or delete them in the <em>Details</em> tab).</p>
@@ -70,7 +70,7 @@
 <p>Start the on device help browser.</p>
 <h2>Members Tab</h2>
 <p>This tab will only be displayed if you are editing a relation, it displays entries for all the members of the relation.</p>
-<p>Members with a dark object field and only a numeric id displayed have not been downloaded.</p>
+<p>Members with a dark object field and only a numeric id displayed have not been downloaded, member highlighted in blue can be clicked on and a new property editor will be opened for the element. Note: during such a drill down operation the property editors are stacked, if you close a stacked property editor you will be returned to the previous one and so on.</p>
 <p>The following operation can be performed on selected relation members.</p>
 <ul>
 <li><em>Delete</em> - remove the object from this (the edited) relation.</li>
@@ -99,6 +99,9 @@
 <p>Go up one level.</p>
 <h3><img src="../images/menu_help.png" alt="Help" /> Help</h3>
 <p>Start the on device help browser.</p>
+<h2>Split window mode</h2>
+<p>On devices running Android 7 and later you can enable an <strong>experimental</strong> split window mode in the <a href="Advanced%20preferences.md">Experimental</a> section of the preferences. When this is enabled and the screen is split (on Android 12 and later this will happen automatically), the property editor will be displayed in parallel with the map display. If you click on a relation member in the <em>Member Tab</em> the element will be selected and the map display will zoom to it. While this will work both on phones and tablets, the usefulness on the former is limited.</p>
+<p>Changes to the data made in the map display will be reflected as far as possible in the property editor, for example changes if relation membership, deletions and so on, note however that currently later changes will override changes made in earlier property editor instances.</p>
 
 </body>
 </html>

--- a/src/main/java/de/blau/android/DebugInformation.java
+++ b/src/main/java/de/blau/android/DebugInformation.java
@@ -112,6 +112,13 @@ public class DebugInformation extends LocaleAwareCompatActivity {
             } else {
                 builder.append("Map not available, this is a seriously curious state, please report a bug!" + eol);
             }
+
+            builder.append("Selection stack" + eol);
+            int pos = 0;
+            for (Selection s : logic.getSelectionStack()) {
+                builder.append("Selection " + pos + " " + s.nodeCount() + " nodes " + s.wayCount() + " ways " + s.relationCount() + " relations" + eol);
+                pos++;
+            }
         } else {
             builder.append("Logic not available, this is a seriously curious state, please report a bug!" + eol);
         }

--- a/src/main/java/de/blau/android/Main.java
+++ b/src/main/java/de/blau/android/Main.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -231,13 +232,14 @@ public class Main extends FullScreenAppCompatActivity
     public static final int VOICE_RECOGNITION_REQUEST_CODE      = 3;
     public static final int VOICE_RECOGNITION_NOTE_REQUEST_CODE = 4;
 
-    public static final String ACTION_EXIT             = "de.blau.android.EXIT";
-    public static final String ACTION_UPDATE           = "de.blau.android.UPDATE";
-    public static final String ACTION_DELETE_PHOTO     = "de.blau.android.DELETE_PHOTO";
-    public static final String ACTION_MAPILLARY_SELECT = "de.blau.android.ACTION_MAPILLARY_SELECT";
-    public static final String ACTION_MAP_UPDATE       = "de.blau.android.MAP_UPDATE";
-    public static final String ACTION_PUSH_SELECTION   = "de.blau.android.PUSH_SELECTION";
-    public static final String ACTION_POP_SELECTION    = "de.blau.android.POP_SELECTION";
+    public static final String ACTION_EXIT                  = "de.blau.android.EXIT";
+    public static final String ACTION_UPDATE                = "de.blau.android.UPDATE";
+    public static final String ACTION_DELETE_PHOTO          = "de.blau.android.DELETE_PHOTO";
+    public static final String ACTION_MAPILLARY_SELECT      = "de.blau.android.ACTION_MAPILLARY_SELECT";
+    public static final String ACTION_MAP_UPDATE            = "de.blau.android.MAP_UPDATE";
+    public static final String ACTION_PUSH_SELECTION        = "de.blau.android.PUSH_SELECTION";
+    public static final String ACTION_POP_SELECTION         = "de.blau.android.POP_SELECTION";
+    public static final String ACTION_CLEAR_SELECTION_STACK = "de.blau.android.CLEAR_SELECTION_STACK";
 
     /**
      * Alpha value for floating action buttons workaround We should probably find a better place for this
@@ -1045,13 +1047,19 @@ public class Main extends FullScreenAppCompatActivity
                             logic.pushSelection(selection);
                         } else {
                             logic.popSelection();
-                        }                       
+                        }
                         final List<OsmElement> selectedElements = logic.getSelectedElements();
                         zoomTo(selectedElements);
                         if (Mode.MODE_EASYEDIT == logic.getMode() && !selectedElements.isEmpty()) {
                             getEasyEditManager().startElementSelectionMode();
                         }
                         invalidateMap();
+                        break;
+                    case ACTION_CLEAR_SELECTION_STACK:
+                        Deque<Selection> stack = logic.getSelectionStack();
+                        while (stack.size() > 1) {
+                            logic.popSelection();
+                        }
                         break;
                     default:
                         // carry on

--- a/src/main/java/de/blau/android/osm/RelationUtils.java
+++ b/src/main/java/de/blau/android/osm/RelationUtils.java
@@ -379,6 +379,7 @@ public final class RelationUtils {
      * 
      * @param list List of relation members
      * @param temp List of relation members used for processing in the method
+     * @param c method to determine if ways are connected
      * @return fully or partially sorted List of RelationMembers, if partially sorted the unsorted elements will come
      *         first
      * @param <T> Class that extents RelationMember

--- a/src/main/java/de/blau/android/propertyeditor/DataUpdate.java
+++ b/src/main/java/de/blau/android/propertyeditor/DataUpdate.java
@@ -1,0 +1,9 @@
+package de.blau.android.propertyeditor;
+
+public interface DataUpdate {
+
+    /**
+     * Called when the OSM data may have changed and we might need to update
+     */
+    abstract void onDataUpdate();
+}

--- a/src/main/java/de/blau/android/propertyeditor/PresetFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/PresetFragment.java
@@ -1,5 +1,6 @@
 package de.blau.android.propertyeditor;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -119,8 +120,8 @@ public class PresetFragment extends BaseFragment implements PresetUpdate, Preset
      * @param paneMode we are displayed in Pane mode
      * @return a new PResetFragment
      */
-    public static PresetFragment newInstance(long elementId, @NonNull String elementName, @Nullable ArrayList<PresetElementPath> alternateRootPath,
-            boolean paneMode) {
+    public static <L extends List<PresetElementPath> & Serializable> PresetFragment newInstance(long elementId, @NonNull String elementName,
+            @Nullable L alternateRootPath, boolean paneMode) {
         PresetFragment f = new PresetFragment();
 
         Bundle args = new Bundle();

--- a/src/main/java/de/blau/android/propertyeditor/PropertyEditorActivity.java
+++ b/src/main/java/de/blau/android/propertyeditor/PropertyEditorActivity.java
@@ -134,6 +134,17 @@ public class PropertyEditorActivity extends LocaleAwareCompatActivity implements
         }
     }
 
+    @Override
+    public void onTopResumedActivityChanged(boolean topResumed) {
+        Log.d(DEBUG_TAG, "onTopResumedActivityChanged " + topResumed);
+        if (topResumed) {
+            Fragment fragment = peekBackStack(getSupportFragmentManager());
+            if (fragment instanceof PropertyEditorFragment) {
+                ((PropertyEditorFragment) fragment).onHiddenChanged(false);
+            }
+        }
+    }
+
     /**
      * Add the Fragment from an Intent
      * 
@@ -160,8 +171,8 @@ public class PropertyEditorActivity extends LocaleAwareCompatActivity implements
         Log.d(DEBUG_TAG, "... done.");
 
         // sanity check
-        if (loadData == null) {
-            abort("loadData null");
+        if (loadData.length == 0) {
+            abort("loadData is empty");
             return;
         }
 
@@ -260,13 +271,14 @@ public class PropertyEditorActivity extends LocaleAwareCompatActivity implements
     public void finished(@Nullable Fragment finishedFragment) {
         final FragmentManager fm = getSupportFragmentManager();
         int count = backStackCount(fm);
+        final boolean notWaiting = getCallingActivity() == null;
         if (count > 1) {
             fm.popBackStackImmediate();
             PropertyEditorFragment top = peekBackStack(fm);
-            final boolean notWaiting = getCallingActivity() == null;
             if (top != null) { // still have a fragment on the stack
                 FragmentTransaction ft = fm.beginTransaction();
                 ft.show(top);
+                ft.commit();
                 if (notWaiting) { // calling activity is not waiting for us
                     startActivity(getIntent(Main.ACTION_POP_SELECTION));
                     return;
@@ -276,6 +288,9 @@ public class PropertyEditorActivity extends LocaleAwareCompatActivity implements
                 startActivity(getIntent(Main.ACTION_MAP_UPDATE));
             }
             return;
+        }
+        if (notWaiting) {
+            startActivity(getIntent(Main.ACTION_CLEAR_SELECTION_STACK));
         }
         finish();
     }

--- a/src/main/java/de/blau/android/propertyeditor/PropertyEditorActivity.java
+++ b/src/main/java/de/blau/android/propertyeditor/PropertyEditorActivity.java
@@ -352,7 +352,7 @@ public class PropertyEditorActivity extends LocaleAwareCompatActivity implements
                 if (f instanceof PropertyEditorFragment) {
                     return (PropertyEditorFragment) f;
                 }
-                Log.e(DEBUG_TAG, "Unexpected fragment " + f.getClass().getCanonicalName());
+                Log.e(DEBUG_TAG, "Unexpected fragment " + (f != null ? f.getClass().getCanonicalName() : " is null"));
             }
         }
         return null;

--- a/src/main/java/de/blau/android/propertyeditor/PropertyEditorFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/PropertyEditorFragment.java
@@ -159,7 +159,7 @@ public class PropertyEditorFragment extends BaseFragment implements PropertyEdit
     /**
      * 
      */
-    private ArrayList<LinkedHashMap<String, String>> originalTags;
+    private List<Map<String, String>> originalTags;
 
     /**
      * the same for relations
@@ -287,7 +287,6 @@ public class PropertyEditorFragment extends BaseFragment implements PropertyEdit
         }
 
         presets = App.getCurrentPresets(getContext());
-
     }
 
     @Override
@@ -904,7 +903,7 @@ public class PropertyEditorFragment extends BaseFragment implements PropertyEdit
             return;
         }
 
-        List<LinkedHashMap<String, String>> currentTags = getUpdatedTags();
+        List<Map<String, String>> currentTags = getUpdatedTags();
 
         // save any address tags for "last address tags"
         final int elementCount = currentTags.size();
@@ -922,7 +921,7 @@ public class PropertyEditorFragment extends BaseFragment implements PropertyEdit
                     Log.w(DEBUG_TAG, "element " + types[i] + osmIds[i] + " is deleted");
                     continue;
                 }
-                final LinkedHashMap<String, String> tags = currentTags.get(i);
+                final Map<String, String> tags = currentTags.get(i);
                 if (!originalTags.get(i).equals(tags)) {
                     try {
                         logic.setTags(getActivity(), types[i], osmIds[i], tags);
@@ -981,7 +980,7 @@ public class PropertyEditorFragment extends BaseFragment implements PropertyEdit
      * @param tags2 second list of tags
      * @return true if the lists are the same
      */
-    private boolean same(@Nullable List<LinkedHashMap<String, String>> tags1, @Nullable List<LinkedHashMap<String, String>> tags2) {
+    private boolean same(@Nullable List<Map<String, String>> tags1, @Nullable List<Map<String, String>> tags2) {
         if (tags1 == null) {
             return tags2 == null;
         }
@@ -1043,7 +1042,7 @@ public class PropertyEditorFragment extends BaseFragment implements PropertyEdit
         if (tagFormFragment != null) {
             tagFormFragment.updateEditorFromText();
         }
-        List<LinkedHashMap<String, String>> currentTags = getUpdatedTags();
+        List<Map<String, String>> currentTags = getUpdatedTags();
         MultiHashMap<Long, RelationMemberPosition> currentParents = null;
         List<RelationMemberDescription> currentMembers = null;
         if (relationMembershipFragment != null) {
@@ -1227,13 +1226,18 @@ public class PropertyEditorFragment extends BaseFragment implements PropertyEdit
     }
 
     @Override
-    public List<LinkedHashMap<String, String>> getUpdatedTags() {
+    public List<Map<String, String>> getUpdatedTags() {
         if (tagEditorFragment != null) {
             return tagEditorFragment.getUpdatedTags();
         } else {
             Log.e(DEBUG_TAG, "getUpdatedTags tagEditorFragment is null");
             return new ArrayList<>();
         }
+    }
+
+    @Override
+    public List<Map<String, String>> getOriginalTags() {
+        return originalTags;
     }
 
     @Override

--- a/src/main/java/de/blau/android/propertyeditor/PropertyEditorFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/PropertyEditorFragment.java
@@ -528,57 +528,87 @@ public class PropertyEditorFragment extends BaseFragment implements PropertyEdit
         }
 
         /**
-         * Get a new TagFormFragment instance
+         * Get s PresetFragment instance
          * 
+         * @param instantiate the fragment
+         * 
+         * @return a PresetFragment instance
+         */
+        private Fragment presetFragment(boolean instantiate) {
+            if (instantiate) {
+                presetFragment = PresetFragment.newInstance(getElement().getOsmId(), getElement().getName(), presetsToApply, false); //
+            }
+            return presetFragment;
+        }
+
+        /**
+         * Get a TagFormFragment instance
+         * 
+         * @param instantiate the fragment
          * @param position position in the Pager
          * @param displayRecentPresets if true display the MRU Fragment
+         * 
          * @return a TagFormFragment instance
          */
         @NonNull
-        Fragment tagFormFragment(int position, boolean displayRecentPresets) {
+        Fragment tagFormFragment(boolean instantiate, int position, boolean displayRecentPresets) {
             tagFormFragmentPosition = position;
-            tagFormFragment = TagFormFragment.newInstance(displayRecentPresets, applyLastAddressTags, loadData[0].focusOnKey);
+            if (instantiate) {
+                tagFormFragment = TagFormFragment.newInstance(displayRecentPresets, applyLastAddressTags, loadData[0].focusOnKey);
+            }
             return tagFormFragment;
         }
 
         /**
-         * Get a new TagEditorFragment instance
+         * Get a TagEditorFragment instance
          * 
+         * @param instantiate the fragment
          * @param position position in the Pager
          * @param displayRecentPresets if true display the MRU Fragment
+         * 
          * @return a TagEditorFragment instance
          */
         @NonNull
-        Fragment tagEditorFragment(int position, boolean displayRecentPresets) {
+        Fragment tagEditorFragment(boolean instantiate, int position, boolean displayRecentPresets) {
             tagEditorFragmentPosition = position;
-            tagEditorFragment = TagEditorFragment.newInstance(osmIds, types, tags, applyLastAddressTags, loadData[0].focusOnKey, displayRecentPresets,
-                    extraTags, presetsToApply);
+            if (instantiate) {
+                tagEditorFragment = TagEditorFragment.newInstance(osmIds, types, tags, applyLastAddressTags, loadData[0].focusOnKey, displayRecentPresets,
+                        extraTags, presetsToApply);
+            }
             return tagEditorFragment;
         }
 
         /**
-         * Get a new RelationMembershipFragment instance
+         * Get a RelationMembershipFragment instance
+         * 
+         * @param instantiate the fragment
          * 
          * @return a RelationMembershipFragment instance
          */
         @Nullable
-        Fragment relationMembershipFragment() {
+        Fragment relationMembershipFragment(boolean instantiate) {
             if (loadData.length == 1) {
-                relationMembershipFragment = RelationMembershipFragment.newInstance(loadData[0].parents, types[0]);
+                if (instantiate) {
+                    relationMembershipFragment = RelationMembershipFragment.newInstance(loadData[0].parents, types[0]);
+                }
                 return relationMembershipFragment;
             }
             return null;
         }
 
         /**
-         * Get a new RelationMembersFragment instance
+         * Get a RelationMembersFragment instance
+         * 
+         * @param instantiate the fragment
          * 
          * @return a new RelationMembersFragment instance
          */
         @Nullable
-        Fragment relationMembersFragment() {
+        Fragment relationMembersFragment(boolean instantiate) {
             if (loadData.length == 1 && types[0].endsWith(Relation.NAME)) {
-                relationMembersFragment = RelationMembersFragment.newInstance(osmIds[0], loadData[0].members);
+                if (instantiate) {
+                    relationMembersFragment = RelationMembersFragment.newInstance(osmIds[0], loadData[0].members);
+                }
                 return relationMembersFragment;
             }
             return null;
@@ -604,33 +634,28 @@ public class PropertyEditorFragment extends BaseFragment implements PropertyEdit
                 if (!usePaneLayout) {
                     switch (position) {
                     case 0:
-                        if (instantiate) {
-                            presetFragment = PresetFragment.newInstance(getElement().getOsmId(), getElement().getName(), presetsToApply, false); //
-                        }
-                        return presetFragment;
+                        return presetFragment(instantiate);
                     case 1:
-                        return instantiate ? tagFormFragment(position, true) : tagFormFragment;
+                        return tagFormFragment(instantiate, position, true);
                     case 2:
-                        return instantiate ? tagEditorFragment(position, false) : tagEditorFragment;
+                        return tagEditorFragment(instantiate, position, false);
                     case 3:
-                        return isRelation ? (instantiate ? relationMembersFragment() : relationMembersFragment)
-                                : (instantiate ? relationMembershipFragment() : relationMembershipFragment);
+                        return getRelationMemberFragment(instantiate);
                     case 4:
-                        return instantiate ? relationMembershipFragment() : relationMembershipFragment;
+                        return relationMembershipFragment(instantiate);
                     default:
                         // ERROR
                     }
                 } else {
                     switch (position) {
                     case 0:
-                        return instantiate ? tagFormFragment(position, false) : tagFormFragment;
+                        return tagFormFragment(instantiate, position, false);
                     case 1:
-                        return instantiate ? tagEditorFragment(position, false) : tagEditorFragment;
+                        return tagEditorFragment(instantiate, position, false);
                     case 2:
-                        return isRelation ? (instantiate ? relationMembersFragment() : relationMembersFragment)
-                                : (instantiate ? relationMembershipFragment() : relationMembershipFragment);
+                        return getRelationMemberFragment(instantiate);
                     case 3:
-                        return instantiate ? relationMembershipFragment() : relationMembershipFragment;
+                        return relationMembershipFragment(instantiate);
                     default:
                         // ERROR
                     }
@@ -639,29 +664,24 @@ public class PropertyEditorFragment extends BaseFragment implements PropertyEdit
                 if (!usePaneLayout) {
                     switch (position) {
                     case 0:
-                        if (instantiate) {
-                            presetFragment = PresetFragment.newInstance(getElement().getOsmId(), getElement().getName(), presetsToApply, false); //
-                        }
-                        return presetFragment;
+                        return presetFragment(instantiate);
                     case 1:
-                        return instantiate ? tagEditorFragment(position, true) : tagEditorFragment;
+                        return tagEditorFragment(instantiate, position, true);
                     case 2:
-                        return isRelation ? (instantiate ? relationMembersFragment() : relationMembersFragment)
-                                : (instantiate ? relationMembershipFragment() : relationMembershipFragment);
+                        return getRelationMemberFragment(instantiate);
                     case 3:
-                        return instantiate ? relationMembershipFragment() : relationMembershipFragment;
+                        return relationMembershipFragment(instantiate);
                     default:
                         // ERROR
                     }
                 } else {
                     switch (position) {
                     case 0:
-                        return instantiate ? tagEditorFragment(position, false) : tagEditorFragment;
+                        return tagEditorFragment(instantiate, position, false);
                     case 1:
-                        return isRelation ? (instantiate ? relationMembersFragment() : relationMembersFragment)
-                                : (instantiate ? relationMembershipFragment() : relationMembershipFragment);
+                        return getRelationMemberFragment(instantiate);
                     case 2:
-                        return instantiate ? relationMembershipFragment() : relationMembershipFragment;
+                        return relationMembershipFragment(instantiate);
                     default:
                         // ERROR
                     }
@@ -669,6 +689,17 @@ public class PropertyEditorFragment extends BaseFragment implements PropertyEdit
             }
             Log.e(DEBUG_TAG, "Unknown position " + position);
             return null;
+        }
+
+        /**
+         * Get the RelationMembersFragment if we are editing a relation, otherwise return the RelationMembershipFragment
+         * 
+         * @param instantiate if we need to instantiate the fragment
+         * @return the appropriate fragment
+         */
+        @Nullable
+        private Fragment getRelationMemberFragment(boolean instantiate) {
+            return isRelation ? relationMembersFragment(instantiate) : relationMembershipFragment(instantiate);
         }
 
         @Override
@@ -684,7 +715,7 @@ public class PropertyEditorFragment extends BaseFragment implements PropertyEdit
                     case 2:
                         return getString(R.string.tag_details);
                     case 3:
-                        return isRelation ? getString(R.string.members) : getString(R.string.relations);
+                        return getRelationFragmentTitle();
                     case 4:
                         return getString(R.string.relations);
                     default:
@@ -697,7 +728,7 @@ public class PropertyEditorFragment extends BaseFragment implements PropertyEdit
                     case 1:
                         return getString(R.string.tag_details);
                     case 2:
-                        return isRelation ? getString(R.string.members) : getString(R.string.relations);
+                        return getRelationFragmentTitle();
                     case 3:
                         return getString(R.string.relations);
                     default:
@@ -712,7 +743,7 @@ public class PropertyEditorFragment extends BaseFragment implements PropertyEdit
                     case 1:
                         return getString(R.string.menu_tags);
                     case 2:
-                        return isRelation ? getString(R.string.members) : getString(R.string.relations);
+                        return getRelationFragmentTitle();
                     case 3:
                         return getString(R.string.relations);
                     default:
@@ -723,7 +754,7 @@ public class PropertyEditorFragment extends BaseFragment implements PropertyEdit
                     case 0:
                         return getString(R.string.menu_tags);
                     case 1:
-                        return isRelation ? getString(R.string.members) : getString(R.string.relations);
+                        return getRelationFragmentTitle();
                     case 2:
                         return getString(R.string.relations);
                     default:
@@ -733,6 +764,17 @@ public class PropertyEditorFragment extends BaseFragment implements PropertyEdit
             }
             Log.e(DEBUG_TAG, "Unknown position " + position);
             return "error";
+        }
+
+        /**
+         * Get the title of the RelationMembersFragment if we are editing a relation, otherwise return the
+         * RelationMembershipFragment title
+         * 
+         * @return the appropriate title
+         */
+        @NonNull
+        private CharSequence getRelationFragmentTitle() {
+            return isRelation ? getString(R.string.members) : getString(R.string.relations);
         }
 
         /**
@@ -752,23 +794,19 @@ public class PropertyEditorFragment extends BaseFragment implements PropertyEdit
         public Object instantiateItem(ViewGroup container, int position) {
             BaseFragment fragment = (BaseFragment) super.instantiateItem(container, position);
             // update fragment refs here
+            Log.d(DEBUG_TAG, "Restoring ref to " + fragment.getClass().getSimpleName());
             if (fragment instanceof TagFormFragment) {
                 tagFormFragment = (TagFormFragment) fragment;
-                Log.d(DEBUG_TAG, "Restored ref to TagFormFragment");
+                tagFormFragmentPosition = position;
             } else if (fragment instanceof TagEditorFragment) {
                 tagEditorFragment = (TagEditorFragment) fragment;
-                Log.d(DEBUG_TAG, "Restored ref to TagEditorFragment");
+                tagEditorFragmentPosition = position;
             } else if (fragment instanceof RelationMembershipFragment) {
                 relationMembershipFragment = (RelationMembershipFragment) fragment;
-                Log.d(DEBUG_TAG, "Restored ref to RelationMembershipFragment");
             } else if (fragment instanceof RelationMembersFragment) {
                 relationMembersFragment = (RelationMembersFragment) fragment;
-                Log.d(DEBUG_TAG, "Restored ref to RelationMembersFragment");
             } else if (fragment instanceof PresetFragment) {
                 presetFragment = (PresetFragment) fragment;
-                Log.d(DEBUG_TAG, "Restored ref to PresetFragment");
-            } else {
-                Log.d(DEBUG_TAG, "Unknown fragment ...");
             }
             // hack to recreate the form ui when restoring as there is no callback that
             // runs after the references here have been recreated
@@ -898,7 +936,6 @@ public class PropertyEditorFragment extends BaseFragment implements PropertyEdit
      * Get current values from the fragments and end the fragment
      */
     public void updateAndFinish() {
-
         if (!validateTags()) {
             return;
         }

--- a/src/main/java/de/blau/android/propertyeditor/PropertyEditorListener.java
+++ b/src/main/java/de/blau/android/propertyeditor/PropertyEditorListener.java
@@ -6,6 +6,7 @@ import java.util.List;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import de.blau.android.osm.Capabilities;
 import de.blau.android.osm.OsmElement;
 import de.blau.android.presets.Preset;
 
@@ -105,4 +106,12 @@ public interface PropertyEditorListener {
      * Disallow presets to be applied
      */
     public void disablePresets();
+    
+    /**
+     * Get the current API-Servers Capabilities object
+     * 
+     * @return a Capabilities instance
+     */
+    @NonNull
+    public Capabilities getCapabilities();
 }

--- a/src/main/java/de/blau/android/propertyeditor/PropertyEditorListener.java
+++ b/src/main/java/de/blau/android/propertyeditor/PropertyEditorListener.java
@@ -1,7 +1,7 @@
 package de.blau.android.propertyeditor;
 
-import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -75,7 +75,15 @@ public interface PropertyEditorListener {
      * @return list containing the tag maps or null if something went wrong
      */
     @Nullable
-    public List<LinkedHashMap<String, String>> getUpdatedTags();
+    public List<Map<String, String>> getUpdatedTags();
+    
+    /**
+     * Get original tags
+     * 
+     * @return list containing the tag maps or null if something went wrong
+     */
+    @Nullable
+    public List<Map<String, String>> getOriginalTags();
 
     /**
      * Re-create the RecentPrestsFragement view

--- a/src/main/java/de/blau/android/propertyeditor/RelationMemberAdapter.java
+++ b/src/main/java/de/blau/android/propertyeditor/RelationMemberAdapter.java
@@ -27,7 +27,7 @@ public class RelationMemberAdapter extends RecyclerView.Adapter<RelationMemberAd
     private final Context        ctx;
     private final TextWatcher    watcher;
 
-    List<MemberEntry> entries;
+    private List<MemberEntry> entries;
 
     private int selected = -1;
 
@@ -72,7 +72,6 @@ public class RelationMemberAdapter extends RecyclerView.Adapter<RelationMemberAd
         Integer position = (Integer) buttonView.getTag();
         if (position != null) {
             RelationMemberAdapter.this.notifyItemChanged(selected);
-
             selected = position;
             groupChangeListener.onCheckedChanged(null, position);
         }
@@ -122,7 +121,6 @@ public class RelationMemberAdapter extends RecyclerView.Adapter<RelationMemberAd
                 watcher.afterTextChanged(s);
                 memberEntry.setRole(s.toString());
             }
-
         });
 
         if (memberEntry.downloaded() && !memberEntry.selected) {

--- a/src/main/java/de/blau/android/propertyeditor/RelationMemberSelectedActionModeCallback.java
+++ b/src/main/java/de/blau/android/propertyeditor/RelationMemberSelectedActionModeCallback.java
@@ -95,9 +95,10 @@ public class RelationMemberSelectedActionModeCallback implements Callback {
 
         menu.add(Menu.NONE, MENU_ITEM_MOVE_UP, Menu.NONE, R.string.tag_menu_move_up).setIcon(ThemeUtils.getResIdFromAttribute(context, R.attr.menu_up));
         menu.add(Menu.NONE, MENU_ITEM_MOVE_DOWN, Menu.NONE, R.string.tag_menu_move_down).setIcon(ThemeUtils.getResIdFromAttribute(context, R.attr.menu_down));
-        menu.add(Menu.NONE, MENU_ITEM_SORT, Menu.NONE, R.string.tag_menu_sort).setIcon(ThemeUtils.getResIdFromAttribute(context, R.attr.menu_sort));
+        menu.add(Menu.NONE, MENU_ITEM_SORT, Menu.NONE, R.string.tag_menu_sort).setIcon(ThemeUtils.getResIdFromAttribute(context, R.attr.menu_sort))
+                .setEnabled(!members.isEmpty());
         menu.add(Menu.NONE, MENU_ITEM_REVERSE_ORDER, Menu.NONE, R.string.tag_menu_reverse_order)
-                .setIcon(ThemeUtils.getResIdFromAttribute(context, R.attr.menu_reverse_order));
+                .setIcon(ThemeUtils.getResIdFromAttribute(context, R.attr.menu_reverse_order)).setEnabled(!members.isEmpty());
 
         // we only display the download button if at least one of the selected elements isn't downloaded
         boolean nonDownloadedSelected = false;
@@ -108,12 +109,11 @@ public class RelationMemberSelectedActionModeCallback implements Callback {
                 break;
             }
         }
-        if (nonDownloadedSelected) {
-            MenuItem downloadItem = menu.add(Menu.NONE, MENU_ITEM_DOWNLOAD, Menu.NONE, R.string.tag_menu_download)
-                    .setIcon(ThemeUtils.getResIdFromAttribute(context, R.attr.menu_download));
-            // if we don't have network connectivity disable
-            downloadItem.setEnabled(new NetworkStatus(caller.getContext()).isConnected());
-        }
+
+        MenuItem downloadItem = menu.add(Menu.NONE, MENU_ITEM_DOWNLOAD, Menu.NONE, R.string.tag_menu_download)
+                .setIcon(ThemeUtils.getResIdFromAttribute(context, R.attr.menu_download));
+        // if we don't have network connectivity disable
+        downloadItem.setEnabled(new NetworkStatus(caller.getContext()).isConnected() && nonDownloadedSelected);
 
         menu.add(Menu.NONE, MENU_ITEM_TOP, Menu.NONE, R.string.tag_menu_top);
         menu.add(Menu.NONE, MENU_ITEM_BOTTOM, Menu.NONE, R.string.tag_menu_bottom);

--- a/src/main/java/de/blau/android/propertyeditor/RelationMemberSelectedActionModeCallback.java
+++ b/src/main/java/de/blau/android/propertyeditor/RelationMemberSelectedActionModeCallback.java
@@ -208,7 +208,7 @@ public class RelationMemberSelectedActionModeCallback implements Callback {
             boolean lineLike = false; // this needs a better name
             if (tags != null && tags.size() == 1) {
                 String type = tags.get(0).get(Tags.KEY_TYPE);
-                lineLike = Tags.VALUE_MULTIPOLYGON.equals(type) || Tags.VALUE_BOUNDARY.equals(type) || Tags.VALUE_ROUTE.equals(type);
+                lineLike = Tags.VALUE_MULTIPOLYGON.equals(type) || Tags.VALUE_BOUNDARY.equals(type);
             }
             List<MemberEntry> temp = RelationUtils.sortRelationMembers(selected, new LinkedList<>(),
                     lineLike ? RelationUtils::haveEndConnection : RelationUtils::haveCommonNode);

--- a/src/main/java/de/blau/android/propertyeditor/RelationMemberSelectedActionModeCallback.java
+++ b/src/main/java/de/blau/android/propertyeditor/RelationMemberSelectedActionModeCallback.java
@@ -2,8 +2,8 @@ package de.blau.android.propertyeditor;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import android.content.Context;
 import android.util.Log;
@@ -204,7 +204,7 @@ public class RelationMemberSelectedActionModeCallback implements Callback {
             ((RelationMembersFragment) caller).scrollToRow(selectedPos.get(selectedPos.size() - 1));
             return true;
         case MENU_ITEM_SORT:
-            List<LinkedHashMap<String, String>> tags = ((RelationMembersFragment) caller).propertyEditorListener.getUpdatedTags();
+            List<Map<String, String>> tags = ((RelationMembersFragment) caller).propertyEditorListener.getUpdatedTags();
             boolean lineLike = false; // this needs a better name
             if (tags != null && tags.size() == 1) {
                 String type = tags.get(0).get(Tags.KEY_TYPE);

--- a/src/main/java/de/blau/android/propertyeditor/RelationMembersFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/RelationMembersFragment.java
@@ -3,7 +3,6 @@ package de.blau.android.propertyeditor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -788,7 +787,7 @@ public class RelationMembersFragment extends BaseFragment implements PropertyRow
         ArrayAdapter<PresetRole> getMemberRoleAutocompleteAdapter() {
             List<PresetRole> roles = new ArrayList<>();
             PropertyEditorListener listener = (PropertyEditorListener) owner.getParentFragment();
-            List<LinkedHashMap<String, String>> allTags = listener.getUpdatedTags();
+            List<Map<String, String>> allTags = listener.getUpdatedTags();
             if (allTags != null && !allTags.isEmpty()) {
                 PresetItem relationPreset = Preset.findBestMatch(listener.getPresets(), allTags.get(0), null, null);
                 if (relationPreset != null) {
@@ -914,7 +913,7 @@ public class RelationMembersFragment extends BaseFragment implements PropertyRow
 
         final Relation r = (Relation) propertyEditorListener.getElement();
         final Preset[] presets = propertyEditorListener.getPresets();
-        final List<LinkedHashMap<String, String>> allTags = propertyEditorListener.getUpdatedTags();
+        final List<Map<String, String>> allTags = propertyEditorListener.getUpdatedTags();
         final PresetItem presetItem = allTags != null && !allTags.isEmpty() ? Preset.findBestMatch(presets, allTags.get(0), null, null) : null;
 
         final MultiHashMap<String, String> originalMembersRoles = new MultiHashMap<>(false);

--- a/src/main/java/de/blau/android/propertyeditor/TagEditorFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/TagEditorFragment.java
@@ -1,5 +1,6 @@
 package de.blau.android.propertyeditor;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -217,9 +218,9 @@ public class TagEditorFragment extends BaseFragment implements PropertyRows, Edi
      * @return a new instance of TagEditorFragment
      */
     @NonNull
-    public static TagEditorFragment newInstance(@NonNull long[] elementIds, @NonNull String[] elementTypes,
-            @NonNull ArrayList<LinkedHashMap<String, String>> tags, boolean applyLastAddressTags, String focusOnKey, boolean displayMRUpresets,
-            @Nullable HashMap<String, String> extraTags, @Nullable ArrayList<PresetElementPath> presetsToApply) {
+    public static <T extends List<Map<String, String>> & Serializable, M extends Map<String, String> & Serializable, L extends List<PresetElementPath> & Serializable> TagEditorFragment newInstance(
+            @NonNull long[] elementIds, @NonNull String[] elementTypes, @NonNull T tags, boolean applyLastAddressTags, String focusOnKey,
+            boolean displayMRUpresets, @Nullable M extraTags, @Nullable L presetsToApply) {
         TagEditorFragment f = new TagEditorFragment();
 
         Bundle args = new Bundle();
@@ -340,7 +341,7 @@ public class TagEditorFragment extends BaseFragment implements PropertyRows, Edi
         }
 
         if (displayMRUpresets) {
-            // FIXME this is arguably wrong for multi select
+            // FIXME this is arguably wrong for multiselect
             de.blau.android.propertyeditor.Util.addMRUPresetsFragment(getChildFragmentManager(), R.id.mru_layout, elements[0].getOsmId(),
                     elements[0].getName());
         }
@@ -1498,7 +1499,7 @@ public class TagEditorFragment extends BaseFragment implements PropertyRows, Edi
             dialog.setTitle(R.string.tag_editor_name_suggestion);
             dialog.setMessage(R.string.tag_editor_name_suggestion_overwrite_message);
             dialog.setPositiveButton(R.string.replace, (d, which) -> {
-                loadEdits(currentValues, false);// FIXME
+                loadEdits(currentValues, false);
                 if (afterApply != null) {
                     afterApply.run();
                 }
@@ -1506,10 +1507,11 @@ public class TagEditorFragment extends BaseFragment implements PropertyRows, Edi
             dialog.setNegativeButton(R.string.cancel, null);
             dialog.create().show();
         } else {
-            loadEdits(currentValues, false);// FIXME
+            loadEdits(currentValues, false);
         }
         if (prefs.nameSuggestionPresetsEnabled()) {
             PresetItem p = Preset.findBestMatch(propertyEditorListener.getPresets(), getKeyValueMapSingle(false), null, null); // FIXME
+                                                                                                                               // multiselect
             if (p != null) {
                 applyPreset((LinearLayout) getOurView(), p, false, false, false, true);
             }
@@ -1983,6 +1985,7 @@ public class TagEditorFragment extends BaseFragment implements PropertyRows, Edi
         case R.id.tag_menu_apply_preset:
         case R.id.tag_menu_apply_preset_with_optional:
             PresetItem pi = Preset.findBestMatch(propertyEditorListener.getPresets(), getKeyValueMapSingle(false), null, null); // FIXME
+                                                                                                                                // multiselect
             if (pi != null) {
                 boolean displayOptional = itemId == R.id.tag_menu_apply_preset_with_optional;
                 presetSelectedListener.onPresetSelected(pi, displayOptional, false);
@@ -2208,7 +2211,7 @@ public class TagEditorFragment extends BaseFragment implements PropertyRows, Edi
         });
         if (!sourceSet[0]) {
             // source wasn't set above - add a new pair
-            ArrayList<String> v = new ArrayList<>();
+            List<String> v = new ArrayList<>();
             v.add(Tags.VALUE_SURVEY);
             insertNewEdit((LinearLayout) getOurView(), sourceKey, v, -1, false);
         }

--- a/src/main/java/de/blau/android/propertyeditor/TagEditorFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/TagEditorFragment.java
@@ -414,9 +414,15 @@ public class TagEditorFragment extends BaseFragment implements PropertyRows, Edi
     @Override
     public void onDataUpdate() {
         Log.d(DEBUG_TAG, "onDataUpdate");
-        if (elements.length == 1) {
+        List<Map<String, String>> currentTags = new ArrayList<>();
+        for (OsmElement e : elements) {
+            currentTags.add(new LinkedHashMap<>(e.getTags()));
+        }
+        if (!currentTags.equals(propertyEditorListener.getOriginalTags())) {
             // simple case as we don't have to check for deleted elements
-            // FIXME implement
+            Snack.toastTopInfo(getContext(), R.string.toast_updating_tags);
+            loadEdits(getTagsInEditForm(currentTags), false);
+            formUpdate.tagsUpdated();
         }
     }
 
@@ -2237,7 +2243,7 @@ public class TagEditorFragment extends BaseFragment implements PropertyRows, Edi
      * reload original arguments
      */
     void doRevert() {
-        loadEdits(getTagsInEditForm(), false);
+        loadEdits(getTagsInEditForm(propertyEditorListener.getOriginalTags()), false);
         updateAutocompletePresetItem(null);
     }
 
@@ -2343,12 +2349,12 @@ public class TagEditorFragment extends BaseFragment implements PropertyRows, Edi
      * @return list of maps containing the tags
      */
     @NonNull
-    public List<LinkedHashMap<String, String>> getUpdatedTags() {
+    public List<Map<String, String>> getUpdatedTags() {
         @SuppressWarnings("unchecked")
 
-        List<Map<String, String>> oldTags = (ArrayList<Map<String, String>>) getArguments().getSerializable(TAGS_KEY);
+        List<Map<String, String>> oldTags = propertyEditorListener.getOriginalTags();
         // make a (nearly) full copy
-        List<LinkedHashMap<String, String>> newTags = new ArrayList<>();
+        List<Map<String, String>> newTags = new ArrayList<>();
         for (Map<String, String> map : oldTags) {
             newTags.add(new LinkedHashMap<>(map));
         }
@@ -2356,7 +2362,7 @@ public class TagEditorFragment extends BaseFragment implements PropertyRows, Edi
         LinkedHashMap<String, List<String>> edits = getKeyValueMap(true);
         if (edits == null) {
             // if we didn't get a LinkedHashMap as input we need to copy
-            List<LinkedHashMap<String, String>> newOldTags = new ArrayList<>();
+            List<Map<String, String>> newOldTags = new ArrayList<>();
             for (Map<String, String> map : oldTags) {
                 newOldTags.add(new LinkedHashMap<>(map));
             }
@@ -2364,7 +2370,7 @@ public class TagEditorFragment extends BaseFragment implements PropertyRows, Edi
         }
 
         for (int index = 0; index < newTags.size(); index++) {
-            LinkedHashMap<String, String> map = newTags.get(index);
+            Map<String, String> map = newTags.get(index);
             for (String key : new TreeSet<>(map.keySet())) {
                 if (edits.containsKey(key)) {
                     List<String> valueList = edits.get(key);

--- a/src/main/java/de/blau/android/propertyeditor/tagform/TagFormFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/TagFormFragment.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.TreeMap;
 
 import android.content.Context;
 import android.content.res.Configuration;
@@ -49,7 +48,6 @@ import de.blau.android.measure.Length;
 import de.blau.android.measure.Measure;
 import de.blau.android.measure.Params;
 import de.blau.android.nsi.Names;
-import de.blau.android.nsi.Names.NameAndTags;
 import de.blau.android.osm.OsmElement;
 import de.blau.android.osm.Server;
 import de.blau.android.osm.Tags;
@@ -306,32 +304,18 @@ public class TagFormFragment extends BaseFragment implements FormUpdate {
     ArrayAdapter<?> getValueAutocompleteAdapter(@Nullable String key, @Nullable List<String> values, @Nullable PresetItem preset,
             @Nullable PresetTagField field, @NonNull Map<String, String> allTags, boolean addRuler, boolean dedup, int addMruSize) {
         ArrayAdapter<?> adapter = null;
-
         if (key != null && key.length() > 0) {
             Set<String> usedKeys = allTags.keySet();
-
             if (TagEditorFragment.isStreetName(key, usedKeys)) {
                 adapter = nameAdapters.getStreetNameAdapter(values);
             } else if (TagEditorFragment.isPlaceName(key, usedKeys)) {
                 adapter = nameAdapters.getPlaceNameAdapter(values);
             } else if (key.equals(Tags.KEY_NAME) && (names != null) && TagEditorFragment.useNameSuggestions(usedKeys)) {
-                Log.d(DEBUG_TAG, "generate suggestions for name from name suggestion index");
-                List<NameAndTags> suggestions = names.getNames(new TreeMap<>(allTags), propertyEditorListener.getIsoCodes());
-                if (suggestions != null && !suggestions.isEmpty()) {
-                    List<NameAndTags> result = suggestions;
-                    Collections.sort(result);
-                    adapter = new ArrayAdapter<>(getActivity(), R.layout.autocomplete_row, result);
-                }
+                adapter = TagEditorFragment.getNameSuggestions(getContext(), names, allTags, propertyEditorListener);
             } else if (Tags.isSpeedKey(key)) {
-                // check if we have localized maxspeed values
-                Properties prop = App.getGeoContext(getContext()).getProperties(propertyEditorListener.getIsoCodes());
-                if (prop != null) {
-                    String[] speedLimits = prop.getSpeedLimits();
-                    if (speedLimits != null) {
-                        adapter = new ArrayAdapter<>(getActivity(), R.layout.autocomplete_row, speedLimits);
-                    }
-                }
+                adapter = TagEditorFragment.getSpeedLimits(getContext(), propertyEditorListener);
             } else {
+                // generate from preset
                 Map<String, Integer> counter = new HashMap<>();
                 int position = 0;
                 ArrayAdapterWithRuler<StringWithDescription> adapter2 = new ArrayAdapterWithRuler<>(getActivity(), R.layout.autocomplete_row, Ruler.class);
@@ -414,7 +398,7 @@ public class TagFormFragment extends BaseFragment implements FormUpdate {
                         }
                     }
                 }
-                Log.d(DEBUG_TAG, adapter2 == null ? "adapter2 is null" : "adapter2 has " + adapter2.getCount() + " elements");
+                Log.d(DEBUG_TAG, "adapter2 has " + adapter2.getCount() + " elements");
                 if (adapter2.getCount() > 0) {
                     return adapter2;
                 }

--- a/src/main/java/de/blau/android/propertyeditor/tagform/TagFormFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/TagFormFragment.java
@@ -625,13 +625,17 @@ public class TagFormFragment extends BaseFragment implements FormUpdate {
         Log.d(DEBUG_TAG, "update");
         // remove all editable stuff
         View sv = getView();
+        if (sv == null) {
+            Log.e(DEBUG_TAG, "update ScrollView null");
+            return;
+        }
         LinearLayout ll = (LinearLayout) sv.findViewById(R.id.form_container_layout);
         if (ll != null) {
             while (ll.getChildAt(0) instanceof EditableLayout) {
                 ll.removeViewAt(0);
             }
         } else {
-            Log.d(DEBUG_TAG, "update container layout null");
+            Log.e(DEBUG_TAG, "update container layout null");
             return;
         }
         final EditableLayout editableView = (EditableLayout) inflater.inflate(R.layout.tag_form_editable, ll, false);

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -689,6 +689,10 @@
     <string name="toast_unexpected_element">Unexpected element clicked:\n%1$s</string>
     <string name="toast_import_destination_exists">Import destination already exists</string>
     <string name="toast_part_selection_not_supported">Way part selection not supported for closed ways</string>
+    <string name="toast_element_has_been_deleted">Element has been deleted</string>
+    <string name="toast_updating_tags">Updating tags…</string>
+    <string name="toast_updating_parents">Updating parents…</string>
+    <string name="toast_updating_members">Updating members…</string>
     <!-- Error messages -->
     <string name="error_mapsplit_missing_zoom">MapSplit sources must have min and max zoom set</string>
     <string name="error_pbf_no_version">Version information missing in PBF file</string>


### PR DESCRIPTION
This improves the split window property editor by trying to keep edits synchronized as far as possible, for example deleting an object via the map will close the corresponding instance and changing relation members and memberships will update the data in affected  property editors.