### PR TITLE
Fix speed conditional templates

### DIFF
--- a/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
+++ b/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
@@ -1563,9 +1563,9 @@ public class PropertyEditorTest {
         assertNotNull(w);
 
         main.performTagEdit(w, null, false, false);
-        PropertyEditorActivity propertyEditor = waitForPropertyEditor();
+        PropertyEditorActivity<?, ?, ?> propertyEditor = waitForPropertyEditor();
 
-        if (!((PropertyEditorActivity) propertyEditor).usingPaneLayout()) {
+        if (!((PropertyEditorActivity<?, ?, ?>) propertyEditor).usingPaneLayout()) {
             assertTrue(TestUtils.clickText(device, true, main.getString(R.string.tag_menu_preset), false, false));
         }
         boolean found = TestUtils.clickText(device, true, getTranslatedPresetGroupName(main, "Highways"), true, false);
@@ -1609,7 +1609,7 @@ public class PropertyEditorTest {
         } catch (UiObjectNotFoundException e) {
             fail();
         }
-        assertEquals("50 @ Mo-Fr 19:00-31:00,Sa,Su; 30 @ maxweight>40", conditionalMaxSpeed.getText());
+        assertEquals("50 @ Mo-Fr 19:00-07:00,Sa,Su; 30 @ maxweight>40", conditionalMaxSpeed.getText());
     }
 
     /**

--- a/src/main/java/de/blau/android/propertyeditor/Util.java
+++ b/src/main/java/de/blau/android/propertyeditor/Util.java
@@ -1,6 +1,7 @@
 package de.blau.android.propertyeditor;
 
 import android.util.Log;
+import android.widget.LinearLayout;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
@@ -79,6 +80,23 @@ public final class Util {
                 FragmentTransaction ft = fm.beginTransaction();
                 ft.remove(alternativePresetItemsFragment);
                 ft.commit();
+            }
+        }
+    }
+
+    /**
+     * Remove all but one child of a LinearLayout, run the runnable for the remaining one
+     * 
+     * @param layout the LinearLayer
+     * @param runnable the Runnable
+     */
+    public static void resetValueLayout(@NonNull LinearLayout layout, @NonNull Runnable runnable) {
+        int childCount = layout.getChildCount();
+        for (int pos = 0; pos < childCount; pos++) { // don't delete first child, just clear
+            if (pos == 0) {
+                runnable.run();
+            } else {
+                layout.removeViewAt(1);
             }
         }
     }

--- a/src/main/java/de/blau/android/propertyeditor/tagform/CheckGroupDialogRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/CheckGroupDialogRow.java
@@ -66,14 +66,7 @@ public class CheckGroupDialogRow extends MultiselectDialogRow {
      */
     public void setSelectedValues(@NonNull Map<String, String> keyValues) {
         this.keyValues = keyValues;
-        int childCount = valueList.getChildCount();
-        for (int pos = 0; pos < childCount; pos++) { // don^t delete first child, just clear
-            if (pos == 0) {
-                setValue("", "");
-            } else {
-                valueList.removeViewAt(1);
-            }
-        }
+        de.blau.android.propertyeditor.Util.resetValueLayout(valueList, () -> setValue("", ""));
 
         boolean first = true;
         PresetCheckGroupField field = null;

--- a/src/main/java/de/blau/android/propertyeditor/tagform/ConditionalRestrictionFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/ConditionalRestrictionFragment.java
@@ -945,14 +945,7 @@ public class ConditionalRestrictionFragment extends DialogFragment implements On
          * @param rules rules parsed from the value
          */
         public void setValue(String ohValue, @Nullable List<Rule> rules) {
-            int childCount = valueList.getChildCount();
-            for (int pos = 0; pos < childCount; pos++) { // don't delete first child, just clear
-                if (pos == 0) {
-                    setValue("", "");
-                } else {
-                    valueList.removeViewAt(1);
-                }
-            }
+            de.blau.android.propertyeditor.Util.resetValueLayout(valueList, () -> setValue("", ""));
             boolean first = true;
             if (rules != null && !rules.isEmpty()) {
                 for (Rule r : rules) {

--- a/src/main/java/de/blau/android/propertyeditor/tagform/MultiselectDialogRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/MultiselectDialogRow.java
@@ -85,14 +85,7 @@ public class MultiselectDialogRow extends DialogRow {
     public void setValue(List<StringWithDescription> values) {
         String value = "";
         char delimiter = preset.getDelimiter(getKey());
-        int childCount = valueList.getChildCount();
-        for (int pos = 0; pos < childCount; pos++) { // don^t delete first child, just clear
-            if (pos == 0) {
-                setValue("", "");
-            } else {
-                valueList.removeViewAt(1);
-            }
-        }
+        de.blau.android.propertyeditor.Util.resetValueLayout(valueList, () -> setValue("", ""));
         boolean first = true;
         StringBuilder builder = new StringBuilder(value);
         for (StringWithDescription swd : values) {

--- a/src/main/java/de/blau/android/propertyeditor/tagform/OpeningHoursDialogRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/OpeningHoursDialogRow.java
@@ -67,14 +67,7 @@ public class OpeningHoursDialogRow extends MultiselectDialogRow {
      * @param rules rules parsed from the value
      */
     public void setValue(@Nullable String ohValue, @Nullable List<Rule> rules) {
-        int childCount = valueList.getChildCount();
-        for (int pos = 0; pos < childCount; pos++) { // don't delete first child, just clear
-            if (pos == 0) {
-                setValue("", "");
-            } else {
-                valueList.removeViewAt(1);
-            }
-        }
+        de.blau.android.propertyeditor.Util.resetValueLayout(valueList, () -> setValue("", ""));
         boolean first = true;
         if (rules != null && !rules.isEmpty()) {
             for (Rule r : rules) {


### PR DESCRIPTION
For conditional max speed values the templates where being ignored. This improves in general the handling of speed tags in the property editor, and adds some special handling for them in the conditional restriction fragment.