### PR TITLE
Josm template support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -618,7 +618,8 @@ dependencies {
     implementation "ch.poole:OpeningHoursFragment:0.13.3"
     implementation 'ch.poole.android:numberpicker:1.0.10'
     implementation 'ch.poole.android:numberpickerpreference:2.0.1'
-    implementation "ch.poole.osm:JosmFilterParser:0.8.2"
+    implementation "ch.poole.osm:JosmFilterParser:0.9.0"
+    implementation "ch.poole.osm:JosmTemplateParser:0.2.0"
     implementation 'ch.poole.android:sprites:0.0.4'
     implementation 'ch.poole.android:indeterminate-checkbox:1.1.0@aar'
     implementation 'ch.poole.misc:bentley-ottmann:0.1.1'

--- a/documentation/docs/tutorials/presets.md
+++ b/documentation/docs/tutorials/presets.md
@@ -1,5 +1,5 @@
 # Vespucci Preset System
-_Documentation for Vespucci 19.0_
+_Documentation for Vespucci 19.1_
 
 As explained in the [help documentation](../help/en/Presets.md) Vespucci uses JOSM compatible presets, currently any preset used in JOSM should simply work with Vespucci, however there can be differences. Particularly with the new preset driven tagging interface presets have become even more important and if you are writing presets yourself and want them to work well in Vespucci please keep on reading.
 
@@ -38,7 +38,7 @@ Note: this is loosely based on what [JOSM claims](https://josm.openstreetmap.de/
 |                   | name_context                  | supported |
 |                   | icon                          | supported | you really should add one for Vespucci
 |                   | type                          | supported |
-|                   | name_template                 | ignored   |
+|                   | name_template                 | supported | if set will always be used 
 |                   | name_template_filter          | ignored   |
 |                   | preset_name_label             | ignored   |
 |                   | deprecated                    | extension | only use the preset for matching and map icon display
@@ -67,6 +67,7 @@ Note: this is loosely based on what [JOSM claims](https://josm.openstreetmap.de/
 |                   | auto_increment                | ignored   |
 |                   | length                        | partial   | depending on the settings a modal will be displayed for editing instead of an inline text field
 |                   | alternative_autocomplete_keys | ignored   |
+|                   | value_template                | ignored   |
 |                   | javascript                    | extension | if value is not set, execute the JS script
 |                   | i18n                          | extension | if set to true this tag has i18n variants
 |                   | value_type                    | extension | indicate the kind of value this tag should have

--- a/src/androidTest/java/de/blau/android/TestUtils.java
+++ b/src/androidTest/java/de/blau/android/TestUtils.java
@@ -1383,6 +1383,24 @@ public final class TestUtils {
             }
         }
     }
+    
+    /**
+     * Scroll to a specific text
+     * 
+     * @param text the text
+     * @param fail fail if scrollable not found
+     */
+    public static void scrollToStartsWith(@NonNull String text, boolean fail) {
+        UiScrollable appView = new UiScrollable(new UiSelector().scrollable(true));
+        try {
+            appView.setSwipeDeadZonePercentage(0.4);
+            appView.scrollIntoView(new UiSelector().textStartsWith(text));
+        } catch (UiObjectNotFoundException e) {
+            if (fail) {
+                Assert.fail(text + " not found");
+            }
+        }
+    }
 
     /**
      * Scroll to end

--- a/src/androidTest/java/de/blau/android/easyedit/RelationTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/RelationTest.java
@@ -181,10 +181,12 @@ public class RelationTest {
     @Test
     public void createAndAddToMultiPolygon() {
         map.getDataLayer().setVisible(true);
-        TestUtils.zoomToLevel(device, main, 22);
         TestUtils.unlock(device);
+        TestUtils.clickAwayTip(device, main);
+        TestUtils.zoomToLevel(device, main, 22);
         // split building first
         TestUtils.clickAtCoordinates(device, map, 8.3882060, 47.3885768, true);
+        TestUtils.clickAwayTip(device, main);
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_wayselect)));
         assertTrue(TestUtils.clickMenuButton(device, "Split", false, true));
         TestUtils.clickAwayTip(device, context);
@@ -255,7 +257,7 @@ public class RelationTest {
         assertTrue(TestUtils.clickOverflowButton(device));
         TestUtils.scrollTo(context.getString(R.string.tag_menu_addtorelation), true);
         assertTrue(TestUtils.clickText(device, false, context.getString(R.string.tag_menu_addtorelation), true, false));
-        assertTrue(TestUtils.clickText(device, false, "Multipolygon Building", true, false));
+        assertTrue(TestUtils.clickText(device, false, "Address Bergstrasse 40", true, false));
         // finish again
         TestUtils.clickButton(device, device.getCurrentPackageName() + ":id/simpleButton", true);
         // assertTrue(TestUtils.findText(device, false, context.getString(R.string.remove), 5000));

--- a/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
+++ b/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
@@ -1094,7 +1094,7 @@ public class PropertyEditorTest {
         TestUtils.clickText(device, true, main.getString(R.string.tag_details), false, false);
         TestUtils.clickText(device, true, main.getString(R.string.members), false, false);
         String name1 = m1.getElement().getTagWithKey(Tags.KEY_NAME);
-        TestUtils.scrollTo(name1, true);
+        TestUtils.scrollToStartsWith(name1, true);
         selectMember(name1);
         clickButtonOrOverflowMenu(main.getString(R.string.tag_menu_move_up));
         // exit property editor
@@ -1117,7 +1117,7 @@ public class PropertyEditorTest {
         TestUtils.clickText(device, true, main.getString(R.string.members), false, false);
  
         String name2 = m2.getElement().getTagWithKey(Tags.KEY_NAME);
-        TestUtils.scrollTo(name2, true);
+        TestUtils.scrollToStartsWith(name2, true);
         selectMember(name1);
         selectMember("#119104097");
         selectMember(name2);

--- a/src/main/java/de/blau/android/layer/data/MapOverlay.java
+++ b/src/main/java/de/blau/android/layer/data/MapOverlay.java
@@ -1140,7 +1140,8 @@ public class MapOverlay<O extends OsmElement> extends MapViewLayer
             if (style.usePresetLabel() && tmpPresets != null) {
                 PresetItem match = Preset.findBestMatch(tmpPresets, e.getTags(), null, null);
                 if (match != null) {
-                    label = match.getTranslatedName();
+                    String template = e.nameFromTemplate(context, match);
+                    label = template != null ? template : match.getTranslatedName();
                 } else {
                     label = e.getPrimaryTag(context);
                 }

--- a/src/main/java/de/blau/android/osm/OsmElement.java
+++ b/src/main/java/de/blau/android/osm/OsmElement.java
@@ -699,7 +699,7 @@ public abstract class OsmElement implements Serializable, XmlSerializable, JosmX
      * @return a name or null
      */
     @Nullable
-    protected String nameFromTemplate(@NonNull Context ctx, @NonNull PresetItem p) {
+    public String nameFromTemplate(@NonNull Context ctx, @NonNull PresetItem p) {
         String nameTemplate = p.getNameTemplate();
         if (nameTemplate != null) {
             JosmTemplateParser parser = new JosmTemplateParser(new ByteArrayInputStream(nameTemplate.getBytes()));

--- a/src/main/java/de/blau/android/osm/Relation.java
+++ b/src/main/java/de/blau/android/osm/Relation.java
@@ -19,6 +19,7 @@ import de.blau.android.App;
 import de.blau.android.R;
 import de.blau.android.presets.Preset;
 import de.blau.android.presets.PresetItem;
+import de.blau.android.util.Util;
 import de.blau.android.util.rtree.BoundedObject;
 import de.blau.android.validation.Validator;
 
@@ -368,12 +369,16 @@ public class Relation extends StyledOsmElement implements BoundedObject {
     public String getDescription(Context ctx) {
         String description = "";
         String type = getTagWithKey(Tags.KEY_TYPE);
-        if (type != null && !"".equals(type)) {
+        if (Util.notEmpty(type)) {
             PresetItem p = null;
             if (ctx != null) {
                 p = Preset.findBestMatch(App.getCurrentPresets(ctx), tags, null, null);
             }
             if (p != null) {
+                String templateName = nameFromTemplate(ctx, p);
+                if (Util.notEmpty(templateName)) {
+                    return templateName;
+                }
                 description = p.getTranslatedName();
                 if (Tags.VALUE_RESTRICTION.equals(type)) {
                     String restriction = getTagWithKey(Tags.VALUE_RESTRICTION);

--- a/src/main/java/de/blau/android/presets/PresetItem.java
+++ b/src/main/java/de/blau/android/presets/PresetItem.java
@@ -85,6 +85,11 @@ public class PresetItem extends PresetElement {
      * Count of labels for naming
      */
     private int labelCounter = 0;
+    
+    /**
+     * Optional template for creating/formatting a name
+     */
+    private String nameTemplate = null;
 
     /**
      * Construct a new PresetItem
@@ -894,6 +899,25 @@ public class PresetItem extends PresetElement {
     }
 
     /**
+     * Get the name template
+     * 
+     * @return the template or null
+     */
+    @Nullable
+    public String getNameTemplate() {
+        return preset.translate(nameTemplate, nameContext);
+    }
+
+    /**
+     * Set the name template
+     * 
+     * @param nameTemplate the template to set
+     */
+    public void setNameTemplate(@Nullable String nameTemplate) {
+        this.nameTemplate = nameTemplate;
+    }
+    
+    /**
      * @return the fixed tags belonging to this item (unmodifiable)
      */
     public Map<String, PresetFixedField> getFixedTags() {
@@ -1224,9 +1248,7 @@ public class PresetItem extends PresetElement {
         String presetName = presetNameBuilder.toString();
         StringBuilder jsonString = new StringBuilder();
         for (Entry<String, PresetFixedField> entry : fixedTags.entrySet()) {
-            if (jsonString.length() != 0) {
-                jsonString.append(",\n");
-            }
+            appendEol(jsonString);
             jsonString.append(tagToJSON(presetName, entry.getKey(), entry.getValue().getValue()));
         }
         for (Entry<String, PresetField> entry : fields.entrySet()) {
@@ -1240,22 +1262,29 @@ public class PresetItem extends PresetElement {
             boolean editable = field instanceof PresetComboField && ((PresetComboField) field).isEditable();
             if (editable || field instanceof PresetTextField || field instanceof PresetCheckField
                     || (match != null && match != MatchType.KEY_VALUE && match != MatchType.KEY)) {
-                if (jsonString.length() != 0) {
-                    jsonString.append(",\n");
-                }
+                appendEol(jsonString);
                 jsonString.append(tagToJSON(presetName, k, null));
             }
             if (field instanceof PresetComboField && !editable
                     && (match == null || match == MatchType.KEY_VALUE || match == MatchType.KEY || match == MatchType.KEY_VALUE_NEG)) {
                 for (StringWithDescription v : ((PresetComboField) entry.getValue()).getValues()) {
-                    if (jsonString.length() != 0) {
-                        jsonString.append(",\n");
-                    }
+                    appendEol(jsonString);
                     jsonString.append(tagToJSON(presetName, k, v));
                 }
             }
         }
         return jsonString.toString();
+    }
+
+    /**
+     * Append an EOL to the StringBuilder
+     * 
+     * @param jsonString the StringBuilder
+     */
+    private static void appendEol(@NonNull StringBuilder jsonString) {
+        if (jsonString.length() != 0) {
+            jsonString.append(",\n");
+        }
     }
 
     /**

--- a/src/main/java/de/blau/android/presets/PresetParser.java
+++ b/src/main/java/de/blau/android/presets/PresetParser.java
@@ -89,6 +89,7 @@ public class PresetParser {
     static final String         ICON                  = "icon";
     private static final String IMAGE                 = "image";
     static final String         NAME                  = "name";
+    private static final String NAME_TEMPLATE         = "name_template";
     private static final String OBJECT_KEYS           = "object_keys";
     static final String         OBJECT                = "object";
     static final String         GROUP                 = "group";
@@ -247,6 +248,10 @@ public class PresetParser {
                     context = attr.getValue(NAME_CONTEXT);
                     if (context != null) {
                         currentItem.setNameContext(context);
+                    }
+                    String nameTemplate = attr.getValue(NAME_TEMPLATE);
+                    if (nameTemplate != null) {
+                        currentItem.setNameTemplate(nameTemplate);
                     }
                     currentItem.setDeprecated(TRUE.equals(attr.getValue(DEPRECATED)));
                     currentItem.setRegions(attr.getValue(REGIONS));

--- a/src/main/java/de/blau/android/search/Wrapper.java
+++ b/src/main/java/de/blau/android/search/Wrapper.java
@@ -5,8 +5,11 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
+
+import org.jetbrains.annotations.NotNull;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
@@ -60,6 +63,16 @@ public class Wrapper implements Meta {
      */
     public void setElement(OsmElement element) {
         this.element = element;
+    }
+
+    @Override
+    public Type getType() {
+        return toJosmFilterType(element);
+    }
+
+    @Override
+    public Map<String, String> getTags() {
+        return element.getTags();
     }
 
     /**
@@ -346,10 +359,8 @@ public class Wrapper implements Meta {
                 if (element.hasParentRelation((Relation) o)) {
                     return true;
                 }
-            } else if (o instanceof Way && element instanceof Node) {
-                if (((Way) o).hasNode((Node) element)) {
-                    return true;
-                }
+            } else if (o instanceof Way && element instanceof Node && ((Way) o).hasNode((Node) element)) {
+                return true;
             }
         }
         return false;
@@ -362,10 +373,8 @@ public class Wrapper implements Meta {
                 if (((OsmElement) o).hasParentRelation((Relation) element)) {
                     return true;
                 }
-            } else if (element instanceof Way && o instanceof Node) {
-                if (((Way) element).hasNode((Node) o)) {
-                    return true;
-                }
+            } else if (element instanceof Way && o instanceof Node && ((Way) element).hasNode((Node) o)) {
+                return true;
             }
         }
         return false;
@@ -426,5 +435,12 @@ public class Wrapper implements Meta {
             }
         }
         return result;
+    }
+
+    @Override
+    public @NotNull Meta wrap(Object arg0) {
+        Wrapper wrapper = new Wrapper(context);
+        wrapper.setElement((OsmElement) arg0);
+        return wrapper;
     }
 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1419,6 +1419,10 @@
     <!-- element description -->
     <string name="address_housenumber">Address %1$s</string>
     <string name="address_housenumber_street">Address %1$s %2$s</string>
+    <string name="description_id">%1$s #%2$s</string>
+    <string name="description_type_id">%1$s %2$s #%3$s</string>
+    <string name="only_id">#%1$s</string>
+    <string name="type_id">%1$s #%2$s</string>
     <!-- undo actions - give a description of the action, in infinitive, to display in strings like "Undo: actionname" or "Redo: actionname" -->
     <string name="undo_action_movenode">Node moved</string>
     <string name="undo_action_moveway">Way moved</string>


### PR DESCRIPTION
This adds support for JOSM name templates in presets, currently their use is limited to the disambiguation modal and rendering node and closed way labels.