### PR TITLE
Avoid race condition with undo

### DIFF
--- a/src/main/java/de/blau/android/NearbyPoiUpdateListener.java
+++ b/src/main/java/de/blau/android/NearbyPoiUpdateListener.java
@@ -68,7 +68,9 @@ public class NearbyPoiUpdateListener<E> implements UpdateInterface.OnUpdateListe
             filterElements(all, relations, filter != null);
             final double[] center = map.getViewBox().getCenter();
             final int[] loc = new int[] { (int) (center[1] * 1E7), (int) (center[0] * 1E7) };
-            Collections.sort(all, (OsmElement e1, OsmElement e2) -> Double.compare(e1.getMinDistance(loc), e2.getMinDistance(loc)));
+            synchronized (App.getDelegator()) {
+                Collections.sort(all, (OsmElement e1, OsmElement e2) -> Double.compare(e1.getMinDistance(loc), e2.getMinDistance(loc)));
+            }
             layout.getAdapter().notifyDataSetChanged();
             updates = 0;
         };

--- a/src/main/java/de/blau/android/osm/Way.java
+++ b/src/main/java/de/blau/android/osm/Way.java
@@ -457,14 +457,12 @@ public class Way extends StyledOsmElement implements BoundedObject {
     @Override
     public ElementType getType(Map<String, String> tags) {
         ElementType type = getType();
-        if (type == ElementType.CLOSEDWAY) {
-            /*
-             * From a systematic pov it would be better to get this from a preset, however the current matching preset
-             * isn't available here and using the style is far cheaper.
-             */
-            if (style != null && style.isArea()) {
-                return ElementType.AREA;
-            }
+        /*
+         * From a systematic pov it would be better to get this from a preset, however the current matching preset isn't
+         * available here and using the style is far cheaper.
+         */
+        if (type == ElementType.CLOSEDWAY && (style != null && style.isArea())) {
+            return ElementType.AREA;
         }
         return type;
     }
@@ -527,9 +525,9 @@ public class Way extends StyledOsmElement implements BoundedObject {
     @Override
     public double getMinDistance(final int[] location) {
         double distance = Double.MAX_VALUE;
-        if (location != null) {
+        int len = nodes.size();
+        if (location != null && len > 0) {
             Node n1 = nodes.get(0);
-            int len = nodes.size();
             for (int i = 1; i < len; i++) {
                 // distance to nodes of way
                 Node n2 = nodes.get(i);


### PR DESCRIPTION
Avoid crash caused by the nearby POI display distance calculation crashing due to trying to use the nodes from a way that has just been removed by an undo operation.