### PR TITLE
Typo fix

### DIFF
--- a/TRANSLATIONS.md
+++ b/TRANSLATIONS.md
@@ -6,7 +6,7 @@ Default preset is [translated separately, also at transifex](https://app.transif
 
 ## Technical issues
 
-The background/overlay names and descriptions are not translatable as iD traslation system for them is non-standard. Somebody would need to code a workaround to fix that part.
+The background/overlay names and descriptions are not translatable as iD translation system for them is non-standard. Somebody would need to code a workaround to fix that part.
 
 NOTE: for building we assume for now that the github repository contains the current language files which the maintainers will commit now and then. If you want to add or change one of the existing default (English) strings you need to make a pull request against this repository.
 


### PR DESCRIPTION
Just a small typo "traslation" -> "translation"