### PR TITLE
Download EGM to temp file and then rename

### DIFF
--- a/src/main/java/de/blau/android/Main.java
+++ b/src/main/java/de/blau/android/Main.java
@@ -1895,7 +1895,8 @@ public class Main extends FullScreenAppCompatActivity
         menu.findItem(R.id.menu_tools_calibrate_height)
                 .setVisible(sensorManager != null && sensorManager.getDefaultSensor(Sensor.TYPE_PRESSURE) != null && haveTracker);
 
-        boolean egmInstalled = prefs.getEgmFile() != null;
+        Uri egmUri = prefs.getEgmFile();
+        boolean egmInstalled = egmUri != null && new File(egmUri.getPath()).exists();
         menu.findItem(R.id.menu_tools_install_egm).setVisible(!egmInstalled);
         menu.findItem(R.id.menu_tools_remove_egm).setVisible(egmInstalled);
 
@@ -2426,7 +2427,7 @@ public class Main extends FullScreenAppCompatActivity
             Uri egm96 = Uri.parse(Urls.EGM96);
             String egmFile = egm96.getLastPathSegment();
             DownloadManager.Request request = new DownloadManager.Request(egm96).setAllowedOverRoaming(false).setTitle(egmFile)
-                    .setDestinationInExternalFilesDir(this, Environment.DIRECTORY_DOWNLOADS, egmFile)
+                    .setDestinationInExternalFilesDir(this, Environment.DIRECTORY_DOWNLOADS, egmFile + "." + FileExtensions.TEMP)
                     .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
             mgr.enqueue(request);
             return true;

--- a/src/main/java/de/blau/android/contract/FileExtensions.java
+++ b/src/main/java/de/blau/android/contract/FileExtensions.java
@@ -16,6 +16,7 @@ public final class FileExtensions {
     public static final String HTML    = "html";
     public static final String RES     = "res";
     public static final String SVG     = "svg";
+    public static final String TEMP    = "temp";
 
     /**
      * Private default constructor

--- a/src/main/java/de/blau/android/services/TrackerService.java
+++ b/src/main/java/de/blau/android/services/TrackerService.java
@@ -196,8 +196,9 @@ public class TrackerService extends Service {
                 egm = new EGM96(egmFile.getPath());
                 egmLoaded = true;
             } catch (IOException ioex) {
-                Log.e(DEBUG_TAG, "Error loading EGM " + ioex.getMessage());
-                Snack.toastTopInfo(this, "Error loading EGM " + ioex.getMessage());
+                String egmError = getString(R.string.toast_error_loading_egm, ioex.getMessage());
+                Log.e(DEBUG_TAG, egmError);
+                Snack.toastTopError(this, egmError);
             }
         }
     }

--- a/src/main/java/de/blau/android/util/DownloadActivity.java
+++ b/src/main/java/de/blau/android/util/DownloadActivity.java
@@ -87,8 +87,10 @@ public class DownloadActivity extends WebViewActivity {
                     }
                 }
                 // Start download
+                @SuppressWarnings("deprecation")
                 DownloadManager.Request request = new DownloadManager.Request(uri).setAllowedOverRoaming(false).setTitle(filename)
-                        .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, Paths.DIRECTORY_PATH_VESPUCCI + Paths.DELIMITER + filename);
+                        .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, Paths.DIRECTORY_PATH_VESPUCCI + Paths.DELIMITER + filename)
+                        .setVisibleInDownloadsUi(true);
                 request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
                 if (!allNetworks) {
                     request.setAllowedNetworkTypes(DownloadManager.Request.NETWORK_WIFI);

--- a/src/main/java/de/blau/android/util/DownloadBroadcastReceiver.java
+++ b/src/main/java/de/blau/android/util/DownloadBroadcastReceiver.java
@@ -1,5 +1,7 @@
 package de.blau.android.util;
 
+import java.io.File;
+
 import android.app.DownloadManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -7,9 +9,12 @@ import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
 import android.util.Log;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import de.blau.android.Main;
 import de.blau.android.R;
 import de.blau.android.contract.FileExtensions;
+import de.blau.android.contract.Urls;
 import de.blau.android.prefs.API;
 import de.blau.android.prefs.AdvancedPrefDatabase;
 import de.blau.android.prefs.Preferences;
@@ -31,41 +36,86 @@ public class DownloadBroadcastReceiver extends BroadcastReceiver {
             if (downloadId > 0) {
                 DownloadManager mgr = (DownloadManager) ctxt.getSystemService(Context.DOWNLOAD_SERVICE);
                 Cursor queryCursor = mgr.query(new DownloadManager.Query().setFilterById(downloadId));
-                if (queryCursor != null && queryCursor.getCount() > 0) { // cancelled downloads seem to be removed from
-                                                                         // the DB
-                    queryCursor.moveToFirst();
-                    try {
-                        int status = queryCursor.getInt(queryCursor.getColumnIndexOrThrow(DownloadManager.COLUMN_STATUS));
-                        if (status == DownloadManager.STATUS_SUCCESSFUL) {
-                            String localUri = queryCursor.getString(queryCursor.getColumnIndexOrThrow(DownloadManager.COLUMN_LOCAL_URI));
-                            if (localUri != null) {
-                                Uri uri = FileUtil.contentUriToFileUri(ctxt, Uri.parse(localUri));
-                                String filename = uri.getLastPathSegment();
-                                if (localUri.endsWith("." + FileExtensions.MSF)) { // create an API entry
-                                    try (AdvancedPrefDatabase db = new AdvancedPrefDatabase(ctxt)) {
-                                        if (db.getReadOnlyApiId(filename) == null) {
-                                            API current = db.getCurrentAPI();
-                                            db.addAPI(java.util.UUID.randomUUID().toString(), filename, current.url, uri.toString(), current.notesurl, "", "",
-                                                    current.oauth);
-                                            Snack.toastTopInfo(ctxt, ctxt.getString(R.string.toast_added_api_entry_for, filename));
-                                        } else {
-                                            Snack.toastTopInfo(ctxt, ctxt.getString(R.string.toast_updated, filename));
-                                        }
-                                    }
-                                } else if (localUri.endsWith("EGM96.dat")) { // gravitation model
-                                    (new Preferences(ctxt)).setEgmFile(uri);
-                                    Snack.toastTopInfo(ctxt, R.string.toast_egm_installed);
-                                    if (ctxt instanceof Main) {
-                                        ((Main) ctxt).invalidateOptionsMenu();
-                                    }
-                                }
-                            }
-                        }
-                    } catch (IllegalArgumentException iaex) {
-                        Log.e(DEBUG_TAG, iaex.getMessage());
-                        Snack.toastTopError(ctxt, iaex.getMessage());
-                    }
+                // cancelled downloads seem to be removed from the DB
+                if (queryCursor == null || queryCursor.getCount() == 0) {
+                    return;
                 }
+                queryCursor.moveToFirst();
+                try {
+                    int status = queryCursor.getInt(queryCursor.getColumnIndexOrThrow(DownloadManager.COLUMN_STATUS));
+                    if (status == DownloadManager.STATUS_SUCCESSFUL) {
+                        processDownload(ctxt, queryCursor.getString(queryCursor.getColumnIndexOrThrow(DownloadManager.COLUMN_LOCAL_URI)));
+                    }
+                } catch (IllegalArgumentException iaex) {
+                    Log.e(DEBUG_TAG, iaex.getMessage());
+                    Snack.toastTopError(ctxt, iaex.getMessage());
+                }
+            }
+        }
+
+    }
+
+    /**
+     * Process a successful download
+     * 
+     * @param ctxt Android Context
+     * @param localUri uri for the downloaded file
+     */
+    private void processDownload(@NonNull Context ctxt, @Nullable String localUri) {
+        if (localUri != null) {
+            Uri uri = FileUtil.contentUriToFileUri(ctxt, Uri.parse(localUri));
+            String filename = uri.getLastPathSegment();
+            if (localUri.endsWith("." + FileExtensions.MSF)) {
+                processMSF(ctxt, uri, filename);
+            } else {
+                final String egmFilename = Uri.parse(Urls.EGM96).getLastPathSegment();
+                if (localUri.endsWith(egmFilename + "." + FileExtensions.TEMP)) {
+                    processEGM(ctxt, uri, egmFilename);
+                }
+            }
+        }
+    }
+
+    /**
+     * Process the temp EGM file
+     * 
+     * @param ctxt Android Context
+     * @param uri file uri of the downloaded file
+     * @param egmFilename target filename
+     */
+    private void processEGM(@NonNull Context ctxt, @NonNull Uri uri, @NonNull final String egmFilename) {
+        // rename the file to avoid the file manager from deleting it
+        File tempFile = new File(ContentResolverUtil.getPath(ctxt, uri));
+        File targetFile = new File(tempFile.getParent(), egmFilename);
+        if (targetFile.exists()) {
+            targetFile.delete(); // NOSONAR
+        }
+        if (!tempFile.renameTo(targetFile)) {
+            Log.e(DEBUG_TAG, "renaming failed!");
+            return;
+        }
+        (new Preferences(ctxt)).setEgmFile(Uri.parse(targetFile.toURI().toString()));
+        Snack.toastTopInfo(ctxt, R.string.toast_egm_installed);
+        if (ctxt instanceof Main) {
+            ((Main) ctxt).invalidateOptionsMenu();
+        }
+    }
+
+    /**
+     * Create an API entry
+     * 
+     * @param ctxt Android Context
+     * @param uri file uri of the downloaded file
+     * @param filename target filename
+     */
+    private void processMSF(@NonNull Context ctxt, @NonNull Uri uri, @NonNull String filename) {
+        try (AdvancedPrefDatabase db = new AdvancedPrefDatabase(ctxt)) {
+            if (db.getReadOnlyApiId(filename) == null) {
+                API current = db.getCurrentAPI();
+                db.addAPI(java.util.UUID.randomUUID().toString(), filename, current.url, uri.toString(), current.notesurl, "", "", current.oauth);
+                Snack.toastTopInfo(ctxt, ctxt.getString(R.string.toast_added_api_entry_for, filename));
+            } else {
+                Snack.toastTopInfo(ctxt, ctxt.getString(R.string.toast_updated, filename));
             }
         }
     }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -695,6 +695,7 @@
     <string name="toast_updating_tags">Updating tags…</string>
     <string name="toast_updating_parents">Updating parents…</string>
     <string name="toast_updating_members">Updating members…</string>
+    <string name="toast_error_loading_egm">Error loading EGM %1$s</string>
     <!-- Error messages -->
     <string name="error_mapsplit_missing_zoom">MapSplit sources must have min and max zoom set</string>
     <string name="error_pbf_no_version">Version information missing in PBF file</string>


### PR DESCRIPTION
This should stop the DownloadManger from deleting the file after a while. WHile MSF files are downloaded to a sub-directory of Download, for good measure we set the now deprecated flag for download visibility for those files.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/2359