### PR TITLE
Fix missing path separator in image path

### DIFF
--- a/src/androidTest/java/de/blau/android/propertyeditor/ImageComboSelectorTest.java
+++ b/src/androidTest/java/de/blau/android/propertyeditor/ImageComboSelectorTest.java
@@ -39,6 +39,10 @@ import de.blau.android.prefs.AdvancedPrefDatabase;
 import de.blau.android.prefs.Preferences;
 import de.blau.android.prefs.PresetLoader;
 import de.blau.android.presets.Preset;
+import de.blau.android.presets.PresetComboField;
+import de.blau.android.presets.PresetItem;
+import de.blau.android.util.StringWithDescription;
+import de.blau.android.util.StringWithDescriptionAndIcon;
 
 @RunWith(AndroidJUnit4.class)
 @LargeTest
@@ -148,5 +152,29 @@ public class ImageComboSelectorTest {
         Node n = logic.getSelectedNode();
         assertNotNull(n);
         assertTrue(n.hasTag("bicycle_parking", "handlebar_holder"));
+    }
+
+    /**
+     * Check that the images can actually be opened
+     */
+    @Test
+    public void checkImage() {
+        Preset[] presets = App.getCurrentPresets(main);
+        for (Preset p:presets) {
+            PresetItem item =p.getItemByName("Parking", null);
+            if (item != null) {
+                PresetComboField combo = (PresetComboField) item.getField("bicycle_parking");
+                for (StringWithDescription value: combo.getValues()) {
+                    if ("stands".equals(value.getValue()) && value instanceof StringWithDescriptionAndIcon) {
+                        String imagePath = ((StringWithDescriptionAndIcon) value).getImagePath();
+                        if (imagePath != null) {
+                            assertTrue(new File(imagePath).exists());
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+        fail("preset not found");
     }
 }

--- a/src/main/java/de/blau/android/presets/PresetParser.java
+++ b/src/main/java/de/blau/android/presets/PresetParser.java
@@ -791,7 +791,7 @@ public class PresetParser {
              */
             @NonNull
             private String getImagePath(@NonNull Preset preset, @NonNull String imagePath) {
-                return preset.isDefault() ? imagePath : preset.getDirectory().toString() + imagePath;
+                return preset.isDefault() ? imagePath : preset.getDirectory().getAbsolutePath() + "/" + imagePath;
             }
         });
     }

--- a/src/main/java/de/blau/android/propertyeditor/tagform/ComboImageLoader.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/ComboImageLoader.java
@@ -22,8 +22,8 @@ public class ComboImageLoader extends ImageLoader {
 
     private static final long serialVersionUID = 1L;
 
-    private List<Value> values; // NOSONAR
-    private String      key;
+    private final List<Value> values; // NOSONAR
+    private final String      key;
 
     /**
      * Construct a new loader
@@ -31,7 +31,7 @@ public class ComboImageLoader extends ImageLoader {
      * @param key the key
      * @param values a list of values
      */
-    ComboImageLoader(String key, @NonNull List<Value> values) {
+    ComboImageLoader(@NonNull String key, @NonNull List<Value> values) {
         this.key = key;
         this.values = values;
     }


### PR DESCRIPTION
At some point in time it seems as if the path separator started missing from the end of the directory path, this adds it back and adds a test that the generated paths actually exist.
