### PR TITLE
Support long text modal in additional items

### DIFF
--- a/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
+++ b/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
@@ -485,7 +485,7 @@ public class PropertyEditorTest {
         found = TestUtils.clickText(device, true, getTranslatedPresetItemName(main, "Restaurant"), true, false);
         assertTrue(found);
         
-        // apply optional tags and check that diaper tag isn't present
+        // apply optional tags 
         assertTrue(TestUtils.clickMenuButton(device, main.getString(R.string.tag_menu_apply_preset_with_optional), false, false));
         TestUtils.scrollTo("Wheelchair access details", false);
         
@@ -499,7 +499,7 @@ public class PropertyEditorTest {
         } catch (UiObjectNotFoundException e) {
             fail();
         }  
-
+        assertTrue(TestUtils.findText(device, false, "1234567890"));
         TestUtils.clickHome(device, true);
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_nodeselect)));
         device.waitForIdle();

--- a/src/main/java/de/blau/android/prefs/Preferences.java
+++ b/src/main/java/de/blau/android/prefs/Preferences.java
@@ -19,7 +19,6 @@ import de.blau.android.App;
 import de.blau.android.Map;
 import de.blau.android.R;
 import de.blau.android.contract.Urls;
-import de.blau.android.osm.Capabilities;
 import de.blau.android.osm.Server;
 import de.blau.android.presets.Preset;
 import de.blau.android.resources.DataStyle;
@@ -316,7 +315,7 @@ public class Preferences {
 
         useImperialUnits = prefs.getBoolean(r.getString(R.string.config_useImperialUnits_key), false);
 
-        longStringLimit = getIntPref(R.string.config_longStringLimit_key, Capabilities.DEFAULT_MAX_STRING_LENGTH);
+        longStringLimit = getIntPref(R.string.config_longStringLimit_key, 80);
     }
 
     /**

--- a/src/main/java/de/blau/android/propertyeditor/tagform/KeyValueRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/KeyValueRow.java
@@ -1,5 +1,8 @@
 package de.blau.android.propertyeditor.tagform;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 public interface KeyValueRow {
 
     /**
@@ -7,6 +10,7 @@ public interface KeyValueRow {
      * 
      * @return the key as a String
      */
+    @NonNull
     String getKey();
     
     /**
@@ -14,5 +18,10 @@ public interface KeyValueRow {
      * 
      * @return the current value as a String
      */
+    @Nullable
     String getValue();
+    
+    default boolean hasKey(@Nullable String key) {
+        return getKey().equals(key);
+    }
 }

--- a/src/main/java/de/blau/android/propertyeditor/tagform/LongTextDialogRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/LongTextDialogRow.java
@@ -10,6 +10,7 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AlertDialog.Builder;
 import de.blau.android.R;
@@ -58,7 +59,7 @@ public class LongTextDialogRow extends DialogRow {
      * @return an instance of TagFormDialogRow
      */
     static DialogRow getRow(@NonNull final TagFormFragment caller, @NonNull final LayoutInflater inflater, @NonNull final LinearLayout rowLayout,
-            @NonNull final PresetItem preset, @NonNull final PresetTextField field, @NonNull final String value, int maxLength) {
+            @Nullable final PresetItem preset, @NonNull final PresetTextField field, @NonNull final String value, int maxLength) {
         final DialogRow row = (DialogRow) inflater.inflate(R.layout.tag_form_text_dialog_row, rowLayout, false);
         String key = field.getKey();
         String hint = field.getHint();

--- a/src/main/java/de/blau/android/util/Util.java
+++ b/src/main/java/de/blau/android/util/Util.java
@@ -560,7 +560,7 @@ public final class Util {
      * @param packageManager a PackageManager instance
      * @return true if the package is installed
      */
-   
+
     public static boolean isPackageInstalled(@NonNull String packageName, @NonNull PackageManager packageManager) {
         try {
             getPackageInfo(packageName, packageManager);
@@ -680,7 +680,17 @@ public final class Util {
      * @return true if text is neither null nor the empty String
      */
     public static boolean notEmpty(@Nullable final String text) {
-        return text != null && !"".equals(text);
+        return text != null && text.length() > 0;
+    }
+
+    /**
+     * Check if a String is either null or the empty String
+     * 
+     * @param text the input String
+     * @return true if text is either null or the empty String
+     */
+    public static boolean isEmpty(@Nullable final String text) {
+        return text == null || text.length() == 0;
     }
 
     /**

--- a/src/main/res/xml-v19/advancedpreferences.xml
+++ b/src/main/res/xml-v19/advancedpreferences.xml
@@ -113,7 +113,7 @@
             app:spt_currentValueText="@string/config_maxInlineValues_current"
             app:spt_setWrapSelectorWheel="false" />
         <ch.poole.android.numberpickerpreference.NumberPickerPreference
-            android:defaultValue="255"
+            android:defaultValue="80"
             android:dialogTitle="@string/config_longStringLimit_title"
             android:key="@string/config_longStringLimit_key"
             android:numeric="integer"

--- a/src/main/res/xml-v24/advancedpreferences.xml
+++ b/src/main/res/xml-v24/advancedpreferences.xml
@@ -113,7 +113,7 @@
             app:spt_currentValueText="@string/config_maxInlineValues_current"
             app:spt_setWrapSelectorWheel="false" />
         <ch.poole.android.numberpickerpreference.NumberPickerPreference
-            android:defaultValue="255"
+            android:defaultValue="80"
             android:dialogTitle="@string/config_longStringLimit_title"
             android:key="@string/config_longStringLimit_key"
             android:numeric="integer"

--- a/src/main/res/xml-v29/advancedpreferences.xml
+++ b/src/main/res/xml-v29/advancedpreferences.xml
@@ -113,7 +113,7 @@
             app:spt_currentValueText="@string/config_maxInlineValues_current"
             app:spt_setWrapSelectorWheel="false" />
         <ch.poole.android.numberpickerpreference.NumberPickerPreference
-            android:defaultValue="255"
+            android:defaultValue="80"
             android:dialogTitle="@string/config_longStringLimit_title"
             android:key="@string/config_longStringLimit_key"
             android:numeric="integer"

--- a/src/main/res/xml/advancedpreferences.xml
+++ b/src/main/res/xml/advancedpreferences.xml
@@ -113,7 +113,7 @@
             app:spt_currentValueText="@string/config_maxInlineValues_current"
             app:spt_setWrapSelectorWheel="false" />
         <ch.poole.android.numberpickerpreference.NumberPickerPreference
-            android:defaultValue="255"
+            android:defaultValue="80"
             android:dialogTitle="@string/config_longStringLimit_title"
             android:key="@string/config_longStringLimit_key"
             android:numeric="integer"


### PR DESCRIPTION
This will show the long text modal for "Additional" items if they are longer then the value set in the preferences.

This set the default max length value in the preferences to 80 as otherwise the modal would essentially never be shown.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/2373