### PR TITLE
Add more context to disambiguation menu

### DIFF
--- a/src/androidTest/java/de/blau/android/KeyboardTest.java
+++ b/src/androidTest/java/de/blau/android/KeyboardTest.java
@@ -150,7 +150,7 @@ public class KeyboardTest {
 
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
         TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
-        Assert.assertTrue(TestUtils.clickText(device, false, "Path", false, false));
+        Assert.assertTrue(TestUtils.clickText(device, false, "↓ Path", false, false));
         Way way = App.getLogic().getSelectedWay();
         Assert.assertNotNull(way);
         Assert.assertEquals(104148456L, way.getOsmId());
@@ -179,7 +179,7 @@ public class KeyboardTest {
         TestUtils.clickText(device, false, "Ok", false); // in case we get a tip
 
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
-        Assert.assertTrue(TestUtils.clickText(device, false, "Path", false, false));
+        Assert.assertTrue(TestUtils.clickText(device, false, "↓ Path", false, false));
         way = App.getLogic().getSelectedWay();
         Assert.assertNotNull(way);
         Assert.assertEquals(104148456L, way.getOsmId());

--- a/src/androidTest/java/de/blau/android/UndoRedoTest.java
+++ b/src/androidTest/java/de/blau/android/UndoRedoTest.java
@@ -80,7 +80,7 @@ public class UndoRedoTest {
     public void dialog() {
         TestUtils.clickAtCoordinates(device, map, 8.38782, 47.390339, true);
         TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
-        TestUtils.clickText(device, false, "Toilets", false, false);
+        TestUtils.clickText(device, false, "↓ Toilets", false, false);
         TestUtils.sleep();
         Node node = App.getLogic().getSelectedNode();
         Assert.assertNotNull(node);

--- a/src/androidTest/java/de/blau/android/easyedit/ExtendedSelectionTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/ExtendedSelectionTest.java
@@ -89,8 +89,8 @@ public class ExtendedSelectionTest {
         TestUtils.sleep(2000);
         TestUtils.clickAtCoordinates(device, map, 8.38782, 47.390339, true);
         TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
-        TestUtils.findText(device, false, "Toilets", 10000);
-        assertTrue(TestUtils.clickText(device, false, "Toilets", false, false));
+        TestUtils.findText(device, false, "↓ Toilets", 10000);
+        assertTrue(TestUtils.clickText(device, false, "↓ Toilets", true, false));
         Node node = App.getLogic().getSelectedNode();
         assertNotNull(node);
         assertEquals(3465444349L, node.getOsmId());
@@ -103,7 +103,7 @@ public class ExtendedSelectionTest {
         // double clicking doesn't currently work reliably in tests TestUtils.doubleClickAtCoordinates(device, map,
         // 8.3877977, 47.3897371, true); // NOSONAR
         TestUtils.clickAtCoordinates(device, map, 8.3877977, 47.3897371, true);
-        assertTrue(TestUtils.clickText(device, false, "Excrement", false, false));
+        assertTrue(TestUtils.clickText(device, false, "↓ Excrement", false, false));
         assertEquals(2, logic.getSelectedNodes().size());
         TestUtils.zoomToLevel(device, main, 22);
         TestUtils.drag(device, map, 8.3877977, 47.3897371, 8.3879, 47.38967, true, 100);
@@ -128,7 +128,7 @@ public class ExtendedSelectionTest {
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
         TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
-        assertTrue(TestUtils.clickText(device, false, "Path", false, false));
+        assertTrue(TestUtils.clickText(device, false, "↓ Path", false, false));
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_wayselect)));
         Way way = App.getLogic().getSelectedWay();
         assertNotNull(way);
@@ -139,14 +139,14 @@ public class ExtendedSelectionTest {
         TestUtils.clickAtCoordinates(device, map, 8.3899934, 47.3898778, true);
         TestUtils.textGone(device, context.getString(R.string.menu_split), 1);
         TestUtils.clickAtCoordinates(device, map, 8.3899204, 47.3898603, true);
-        assertTrue(TestUtils.clickText(device, false, "Path", false, false));
+        assertTrue(TestUtils.clickText(device, false, "↙ Path", false, false));
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_wayselect)));
         assertTrue(TestUtils.clickOverflowButton(device));
         TestUtils.scrollTo(context.getString(R.string.menu_extend_selection), false);
         assertTrue(TestUtils.clickText(device, false, context.getString(R.string.menu_extend_selection), true, false));
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_multiselect)));
         TestUtils.clickAtCoordinates(device, map, 8.3900912, 47.3899572, true);
-        assertTrue(TestUtils.clickText(device, false, "Path", false, false));
+        assertTrue(TestUtils.clickText(device, false, "↗ Path", false, false));
         assertTrue(TestUtils.findText(device, false, context.getResources().getQuantityString(R.plurals.actionmode_object_count, 2, 2)));
         // force the highway type to something else
         List<Way> ways = App.getLogic().getSelectedWays();

--- a/src/androidTest/java/de/blau/android/easyedit/NodeTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/NodeTest.java
@@ -90,7 +90,7 @@ public class NodeTest {
     public void selectNode() {
         TestUtils.clickAtCoordinates(device, map, 8.38782, 47.390339, true);
         TestUtils.clickAwayTip(device, context); 
-        assertTrue(TestUtils.clickText(device, false, "Toilets", true, false, 5000));
+        assertTrue(TestUtils.clickText(device, false, "↓ Toilets", true, false, 5000));
         Node node = App.getLogic().getSelectedNode();
         assertNotNull(node);
         assertEquals(3465444349L, node.getOsmId());
@@ -120,7 +120,7 @@ public class NodeTest {
     public void dragNode() {
         TestUtils.clickAtCoordinates(device, map, 8.38782, 47.390339, true);
         TestUtils.clickAwayTip(device, context); 
-        assertTrue(TestUtils.clickText(device, false, "Toilets", true, false, 5000));
+        assertTrue(TestUtils.clickText(device, false, "↓ Toilets", true, false, 5000));
         Node node = App.getLogic().getSelectedNode();
         assertNotNull(node);
         assertEquals(3465444349L, node.getOsmId());
@@ -163,7 +163,7 @@ public class NodeTest {
 
         TestUtils.clickAtCoordinates(device, map, 8.3874964, 47.3884769, false);
         TestUtils.clickAwayTip(device, context); 
-        assertTrue(TestUtils.clickText(device, false, "#633468419", false, false)); // the first node in the list
+        assertTrue(TestUtils.clickText(device, false, "↓ #633468419", false, false)); // the first node in the list
         assertTrue(TestUtils.clickMenuButton(device, context.getString(R.string.menu_merge), false, true));
 
         List<Way> waysAfter = logic.getWaysForNode(node);
@@ -191,7 +191,7 @@ public class NodeTest {
 
         TestUtils.clickAtCoordinates(device, map, 8.3866386, 47.3904394, false);
         TestUtils.clickAwayTip(device, context); 
-        assertTrue(TestUtils.clickText(device, false, "#-2221", false, false)); // the first node in the list
+        assertTrue(TestUtils.clickText(device, false, "↓ #-2221", false, false)); // the first node in the list
         assertTrue(TestUtils.clickMenuButton(device, context.getString(R.string.menu_merge), false, true));
 
         // merge all

--- a/src/androidTest/java/de/blau/android/easyedit/RelationTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/RelationTest.java
@@ -99,7 +99,7 @@ public class RelationTest {
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
         TestUtils.clickAwayTip(device, context);
-        assertTrue(TestUtils.clickText(device, false, "Hiking", false, false));
+        assertTrue(TestUtils.clickText(device, false, "↓ Hiking", false, false));
         List<Relation> rels = App.getLogic().getSelectedRelations();
         assertNotNull(rels);
         assertEquals(1, rels.size());
@@ -135,8 +135,8 @@ public class RelationTest {
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
         TestUtils.clickAwayTip(device, context);
-        assertTrue(TestUtils.findText(device, false, "Path", 2000));
-        assertTrue(TestUtils.clickText(device, false, "Path", false, false));
+        assertTrue(TestUtils.findText(device, false, "↓ Path", 2000));
+        assertTrue(TestUtils.clickText(device, false, "↓ Path", false, false));
         Way way = App.getLogic().getSelectedWay();
         assertNotNull(way);
         assertEquals(104148456L, way.getOsmId());

--- a/src/androidTest/java/de/blau/android/easyedit/SaveResumeTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/SaveResumeTest.java
@@ -110,7 +110,7 @@ public class SaveResumeTest {
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
         TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
-        assertTrue(TestUtils.clickText(device, false, "Path", false, false));
+        assertTrue(TestUtils.clickText(device, false, "↓ Path", false, false));
         Way way = App.getLogic().getSelectedWay();
         assertNotNull(way);
         assertEquals(104148456L, way.getOsmId());
@@ -171,7 +171,7 @@ public class SaveResumeTest {
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
         TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
-        TestUtils.clickText(device, false, "Path", false, false);
+        TestUtils.clickText(device, false, "↓ Path", false, false);
         Way way = App.getLogic().getSelectedWay();
         assertNotNull(way);
         assertEquals(104148456L, way.getOsmId());

--- a/src/androidTest/java/de/blau/android/easyedit/WayActionsTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/WayActionsTest.java
@@ -154,7 +154,7 @@ public class WayActionsTest {
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
         TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
-        assertTrue(TestUtils.clickText(device, false, "Path", false, false));
+        assertTrue(TestUtils.clickText(device, false, "↓ Path", false, false));
         Way way = App.getLogic().getSelectedWay();
         List<Node> origWayNodes = new ArrayList<>(way.getNodes());
         assertNotNull(way);
@@ -199,7 +199,7 @@ public class WayActionsTest {
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
         TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
-        assertTrue(TestUtils.clickText(device, false, "Path", false, false));
+        assertTrue(TestUtils.clickText(device, false, "↓ Path", false, false));
         Way way = App.getLogic().getSelectedWay();
         assertNotNull(way);
         assertEquals(104148456L, way.getOsmId());
@@ -250,7 +250,7 @@ public class WayActionsTest {
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3884403, 47.3884988, true);
         TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
-        assertTrue(TestUtils.clickText(device, false, "Bergstrasse", true, false));
+        assertTrue(TestUtils.clickText(device, false, "↑ Bergstrasse", true, false));
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_wayselect)));
         Way way = App.getLogic().getSelectedWay();
         assertNotNull(way);
@@ -313,7 +313,7 @@ public class WayActionsTest {
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3884403, 47.3884988, true);
         TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
-        assertTrue(TestUtils.clickText(device, false, "Bergstrasse", false, false));
+        assertTrue(TestUtils.clickText(device, false, "↑ Bergstrasse", false, false));
         Way way = App.getLogic().getSelectedWay();
         assertNotNull(way);
         assertEquals(119104094L, way.getOsmId());
@@ -497,7 +497,7 @@ public class WayActionsTest {
             TestUtils.zoomToLevel(device, main, 21);
             TestUtils.clickAtCoordinates(device, map, 8.3884403, 47.3884988, true);
             TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
-            assertTrue(TestUtils.clickText(device, false, "Bergstrasse", false, false));
+            assertTrue(TestUtils.clickText(device, false, "↑ Bergstrasse", false, false));
             Way way = App.getLogic().getSelectedWay();
             assertNotNull(way);
             assertEquals(119104094L, way.getOsmId());
@@ -578,7 +578,7 @@ public class WayActionsTest {
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3884403, 47.3884988, true);
         TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
-        assertTrue(TestUtils.clickText(device, false, "Bergstrasse", false, false));
+        assertTrue(TestUtils.clickText(device, false, "↑ Bergstrasse", false, false));
         Way way = App.getLogic().getSelectedWay();
         assertNotNull(way);
         assertEquals(119104094L, way.getOsmId());

--- a/src/androidTest/java/de/blau/android/easyedit/WayTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/WayTest.java
@@ -101,7 +101,7 @@ public class WayTest {
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
         TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
-        assertTrue(TestUtils.clickText(device, false, "Path", false, false));
+        assertTrue(TestUtils.clickText(device, false, "↓ Path", false, false));
         Way way = App.getLogic().getSelectedWay();
         assertNotNull(way);
         List<Node> origWayNodes = new ArrayList<>(way.getNodes());
@@ -161,7 +161,7 @@ public class WayTest {
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
         TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
-        assertTrue(TestUtils.clickText(device, false, "Path", false, false));
+        assertTrue(TestUtils.clickText(device, false, "↓ Path", false, false));
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_wayselect)));
         Way way = App.getLogic().getSelectedWay();
         assertNotNull(way);
@@ -174,7 +174,7 @@ public class WayTest {
         TestUtils.sleep(2000);
         assertTrue(TestUtils.textGone(device, context.getString(R.string.actionmode_wayselect), 5000));
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
-        assertTrue(TestUtils.clickText(device, false, "Path", false, false));
+        assertTrue(TestUtils.clickText(device, false, "↗ Path", false, false));
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_wayselect)));
         way = App.getLogic().getSelectedWay();
         assertNotNull(way);
@@ -200,7 +200,7 @@ public class WayTest {
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
         TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
-        assertTrue(TestUtils.clickText(device, false, "Path", false, false));
+        assertTrue(TestUtils.clickText(device, false, "↓ Path", false, false));
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_wayselect)));
         Way way = App.getLogic().getSelectedWay();
         assertNotNull(way);
@@ -215,7 +215,7 @@ public class WayTest {
         TestUtils.sleep(2000);
         assertTrue(TestUtils.textGone(device, context.getString(R.string.actionmode_wayselect), 5000));
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
-        assertTrue(TestUtils.clickText(device, false, "Path", false, false));
+        assertTrue(TestUtils.clickText(device, false, "↗ Path", false, false));
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_wayselect)));
         way = App.getLogic().getSelectedWay();
         assertNotNull(way);
@@ -233,7 +233,7 @@ public class WayTest {
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
         TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
-        assertTrue(TestUtils.clickText(device, false, "Path", false, false));
+        assertTrue(TestUtils.clickText(device, false, "↓ Path", false, false));
         Way way = App.getLogic().getSelectedWay();
         assertNotNull(way);
         List<Node> wayNodes = new ArrayList<>(way.getNodes());
@@ -265,7 +265,7 @@ public class WayTest {
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
         TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
-        assertTrue(TestUtils.clickText(device, false, "Path", false, false));
+        assertTrue(TestUtils.clickText(device, false, "↓ Path", false, false));
         Way way = App.getLogic().getSelectedWay();
         assertNotNull(way);
         assertEquals(104148456L, way.getOsmId());
@@ -301,7 +301,7 @@ public class WayTest {
         TestUtils.zoomToLevel(device, main, 22);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
         TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
-        assertTrue(TestUtils.clickText(device, false, "Path", false, false));
+        assertTrue(TestUtils.clickText(device, false, "↓ Path", false, false));
         Way way = App.getLogic().getSelectedWay();
         List<Node> origWayNodes = new ArrayList<>(way.getNodes());
         assertNotNull(way);
@@ -346,7 +346,7 @@ public class WayTest {
         TestUtils.zoomToLevel(device, main, 22);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
         TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
-        assertTrue(TestUtils.clickText(device, false, "Path", false, false)); 
+        assertTrue(TestUtils.clickText(device, false, "↓ Path", false, false)); 
         Way way = App.getLogic().getSelectedWay();
         assertNotNull(way);
         assertEquals(104148456L, way.getOsmId());
@@ -400,7 +400,7 @@ public class WayTest {
         TestUtils.zoomToLevel(device, main, 22);
         TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
         TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
-        assertTrue(TestUtils.clickText(device, false, "Path", false, false));
+        assertTrue(TestUtils.clickText(device, false, "↓ Path", false, false));
         Way way = App.getLogic().getSelectedWay();
         assertNotNull(way);
         assertEquals(104148456L, way.getOsmId());

--- a/src/androidTest/java/de/blau/android/filter/PresetFilterTest.java
+++ b/src/androidTest/java/de/blau/android/filter/PresetFilterTest.java
@@ -40,6 +40,7 @@ public class PresetFilterTest {
     private UiDevice        device          = null;
     private Main            main            = null;
     private Map             map             = null;
+    private Preferences     prefs;
 
     @Rule
     public ActivityTestRule<Main> mActivityRule = new ActivityTestRule<>(Main.class);
@@ -54,8 +55,10 @@ public class PresetFilterTest {
         context = instrumentation.getTargetContext();
         monitor = instrumentation.addMonitor(PresetFilterActivity.class.getName(), null, false);
         main = mActivityRule.getActivity();
-        Preferences prefs = new Preferences(context);
+        prefs = App.getPreferences(context);
         LayerUtils.removeImageryLayers(context);
+        prefs.enablePresetFilter(false);
+        prefs.enableTagFilter(false);
         map = main.getMap();
         map.setPrefs(main, prefs);
 
@@ -71,6 +74,8 @@ public class PresetFilterTest {
     @After
     public void teardown() {
         instrumentation.removeMonitor(monitor);
+        prefs.enablePresetFilter(false);
+        prefs.enableTagFilter(false);
     }
 
     /**
@@ -111,15 +116,15 @@ public class PresetFilterTest {
         assertTrue(TestUtils.clickText(device, false, "Waypoints", true, true));
         assertTrue(TestUtils.clickText(device, false, "Pedestrian Crossing", true));
         TestUtils.sleep(2000);
-        TestUtils.clickAtCoordinates(device, main.getMap(),  8.3886622D, 47.3887223D, true);
+        TestUtils.clickAtCoordinates(device, main.getMap(), 8.3886622D, 47.3887223D, true);
         assertTrue(TestUtils.findText(device, false, main.getString(R.string.actionmode_nodeselect), 5000));
         assertEquals(289987514L, App.getLogic().getSelectedNode().getOsmId());
 
-        TestUtils.drag(device, main.getMap(), 8.3886622D, 47.3887223D,  8.389D, 47.389D, false, 10);
-        
+        TestUtils.drag(device, main.getMap(), 8.3886622D, 47.3887223D, 8.389D, 47.389D, false, 10);
+
         TestUtils.findText(device, false, main.getString(R.string.attached_object_warning_stop), 2000);
         assertTrue(TestUtils.clickText(device, false, main.getString(R.string.attached_object_warning_stop), true));
-        
+
         TestUtils.clickUp(device);
         TestUtils.clickOverflowButton(device);
         TestUtils.clickText(device, false, main.getString(R.string.menu_enable_presetfilter), true, false);

--- a/src/androidTest/java/de/blau/android/measure/streetmeasure/MeasureTest.java
+++ b/src/androidTest/java/de/blau/android/measure/streetmeasure/MeasureTest.java
@@ -168,7 +168,7 @@ public class MeasureTest {
         TestUtils.zoomToLevel(device, main, 23);
         TestUtils.clickAtCoordinates(device, main.getMap(), 8.3848461, 47.3899166, true);
         TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
-        assertTrue(TestUtils.clickText(device, false, "Kindhauserstrasse", false, false));
+        assertTrue(TestUtils.clickText(device, false, "↖ Kindhauserstrasse", false, false));
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_wayselect)));
         Way w = App.getLogic().getSelectedWay();
         assertNotNull(w);

--- a/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
+++ b/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
@@ -618,7 +618,7 @@ public class PropertyEditorTest {
         TestUtils.zoomToLevel(device, main, 23);
         TestUtils.clickAtCoordinates(device, main.getMap(), 8.3848461, 47.3899166, true);
         TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
-        assertTrue(TestUtils.clickText(device, false, "Kindhauserstrasse", false, false));
+        assertTrue(TestUtils.clickText(device, false, "↖ Kindhauserstrasse", false, false));
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_wayselect)));
         Way w = App.getLogic().getSelectedWay();
         assertNotNull(w);
@@ -768,7 +768,7 @@ public class PropertyEditorTest {
         TestUtils.zoomToLevel(device, main, 22);
         TestUtils.clickAtCoordinates(device, main.getMap(), 8.3848461, 47.3899166, true);
         TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
-        assertTrue(TestUtils.clickText(device, false, "Kindhauserstrasse", false, false));
+        assertTrue(TestUtils.clickText(device, false, "↖ Kindhauserstrasse", false, false));
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_wayselect)));
         Way w = App.getLogic().getSelectedWay();
         assertNotNull(w);

--- a/src/androidTest/java/de/blau/android/tasks/TodoTest.java
+++ b/src/androidTest/java/de/blau/android/tasks/TodoTest.java
@@ -97,7 +97,7 @@ public class TodoTest {
     public void addAndCloseTodo() {
         TestUtils.clickAtCoordinates(device, map, 8.38782, 47.390339, true);
         TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
-        assertTrue(TestUtils.clickText(device, false, "Toilets", true, false, 5000));
+        assertTrue(TestUtils.clickText(device, false, "↓ Toilets", true, false, 5000));
         Node node = App.getLogic().getSelectedNode();
         assertNotNull(node);
         assertEquals(3465444349L, node.getOsmId());

--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -4311,8 +4311,8 @@ public class Logic {
                 if (result > 0) {
                     try {
                         if (activity != null) {
-                            ScreenMessage.barInfo(activity, activity.getResources().getQuantityString(R.plurals.toast_unread_mail, result, result), R.string.read_mail,
-                                    v -> {
+                            ScreenMessage.barInfo(activity, activity.getResources().getQuantityString(R.plurals.toast_unread_mail, result, result),
+                                    R.string.read_mail, v -> {
                                         try {
                                             activity.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(Urls.OSM_LOGIN)));
                                         } catch (Exception ex) {
@@ -5375,7 +5375,8 @@ public class Logic {
      */
     public void copyToClipboard(@NonNull List<OsmElement> elements) {
         int[] centroid = calcCentroid(elements);
-        if (centroid == null) {
+        if (centroid.length != 2) {
+            Log.e(DEBUG_TAG, "Unable to determine centroid");
             return;
         }
         getDelegator().copyToClipboard(elements, centroid[0], centroid[1]);
@@ -5402,7 +5403,8 @@ public class Logic {
     public void cutToClipboard(@Nullable Activity activity, @NonNull List<OsmElement> elements) {
         createCheckpoint(activity, R.string.undo_action_cut);
         int[] centroid = calcCentroid(elements);
-        if (centroid == null) {
+        if (centroid.length != 2) {
+            Log.e(DEBUG_TAG, "Unable to determine centroid");
             return;
         }
         getDelegator().cutToClipboard(elements, centroid[0], centroid[1]);
@@ -5416,13 +5418,13 @@ public class Logic {
      * better match the expectation of a user (in which points have the same importance as an area or a way.
      * 
      * @param elements a list of OsmElements
-     * @return the centroid or null if an error occurs
+     * @return the centroid or an empty array if an error occurs [lat, lon] WGS84*E7
      */
-    @Nullable
-    int[] calcCentroid(@NonNull List<OsmElement> elements) {
+    @NonNull
+    private int[] calcCentroid(@NonNull List<OsmElement> elements) {
         if (elements.isEmpty()) {
             Log.e(DEBUG_TAG, "empty element list for for centroid");
-            return null;
+            return new int[0];
         }
         long latE7 = 0;
         long lonE7 = 0;
@@ -5433,15 +5435,15 @@ public class Logic {
             } else if (e instanceof Way) {
                 // use current centroid of way
                 int[] centroid = Geometry.centroid(map.getWidth(), map.getHeight(), viewBox, (Way) e);
-                if (centroid == null) {
+                if (centroid.length != 2) {
                     Log.e(DEBUG_TAG, "centroid of way " + e.getDescription() + " is null");
-                    return null;
+                    return new int[0];
                 }
                 latE7 += centroid[0];
                 lonE7 += centroid[1];
             } else {
                 Log.e(DEBUG_TAG, "unknown object type for centroid");
-                return null;
+                return new int[0];
             }
         }
         final int size = elements.size();

--- a/src/main/java/de/blau/android/address/Address.java
+++ b/src/main/java/de/blau/android/address/Address.java
@@ -145,7 +145,7 @@ public final class Address implements Serializable {
         case AREA:
             if (Way.NAME.equals(e.getName())) {
                 double[] center = Geometry.centroidLonLat((Way) e);
-                if (center != null) {
+                if (center.length == 2) {
                     lat = (float) center[1];
                     lon = (float) center[0];
                 }

--- a/src/main/java/de/blau/android/easyedit/NodeSelectionActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/NodeSelectionActionModeCallback.java
@@ -258,7 +258,7 @@ public class NodeSelectionActionModeCallback extends ElementSelectionActionModeC
      */
     private <T extends OsmElement> void addElementsToContextMenu(@NonNull DisambiguationMenu menu, int startIndex, @NonNull List<T> elements) {
         for (OsmElement e : elements) {
-            menu.add(startIndex++, e, main.descriptionForContextMenu(e), false, this);
+            menu.add(startIndex++, e, main.descriptionForContextMenu(e, Double.MAX_VALUE, Double.MAX_VALUE), false, this);
         }
     }
 

--- a/src/main/java/de/blau/android/tasks/Todo.java
+++ b/src/main/java/de/blau/android/tasks/Todo.java
@@ -160,7 +160,7 @@ public final class Todo extends Bug implements Serializable {
         case Way.NAME:
             ways = elementList;
             double[] center = Geometry.centroidLonLat((Way) element);
-            if (center != null) {
+            if (center.length == 2) {
                 lon = (int) Math.round(center[0] * 1E7D);
                 lat = (int) Math.round(center[1] * 1E7D);
             }

--- a/src/main/java/de/blau/android/util/GeoContext.java
+++ b/src/main/java/de/blau/android/util/GeoContext.java
@@ -322,7 +322,7 @@ public class GeoContext {
                 lat = ((Node) e).getLat() / 1E7D;
             } else if (e instanceof Way) {
                 double[] coords = Geometry.centroidLonLat((Way) e);
-                if (coords == null) {
+                if (coords.length != 2) {
                     throw new IllegalStateException("way " + e.getOsmId() + " no coords");
                 }
                 lon = coords[0];
@@ -409,7 +409,7 @@ public class GeoContext {
      */
     public boolean imperial(@NonNull Way w) {
         double[] coords = Geometry.centroidLonLat(w);
-        return imperial(coords[0], coords[1]);
+        return coords.length == 2 && imperial(coords[0], coords[1]);
     }
 
     /**
@@ -464,7 +464,7 @@ public class GeoContext {
      */
     public boolean driveLeft(@NonNull Way w) {
         double[] coords = Geometry.centroidLonLat(w);
-        return driveLeft(coords[0], coords[1]);
+        return coords.length == 2 && driveLeft(coords[0], coords[1]);
     }
 
     /**

--- a/src/main/java/de/blau/android/util/Geometry.java
+++ b/src/main/java/de/blau/android/util/Geometry.java
@@ -171,7 +171,7 @@ public final class Geometry {
      * @return a double array containing lon - lat in WGS84 coords
      */
     @NonNull
-    static double[] centroid(@NonNull OsmElement e) {
+    public static double[] centroid(@NonNull OsmElement e) {
         switch (e.getName()) {
         case Node.NAME:
             return new double[] { ((Node) e).getLon() / 1E7D, ((Node) e).getLat() / 1E7D };

--- a/src/main/java/de/blau/android/util/Util.java
+++ b/src/main/java/de/blau/android/util/Util.java
@@ -196,7 +196,7 @@ public final class Util {
         }
         if (osmElement instanceof Way) {
             double[] coords = Geometry.centroidLonLat((Way) osmElement);
-            if (coords != null) {
+            if (coords.length == 2) {
                 return new IntCoordinates((int) (coords[0] * 1E7), (int) (coords[1] * 1E7));
             }
         }
@@ -208,6 +208,31 @@ public final class Util {
             }
         }
         return null;
+    }
+
+    private static final int[] bearings = { R.string.bearing_ne, R.string.bearing_e, R.string.bearing_se, R.string.bearing_s, R.string.bearing_sw,
+            R.string.bearing_w, R.string.bearing_nw, R.string.bearing_n };
+
+    /**
+     * Get a String indicating the bearing from (sLon/sLat) to (eLon/eLat)
+     * 
+     * @param context an Android Context
+     * @param sLon start lon
+     * @param sLat start lat
+     * @param eLon end lon
+     * @param eLat end lat
+     * @return a String indicating the bearing
+     */
+    @NonNull
+    public static String getBearingString(@NonNull Context context, double sLon, double sLat, double eLon, double eLat) {
+        long bearing = GeoMath.bearing(sLon, sLat, eLon, eLat);
+
+        int index = (int) (bearing - 22.5);
+        if (index < 0) {
+            index += 360;
+        }
+        index = index / 45;
+        return context.getString(bearings[index]);
     }
 
     /**
@@ -308,8 +333,8 @@ public final class Util {
      * @param lonLat coordinates to share
      * @param z the zoom level or null
      */
-    public static void sharePosition(@NonNull Activity activity, @Nullable double[] lonLat, @Nullable Integer z) {
-        if (lonLat != null) {
+    public static void sharePosition(@NonNull Activity activity, @NonNull double[] lonLat, @Nullable Integer z) {
+        if (lonLat.length == 2) {
             Uri geo = Uri.parse("geo:" + String.format(Locale.US, "%.7f", lonLat[1]) + "," + String.format(Locale.US, "%.7f", lonLat[0])
                     + (z != null ? "?z=" + z.toString() : ""));
             Log.d(DEBUG_TAG, "sharing " + geo);

--- a/src/main/java/de/blau/android/util/Util.java
+++ b/src/main/java/de/blau/android/util/Util.java
@@ -210,7 +210,7 @@ public final class Util {
         return null;
     }
 
-    private static final int[] bearings = { R.string.bearing_ne, R.string.bearing_e, R.string.bearing_se, R.string.bearing_s, R.string.bearing_sw,
+    private static final int[] bearingStrings = { R.string.bearing_ne, R.string.bearing_e, R.string.bearing_se, R.string.bearing_s, R.string.bearing_sw,
             R.string.bearing_w, R.string.bearing_nw, R.string.bearing_n };
 
     /**
@@ -232,7 +232,30 @@ public final class Util {
             index += 360;
         }
         index = index / 45;
-        return context.getString(bearings[index]);
+        return context.getString(bearingStrings[index]);
+    }
+
+    private static final char[] bearingArrows = { '↗', '→', '↘', '↓', '↙', '←', '↖', '↑' };
+
+    /**
+     * Get a char indicating the bearing from (sLon/sLat) to (eLon/eLat)
+     * 
+     * @param sLon start lon
+     * @param sLat start lat
+     * @param eLon end lon
+     * @param eLat end lat
+     * @return a char indicating the bearing
+     */
+    @NonNull
+    public static char getBearingArrow(double sLon, double sLat, double eLon, double eLat) {
+        long bearing = GeoMath.bearing(sLon, sLat, eLon, eLat);
+
+        int index = (int) (bearing - 22.5);
+        if (index < 0) {
+            index += 360;
+        }
+        index = index / 45;
+        return bearingArrows[index];
     }
 
     /**

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1029,7 +1029,9 @@
     <string name="menu_tags">Properties</string>
     <!-- ELement entry in context menu -->
     <string name="element_for_menu">%1$s</string>
+    <string name="element_for_menu_with_direction">%1$s %2$s</string>
     <string name="element_for_menu_with_parents">%1$s (%2$s)</string>
+    <string name="element_for_menu_with_parents_with_direction">%1$s %2$s (%3$s)</string>
     <!-- Text should be as short as possible -->
     <string name="start_end_way_description">Go to the Start or the End of the Way</string>
     <string name="menu_history">History</string>

--- a/src/test/java/de/blau/android/util/GeometryTest.java
+++ b/src/test/java/de/blau/android/util/GeometryTest.java
@@ -69,23 +69,23 @@ public class GeometryTest {
         Geometry.offset(input3, output3, input3.length, true, 1);
         assertArrayEquals(new float[] { -4f, 4f, 4f, 4f, 4f, 4f, 4f, -4f, 4f, -4f, -4f, -4f, -4f, -4f, -4f, 4f }, output3, 0.000001f);
     }
-    
+
     /**
-     * Test that calculating the centroid of degenerate ways does what is expected 
+     * Test that calculating the centroid of degenerate ways does what is expected
      */
     @Test
     public void centroidDegenerateWays() {
         final StorageDelegator delegator = App.getDelegator();
         OsmElementFactory factory = delegator.getFactory();
         Way w = factory.createWayWithNewId();
-        
+
         double[] centroid = Geometry.centroidLonLat(w);
-        assertNull(centroid);
+        assertEquals(0, centroid.length);
         Node n0 = factory.createNodeWithNewId(toE7(51.5019094D), toE7(-0.1417412D));
         delegator.addNodeToWay(n0, w);
         centroid = Geometry.centroidLonLat(w);
-        assertNotNull(centroid);
-        assertEquals(centroid[0],-0.1417412D, 0.0000001);
-        assertEquals(centroid[1],51.5019094D, 0.0000001);
+        assertEquals(2, centroid.length);
+        assertEquals(centroid[0], -0.1417412D, 0.0000001);
+        assertEquals(centroid[1], 51.5019094D, 0.0000001);
     }
 }


### PR DESCRIPTION
This adds arrows to the disambiguation menu roughly indicating where the objects are.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/1938