### PR TITLE
Assure that UndoStorage is emptied correctly after an upload

### DIFF
--- a/src/main/java/de/blau/android/osm/StorageDelegator.java
+++ b/src/main/java/de/blau/android/osm/StorageDelegator.java
@@ -166,6 +166,15 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
     }
 
     /**
+     * Clears a list of OsmElement from the undo storage.
+     */
+    public synchronized void clearUndo(@NonNull List<OsmElement> elements) {
+        for (OsmElement element : elements) {
+            undo.removeFromAll(element);
+        }
+    }
+
+    /**
      * Get the current OsmElementFactory instance used by this delegator. Use only the factory returned by this to
      * create new element IDs for insertion into this delegator! For immediate use only - DO NOT CACHE THIS.
      * 

--- a/src/main/java/de/blau/android/osm/UndoStorage.java
+++ b/src/main/java/de/blau/android/osm/UndoStorage.java
@@ -227,6 +227,30 @@ public class UndoStorage implements Serializable {
     }
 
     /**
+     * Remove the saved state of this element from the all checkpoints
+     * 
+     * @param element element for which the state should be removed
+     */
+    public void removeFromAll(@NonNull OsmElement element) {
+        for (Checkpoint checkpoint : new ArrayList<>(undoCheckpoints)) {
+            if (checkpoint != null) {
+                checkpoint.remove(element);
+                if (checkpoint.isEmpty()) {
+                    undoCheckpoints.remove(checkpoint);
+                }
+            }
+        }
+        for (Checkpoint checkpoint : new ArrayList<>(redoCheckpoints)) {
+            if (checkpoint != null) {
+                checkpoint.remove(element);
+                if (checkpoint.isEmpty()) {
+                    undoCheckpoints.remove(checkpoint);
+                }
+            }
+        }
+    }
+
+    /**
      * Get the current BoundingBox of the elements affected by the last Checkpoint
      * 
      * @return a BoundingBox or null
@@ -970,7 +994,7 @@ public class UndoStorage implements Serializable {
                 ((Relation) restored).members.clear();
                 for (RelationMember rm : members) {
                     OsmElement rmElement = rm.getElement();
-                    if (rmElement instanceof StyleableFeature ) {
+                    if (rmElement instanceof StyleableFeature) {
                         ((StyleableFeature) rmElement).setStyle(null); // style could have been generated from Relation
                     }
                     OsmElement rmStorage = currentStorage.getOsmElement(rm.getType(), rm.getRef());


### PR DESCRIPTION
This makes sure that the UndoStorage is reset before saving the current state to ensure that it is not reinstated after restart and handles removing undo data for selective uploads. Fixes a further issue in which the failure listener was always called after an upload, as this is not used in normal ops this was a test only issue.