### PR TITLE
Switch logic around to display menu in preset fragment in pane mode

### DIFF
--- a/src/main/java/de/blau/android/propertyeditor/PresetFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/PresetFragment.java
@@ -284,7 +284,6 @@ public class PresetFragment extends BaseFragment implements PresetUpdate, Preset
         }
 
         return presetPaneLayout;
-
     }
 
     /**
@@ -486,6 +485,7 @@ public class PresetFragment extends BaseFragment implements PresetUpdate, Preset
         // the library providing the Feedback UI is not supported under SDK 15
         boolean enablePresetFeedback = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT && BuildConfig.FLAVOR.equals(Flavors.CURRENT);
         if (paneMode) {
+            menuView.setVisibility(View.VISIBLE);
             getActivity().getMenuInflater().inflate(R.menu.preset_nav_menu, menuView.getMenu());
             menuView.setOnMenuItemClickListener(this::onOptionsItemSelected);
             if (enablePresetFeedback) {
@@ -494,7 +494,6 @@ public class PresetFragment extends BaseFragment implements PresetUpdate, Preset
             }
         } else {
             inflater.inflate(R.menu.preset_menu, menu);
-            menuView.setVisibility(View.GONE);
             if (enablePresetFeedback) {
                 menu.findItem(R.id.menu_preset_feedback).setVisible(true).setEnabled(propertyEditorListener.isConnected());
             }

--- a/src/main/res/layout/preset_pane.xml
+++ b/src/main/res/layout/preset_pane.xml
@@ -19,7 +19,8 @@
         <EditText
             android:id="@+id/preset_search_edit"
             android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="34dp" 
             android:layout_marginBottom="1dp"
             android:layout_weight="1"
             android:drawableEnd="@drawable/baseline_clear_white_36dp"
@@ -35,13 +36,14 @@
         <androidx.appcompat.widget.ActionMenuView
             android:id="@+id/preset_menu"
             android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="fill_parent"
             android:layout_gravity="end"
             android:layout_weight="2"
             android:layout_marginBottom="1dp"         
             android:minHeight="?attr/actionBarSize" 
             android:background="?attr/colorPrimary"
-            android:saveEnabled="false" />
+            android:saveEnabled="false"
+            android:visibility="gone" />
     </LinearLayout>
 
     <LinearLayout


### PR DESCRIPTION
This makes the menu adjacent to the search TextView invisible by default and makes it visible in landscape/pane mode. Hiding it caused layout artifacts while swiping in normal tab mode.

Further we now use the standard height for the search TextView.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/2459