### PR TITLE
Add function to start OSM signup in WebView

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -226,6 +226,25 @@
             android:launchMode="singleInstance"
             android:theme="@style/Theme.AppCompat" />
         <activity
+            android:name="Signup"
+            android:configChanges="orientation|screenSize|keyboardHidden|density|screenLayout|uiMode|fontScale"
+            android:launchMode="singleInstance"
+            android:theme="@style/Theme.AppCompat" 
+            android:exported="true" >
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="http" /> 
+                <data android:scheme="https" /> 
+                <data android:host="master.apis.dev.openstreetmap.org" />
+                <data android:host="www.openstreetmap.org" />
+                <data android:pathPattern="/user/.*/confirm.*" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name="LicenseViewer"
             android:configChanges="orientation|screenSize|keyboardHidden|density|screenLayout|uiMode|fontScale"
             android:theme="@style/Theme.custom" />

--- a/src/main/java/de/blau/android/Main.java
+++ b/src/main/java/de/blau/android/Main.java
@@ -2528,6 +2528,9 @@ public class Main extends FullScreenAppCompatActivity
         case R.id.tag_menu_reset_address_prediction:
             Address.resetLastAddresses(this);
             return true;
+        case R.id.menu_tools_signup:
+            Signup.startForResult(this, null);
+            break;
         case R.id.menu_tools_oauth_reset: // reset the current OAuth tokens
             if (server.getOAuth()) {
                 try (AdvancedPrefDatabase prefdb = new AdvancedPrefDatabase(this)) {

--- a/src/main/java/de/blau/android/Signup.java
+++ b/src/main/java/de/blau/android/Signup.java
@@ -1,0 +1,122 @@
+package de.blau.android;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.util.Log;
+import android.webkit.WebView;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.FragmentActivity;
+import de.blau.android.dialogs.Progress;
+import de.blau.android.prefs.Preferences;
+import de.blau.android.util.ActivityResultHandler;
+import de.blau.android.util.OsmWebViewClient;
+import de.blau.android.util.WebViewActivity;
+
+/**
+ * Create a new OSM account
+ * 
+ * Depends on the path of the page with the sign up form
+ * 
+ * https://master.apis.dev.openstreetmap.org/user/new
+ * 
+ * the format of confirmation url received in the received e-mail (see the app manifest)
+ * 
+ * https://master.apis.dev.openstreetmap.org/user/SimonDev1234/confirm?confirm_string=7x4FHpz7zvd1O8Z8hd70NIxVQDvIXpFH
+ * 
+ * and the query parameter added when the "Start mapping" button in clicked
+ * 
+ * @author Simon
+ *
+ */
+public class Signup extends WebViewActivity {
+
+    private static final String DEBUG_TAG = Signup.class.getSimpleName();
+
+    public static final int REQUEST_CODE = Signup.class.hashCode() & 0x0000FFFF;
+
+    private static final String EDIT_HELP_VALUE = "1";
+    private static final String EDIT_HELP_PARAM = "edit_help";
+    private static final String USER_NEW_PATH   = "/user/new";
+
+    /**
+     * Start a Signup activity
+     * 
+     * @param activity calling activity
+     * @param listener an ActivityResult.Listener to process the result or null
+     */
+    public static void startForResult(@NonNull FragmentActivity activity, @Nullable ActivityResultHandler.Listener listener) {
+        Log.d(DEBUG_TAG, "startForResult");
+        if (!hasWebView(activity)) {
+            return;
+        }
+        Log.d(DEBUG_TAG, "request code " + REQUEST_CODE);
+        if (listener != null) {
+            if (activity instanceof ActivityResultHandler) {
+                ((ActivityResultHandler) activity).setResultListener(REQUEST_CODE, listener);
+            } else {
+                throw new ClassCastException("activity must implement ActivityResultHandler");
+            }
+        }
+
+        Intent intent = new Intent(activity, Signup.class);
+        activity.startActivityForResult(intent, REQUEST_CODE);
+    }
+
+    private class SignupViewClient extends OsmWebViewClient {
+
+        @Override
+        public boolean handleLoading(WebView view, Uri uri) {
+            final String editHelp = uri.getQueryParameter(EDIT_HELP_PARAM);
+            if (editHelp != null && editHelp.equals(EDIT_HELP_VALUE)) {
+                exit();
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public void exit() {
+            Signup.this.exit();
+        }
+
+        @Override
+        protected void showProgressDialog() {
+            Progress.showDialog(Signup.this, Progress.PROGRESS_WEBSITE);
+        }
+
+        @Override
+        protected void dismissProgressDialog() {
+            Progress.dismissDialog(Signup.this, Progress.PROGRESS_WEBSITE);
+        }
+    }
+
+    @Override
+    protected void onCreate(final Bundle savedInstanceState) {
+        final Preferences prefs = App.getPreferences(this);
+        if (prefs.lightThemeEnabled()) {
+            setTheme(R.style.Theme_customMain_Light);
+        }
+        super.onCreate(savedInstanceState);
+
+        String dataUrl = getIntent().getDataString();
+        String signupUrl = dataUrl == null ? prefs.getServer().getWebsiteBaseUrl() + USER_NEW_PATH : dataUrl;
+
+        Log.d(DEBUG_TAG, "signup for " + signupUrl);
+        synchronized (webViewLock) {
+            webView = new WebView(this);
+            setContentView(webView);
+            webView.getSettings().setJavaScriptEnabled(true);
+            webView.setWebViewClient(new SignupViewClient());
+            loadUrlOrRestore(savedInstanceState, signupUrl);
+        }
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        Log.d(DEBUG_TAG, "onNewIntent");
+        super.onNewIntent(intent);
+        loadUrlOrRestore(null, intent.getDataString());
+    }
+}

--- a/src/main/java/de/blau/android/dialogs/Progress.java
+++ b/src/main/java/de/blau/android/dialogs/Progress.java
@@ -37,6 +37,7 @@ public class Progress extends ImmersiveDialogFragment {
     public static final int PROGRESS_LOADING_PRESET            = 14;
     public static final int PROGRESS_IMPORTING_FILE            = 15;
     public static final int PROGRESS_DOWNLOAD_TASKS            = 16;
+    public static final int PROGRESS_WEBSITE                   = 17;
 
     private int dialogType;
 
@@ -116,6 +117,7 @@ public class Progress extends ImmersiveDialogFragment {
         dismissDialog(activity, PROGRESS_LOADING_PRESET);
         dismissDialog(activity, PROGRESS_IMPORTING_FILE);
         dismissDialog(activity, PROGRESS_DOWNLOAD_TASKS);
+        dismissDialog(activity, PROGRESS_WEBSITE);
     }
 
     /**
@@ -159,6 +161,8 @@ public class Progress extends ImmersiveDialogFragment {
             return "dialog_progress_importing_file";
         case PROGRESS_DOWNLOAD_TASKS:
             return "dialog_progress_download_tasks";
+        case PROGRESS_WEBSITE:
+            return "dialog_progress_website";
         default:
             Log.w(DEBUG_TAG, "Unknown dialog type " + dialogType);
         }

--- a/src/main/java/de/blau/android/dialogs/ProgressDialog.java
+++ b/src/main/java/de/blau/android/dialogs/ProgressDialog.java
@@ -99,6 +99,10 @@ public final class ProgressDialog {
             titleId = R.string.progress_title;
             messageId = R.string.progress_download_tasks_message;
             break;
+        case Progress.PROGRESS_WEBSITE:
+            titleId = R.string.progress_general_title;
+            messageId = R.string.progress_website;
+            break;
         default:
             return null;
         }

--- a/src/main/java/de/blau/android/util/DownloadActivity.java
+++ b/src/main/java/de/blau/android/util/DownloadActivity.java
@@ -107,7 +107,7 @@ public class DownloadActivity extends WebViewActivity {
         @Override
         protected WebResourceResponse handleIntercept(WebView view, Uri uri) {
             if (FAVICON.equals(uri.getLastPathSegment())) {
-                return new WebResourceResponse(MimeTypes.PNG, "utf-8", new ByteArrayInputStream("".getBytes()));
+                return emptyResponse();
             }
             return super.handleIntercept(view, uri);
         }

--- a/src/main/java/de/blau/android/util/OsmWebViewClient.java
+++ b/src/main/java/de/blau/android/util/OsmWebViewClient.java
@@ -1,0 +1,94 @@
+package de.blau.android.util;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.net.Uri;
+import android.util.Log;
+import android.webkit.WebResourceResponse;
+import android.webkit.WebView;
+import androidx.annotation.Nullable;
+
+/**
+ * WebViewClient for some OSM website specifics
+ * 
+ * @author Simon
+ *
+ */
+public abstract class OsmWebViewClient extends UpdatedWebViewClient {
+
+    private static final String DEBUG_TAG = OsmWebViewClient.class.getSimpleName();
+
+    private static final String MATOMO = "matomo";
+
+    private Runnable dismiss = () -> dismissProgressDialog();
+
+    private Object  progressLock  = new Object();
+    private boolean progressShown = false;
+
+    /**
+     * Manipulate the response to a query
+     * 
+     * @param view the WebView
+     * @param uri the request Uri
+     * @return a WebResourceResponse or null if normal processing should continue
+     */
+    @Nullable
+    protected WebResourceResponse handleIntercept(WebView view, Uri uri) { // NOSONAR
+        // remove known trackers
+        final String path = uri.getPath();
+        if (path != null && path.toLowerCase().contains(MATOMO)) {
+            return emptyResponse();
+        }
+        return null;
+    }
+
+    @Override
+    public void receivedError(WebView view, int errorCode, String description, String failingUrl) {
+        exit();
+        ScreenMessage.toastTopError(view.getContext(), description);
+    }
+
+    @Override
+    public void onPageStarted(WebView view, String url, Bitmap favicon) {
+        synchronized (progressLock) {
+            if (!progressShown) {
+                progressShown = true;
+                showProgressDialog();
+            }
+        }
+    }
+
+    @Override
+    public void onPageFinished(WebView view, String url) {
+        synchronized (progressLock) {
+            if (view != null) { // shouldn't happen but historically has
+                Context context = view.getContext();
+                if (context instanceof WebViewActivity) {
+                    synchronized (((WebViewActivity) context).webViewLock) {
+                        if (progressShown) {
+                            view.removeCallbacks(dismiss);
+                            view.postDelayed(dismiss, 500);
+                        }
+                    }
+                    return;
+                }
+            }
+            Log.e(DEBUG_TAG, "onPageFinish context not a WebViewActivity");
+        }
+    }
+
+    /**
+     * Exit the activity holding the WebView
+     */
+    protected abstract void exit();
+
+    /**
+     * Show the progress dialog
+     */
+    protected abstract void showProgressDialog();
+
+    /**
+     * Dismiss the progress dialog
+     */
+    protected abstract void dismissProgressDialog();
+}

--- a/src/main/java/de/blau/android/util/UpdatedWebViewClient.java
+++ b/src/main/java/de/blau/android/util/UpdatedWebViewClient.java
@@ -1,5 +1,7 @@
 package de.blau.android.util;
 
+import java.io.ByteArrayInputStream;
+
 import android.annotation.TargetApi;
 import android.net.Uri;
 import android.os.Build;
@@ -10,6 +12,7 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import de.blau.android.contract.MimeTypes;
 
 /**
  * Class to handle some of the deprecations in Androids WebViewClient
@@ -18,7 +21,7 @@ import androidx.annotation.Nullable;
  *
  */
 public abstract class UpdatedWebViewClient extends WebViewClient {
-
+ 
     @SuppressWarnings("deprecation")
     @Override
     public boolean shouldOverrideUrlLoading(WebView view, String url) { // nOSONAR
@@ -64,6 +67,15 @@ public abstract class UpdatedWebViewClient extends WebViewClient {
     @Nullable
     protected WebResourceResponse handleIntercept(WebView view, Uri uri) { // NOSONAR
         return null;
+    }
+
+    /**
+     * Create and return an empty WebResourceResponse
+     * 
+     * @return an empty response
+     */
+    protected WebResourceResponse emptyResponse() {
+        return new WebResourceResponse(MimeTypes.TEXTPLAIN, "utf-8", new ByteArrayInputStream("".getBytes()));
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/res/menu-v24/main_menu_nosubmenus.xml
+++ b/src/main/res/menu-v24/main_menu_nosubmenus.xml
@@ -189,6 +189,9 @@
                 app:showAsAction="never"
                 android:title="@string/tag_menu_reset_address_prediction" />
             <item
+                android:id="@+id/menu_tools_signup"
+                android:title="@string/menu_tools_signup" />
+            <item
                 android:id="@+id/menu_tools_oauth_reset"
                 android:title="@string/menu_tools_oauth_reset" />
             <item

--- a/src/main/res/menu/main_menu.xml
+++ b/src/main/res/menu/main_menu.xml
@@ -198,6 +198,9 @@
                 app:showAsAction="never"
                 android:title="@string/tag_menu_reset_address_prediction" />
             <item
+                android:id="@+id/menu_tools_signup"
+                android:title="@string/menu_tools_signup" />
+            <item
                 android:id="@+id/menu_tools_oauth_reset"
                 android:title="@string/menu_tools_oauth_reset" />
             <item

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -102,6 +102,7 @@
     <string name="progress_query_oam">Querying OAM…</string>
     <string name="progress_pruning">Pruning…</string>
     <string name="progress_migration">Migrating…</string>
+    <string name="progress_website">Loading website…</string>
     <!-- Confirm upload dialog -->
     <string name="changes_deleted">"%1$s" deleted</string>
     <string name="changes_changed">"%1$s" changed</string>
@@ -1036,9 +1037,10 @@
     <string name="wms_hint">%1$s [wms]</string>
     <!--  -->
     <string name="menu_tools_apply_local_offset">Apply stored offset to imagery</string>
-    <string name="menu_tools_background_contrast">Contrast</string>
-    <string name="menu_tools_oauth_reset">Reset OAuth</string>
-    <string name="menu_tools_oauth_authorisation">Authorise OAuth</string>
+    <string name="menu_tools_background_contrast">Contrast…</string>
+    <string name="menu_tools_oauth_reset">Reset authorisation (OAuth 1/2)</string>
+    <string name="menu_tools_oauth_authorisation">Authorise app (OAuth 1/2)…</string>
+    <string name="menu_tools_signup">Create OSM account…</string>
     <string name="menu_enable_tagfilter">Tag filter</string>
     <string name="menu_enable_presetfilter">Preset filter</string>
     <string name="preset_menu_waynodes">Include way nodes</string>


### PR DESCRIPTION
This starts the signup process in a webview and then captures the link from the confirmation e-mail to open it in the app. Pressing the "Start mapping" button then terminates the webview and leaves the user in Vespucci.

Would fix https://github.com/MarcusWolschon/osmeditor4android/issues/1506 if merged, but that wont happen in a month of Sundays for obvious reasons.

If the world stood still and it is merged. it would need, besides a test, a bit more refinement, for example immediately authorizing the app via OAuth 2 and then returning to the app.