### PR TITLE
Improve how we handle closed ways with indication that they are areas

### DIFF
--- a/documentation/docs/tutorials/data_styling.md
+++ b/documentation/docs/tutorials/data_styling.md
@@ -31,7 +31,7 @@ Node styling is limited to the __labelKey__ and __iconPath__ attributes.
 |                           | type           |         | "way", "node" or "relation" to match the corresponding OSM elements, or a name
 |                           | tags           |         | Tags to use for matching, ignored for named styles, in the format _key_=_value_ or _key_=_*_ for any value. Multiple tags can be added using __&vert;__ as a separator.
 |                           | closed         |         | If not present will match all ways, if present will match closed ways if true, or if false open ways, ignored for relations
-|                           | area           |         | Use area semantics for rendering if true
+|                           | area           |         | Use area semantics for rendering if true, note that this will also effect preset matching
 |                           | dontrender     |         | Don't render the matching element
 |                           | updateWidth    |         | Dynamically update the way width on zoom changes if true
 |                           | widthFactor    |         | Determine a way width relative to the extent of the current map shown, ignored if updateWidth is false

--- a/documentation/docs/tutorials/presets.md
+++ b/documentation/docs/tutorials/presets.md
@@ -37,7 +37,7 @@ Note: this is loosely based on what [JOSM claims](https://josm.openstreetmap.de/
 |                   | name                          | supported | required
 |                   | name_context                  | supported |
 |                   | icon                          | supported | you really should add one for Vespucci
-|                   | type                          | supported |
+|                   | type                          | supported | extension: "area" is supported as a replacement for "multipolygon" and matches closed ways with an area=yes tag besides multipolygons
 |                   | name_template                 | supported | if set will always be used 
 |                   | name_template_filter          | ignored   |
 |                   | preset_name_label             | ignored   |

--- a/src/main/assets/styles/Color-round-no-mp.xml
+++ b/src/main/assets/styles/Color-round-no-mp.xml
@@ -89,7 +89,7 @@
     
     <feature type="way" tags="leisure=pitch" updateWidth="true" widthFactor="1.0" color="8839AC39" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
     <feature type="way" tags="leisure=swimming_pool" updateWidth="true" widthFactor="1.0" color="880000ff" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />    
-    <feature type="way" tags="leisure=playground" area="true" updateWidth="true" widthFactor="0.8" color="88f4a460" style="STROKE" cap="BUTT" join="MITER" offset="0.50"/>
+    <feature type="way" tags="leisure=playground" area="true" updateWidth="true" widthFactor="1.0" color="88f4a460" style="STROKE" cap="BUTT" join="MITER" offset="0.50"/>
     <feature type="way" tags="leisure=garden" updateWidth="true" widthFactor="1.0" color="882d6e3a" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
     <feature type="way" tags="leisure=park" updateWidth="true" area="true" widthFactor="2.0" minVisibleZoom="10" color="88DFFCE2" style="STROKE" cap="BUTT" join="BEVEL" offset="0.50"/>
 
@@ -228,7 +228,9 @@
     <feature type="way" tags="highway" updateWidth="true" widthFactor="1.0" color="88888888" style="STROKE" cap="BUTT" join="MITER" arrowStyle="oneway_direction" labelZoomLimit="20" >
         <feature type="way" tags="highway=construction" widthFactor="1.0" color="88888888" />
         <feature type="way" tags="highway=proposed" widthFactor="1.0" color="88888888" />
-        <feature type="way" tags="highway=pedestrian" widthFactor="0.8" color="ff888888" />
+        <feature type="way" tags="highway=pedestrian" widthFactor="0.8" color="ff888888" >
+            <feature type="way" tags="area=yes" area="yes" widthFactor="1.0" offset="0.50"/>
+        </feature>
         <feature type="way" tags="highway=path|surface=asphalt" widthFactor="0.6" color="ffc69c49" >
             <feature type="way" tags="bridge=yes" casingStyle="minor_ways_bridge_casing" />
         </feature>

--- a/src/main/assets/styles/Color-round.xml
+++ b/src/main/assets/styles/Color-round.xml
@@ -89,7 +89,7 @@
     
     <feature type="way" tags="leisure=pitch" updateWidth="true" widthFactor="1.0" color="8839AC39" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
     <feature type="way" tags="leisure=swimming_pool" updateWidth="true" widthFactor="1.0" color="880000ff" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />    
-    <feature type="way" tags="leisure=playground" area="true" updateWidth="true" widthFactor="0.8" color="88f4a460" style="STROKE" cap="BUTT" join="MITER" offset="0.50"/>
+    <feature type="way" tags="leisure=playground" area="true" updateWidth="true" widthFactor="1.0" color="88f4a460" style="STROKE" cap="BUTT" join="MITER" offset="0.50"/>
     <feature type="way" tags="leisure=garden" updateWidth="true" widthFactor="1.0" color="882d6e3a" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
     <feature type="way" tags="leisure=park" updateWidth="true" area="true" widthFactor="2.0" minVisibleZoom="10" color="88DFFCE2" style="STROKE" cap="BUTT" join="BEVEL" offset="0.50"/>
 
@@ -228,7 +228,9 @@
     <feature type="way" tags="highway" updateWidth="true" widthFactor="1.0" color="88888888" style="STROKE" cap="BUTT" join="MITER" arrowStyle="oneway_direction" labelZoomLimit="20" >
         <feature type="way" tags="highway=construction" widthFactor="1.0" color="88888888" />
         <feature type="way" tags="highway=proposed" widthFactor="1.0" color="88888888" />
-        <feature type="way" tags="highway=pedestrian" widthFactor="0.8" color="ff888888" />
+        <feature type="way" tags="highway=pedestrian" widthFactor="0.8" color="ff888888" >
+            <feature type="way" tags="area=yes" area="yes" widthFactor="1.0" offset="0.50"/>
+        </feature>
         <feature type="way" tags="highway=path|surface=asphalt" widthFactor="0.6" color="ffc69c49" >
             <feature type="way" tags="bridge=yes" casingStyle="minor_ways_bridge_casing" />
         </feature>
@@ -435,11 +437,13 @@
     <feature type="relation" tags="boundary" dontrender="true" />
     <feature type="relation" tags="type=multipolygon" updateWidth="true" widthFactor="0.8" color="88222222" style="STROKE" cap="BUTT" join="MITER" offset="0.50">
         <feature type="relation" tags="building" widthFactor="1.0" color="ffcc9999"/>
-        <feature type="relation" tags="leisure=playground" widthFactor="0.8" color="88f4a460" style="FILL_AND_STROKE" />
+        <feature type="relation" tags="leisure=playground" widthFactor="1.0" color="88f4a460" style="FILL_AND_STROKE" />
         <feature type="relation" tags="leisure=pitch" updateWidth="true" widthFactor="1.0" color="8839AC39" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
         <feature type="relation" tags="leisure=swimming_pool" updateWidth="true" widthFactor="1.0" color="880000ff" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
         <feature type="relation" tags="leisure=garden" updateWidth="true" widthFactor="1.0" color="882d6e3a" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />    
         <feature type="relation" tags="leisure=park" updateWidth="true" widthFactor="2.0" minVisibleZoom="10" color="88DFFCE2" style="STROKE" cap="BUTT" join="BEVEL"/>
+
+        <feature type="relation" tags="highway=pedestrian" widthFactor="1.0" color="ff888888" offset="0.50"/>
 
         <feature type="relation" tags="natural" color="ff71BE80" >
             <feature type="relation" tags="natural=water" widthFactor="1.0" minVisibleZoom="10" color="ff0000ff" />

--- a/src/main/assets/styles/No-path-patterns.xml
+++ b/src/main/assets/styles/No-path-patterns.xml
@@ -89,7 +89,7 @@
     
     <feature type="way" tags="leisure=pitch" updateWidth="true" widthFactor="1.0" color="8839AC39" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
     <feature type="way" tags="leisure=swimming_pool" updateWidth="true" widthFactor="1.0" color="880000ff" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />    
-    <feature type="way" tags="leisure=playground" area="true" updateWidth="true" widthFactor="0.8" color="88f4a460" style="STROKE" cap="BUTT" join="MITER" offset="0.50"/>
+    <feature type="way" tags="leisure=playground" area="true" updateWidth="true" widthFactor="1.0" color="88f4a460" style="STROKE" cap="BUTT" join="MITER" offset="0.50"/>
     <feature type="way" tags="leisure=garden" updateWidth="true" widthFactor="1.0" color="882d6e3a" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
     <feature type="way" tags="leisure=park" updateWidth="true" area="true" widthFactor="2.0" minVisibleZoom="10" color="88DFFCE2" style="STROKE" cap="BUTT" join="BEVEL" offset="0.50"/>
 
@@ -228,7 +228,9 @@
     <feature type="way" tags="highway" updateWidth="true" widthFactor="1.0" color="88888888" style="STROKE" cap="BUTT" join="MITER" arrowStyle="oneway_direction" labelZoomLimit="20" >
         <feature type="way" tags="highway=construction" widthFactor="1.0" color="88888888" />
         <feature type="way" tags="highway=proposed" widthFactor="1.0" color="88888888" />
-        <feature type="way" tags="highway=pedestrian" widthFactor="0.8" color="ff888888" />
+        <feature type="way" tags="highway=pedestrian" widthFactor="0.8" color="ff888888" >
+            <feature type="way" tags="area=yes" area="yes" widthFactor="1.0" offset="0.50"/>
+        </feature>
         <feature type="way" tags="highway=path|surface=asphalt" widthFactor="0.6" color="ffc69c49" >
             <feature type="way" tags="bridge=yes" casingStyle="minor_ways_bridge_casing" />
         </feature>
@@ -435,11 +437,13 @@
     <feature type="relation" tags="boundary" dontrender="true" />
     <feature type="relation" tags="type=multipolygon" updateWidth="true" widthFactor="0.8" color="88222222" style="STROKE" cap="BUTT" join="MITER" offset="0.50">
         <feature type="relation" tags="building" widthFactor="1.0" color="ffcc9999"/>
-        <feature type="relation" tags="leisure=playground" widthFactor="0.8" color="88f4a460" style="FILL_AND_STROKE" />
+        <feature type="relation" tags="leisure=playground" widthFactor="1.0" color="88f4a460" style="FILL_AND_STROKE" />
         <feature type="relation" tags="leisure=pitch" updateWidth="true" widthFactor="1.0" color="8839AC39" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
         <feature type="relation" tags="leisure=swimming_pool" updateWidth="true" widthFactor="1.0" color="880000ff" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
         <feature type="relation" tags="leisure=garden" updateWidth="true" widthFactor="1.0" color="882d6e3a" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />    
         <feature type="relation" tags="leisure=park" updateWidth="true" widthFactor="2.0" minVisibleZoom="10" color="88DFFCE2" style="STROKE" cap="BUTT" join="BEVEL"/>
+
+        <feature type="relation" tags="highway=pedestrian" widthFactor="1.0" color="ff888888" offset="0.50"/>
 
         <feature type="relation" tags="natural" color="ff71BE80" >
             <feature type="relation" tags="natural=water" widthFactor="1.0" minVisibleZoom="10" color="ff0000ff" />

--- a/src/main/assets/styles/Pen-round.xml
+++ b/src/main/assets/styles/Pen-round.xml
@@ -89,7 +89,7 @@
     
     <feature type="way" tags="leisure=pitch" updateWidth="true" widthFactor="1.0" color="8839AC39" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
     <feature type="way" tags="leisure=swimming_pool" updateWidth="true" widthFactor="1.0" color="880000ff" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />    
-    <feature type="way" tags="leisure=playground" area="true" updateWidth="true" widthFactor="0.8" color="88f4a460" style="STROKE" cap="BUTT" join="MITER" offset="0.50"/>
+    <feature type="way" tags="leisure=playground" area="true" updateWidth="true" widthFactor="1.0" color="88f4a460" style="STROKE" cap="BUTT" join="MITER" offset="0.50"/>
     <feature type="way" tags="leisure=garden" updateWidth="true" widthFactor="1.0" color="882d6e3a" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
     <feature type="way" tags="leisure=park" updateWidth="true" area="true" widthFactor="2.0" minVisibleZoom="10" color="88DFFCE2" style="STROKE" cap="BUTT" join="BEVEL" offset="0.50"/>
 
@@ -228,7 +228,9 @@
     <feature type="way" tags="highway" updateWidth="true" widthFactor="1.0" color="88888888" style="STROKE" cap="BUTT" join="MITER" arrowStyle="oneway_direction" labelZoomLimit="20" >
         <feature type="way" tags="highway=construction" widthFactor="1.0" color="88888888" />
         <feature type="way" tags="highway=proposed" widthFactor="1.0" color="88888888" />
-        <feature type="way" tags="highway=pedestrian" widthFactor="0.8" color="ff888888" />
+        <feature type="way" tags="highway=pedestrian" widthFactor="0.8" color="ff888888" >
+            <feature type="way" tags="area=yes" area="yes" widthFactor="1.0" offset="0.50"/>
+        </feature>
         <feature type="way" tags="highway=path|surface=asphalt" widthFactor="0.6" color="ffc69c49" >
             <feature type="way" tags="bridge=yes" casingStyle="minor_ways_bridge_casing" />
         </feature>
@@ -435,11 +437,13 @@
     <feature type="relation" tags="boundary" dontrender="true" />
     <feature type="relation" tags="type=multipolygon" updateWidth="true" widthFactor="0.8" color="88222222" style="STROKE" cap="BUTT" join="MITER" offset="0.50">
         <feature type="relation" tags="building" widthFactor="1.0" color="ffcc9999"/>
-        <feature type="relation" tags="leisure=playground" widthFactor="0.8" color="88f4a460" style="FILL_AND_STROKE" />
+        <feature type="relation" tags="leisure=playground" widthFactor="1.0" color="88f4a460" style="FILL_AND_STROKE" />
         <feature type="relation" tags="leisure=pitch" updateWidth="true" widthFactor="1.0" color="8839AC39" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
         <feature type="relation" tags="leisure=swimming_pool" updateWidth="true" widthFactor="1.0" color="880000ff" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />
         <feature type="relation" tags="leisure=garden" updateWidth="true" widthFactor="1.0" color="882d6e3a" style="FILL_AND_STROKE" cap="BUTT" join="MITER" />    
         <feature type="relation" tags="leisure=park" updateWidth="true" widthFactor="2.0" minVisibleZoom="10" color="88DFFCE2" style="STROKE" cap="BUTT" join="BEVEL"/>
+
+        <feature type="relation" tags="highway=pedestrian" widthFactor="1.0" color="ff888888" offset="0.50"/>
 
         <feature type="relation" tags="natural" color="ff71BE80" >
             <feature type="relation" tags="natural=water" widthFactor="1.0" minVisibleZoom="10" color="ff0000ff" />

--- a/src/main/java/de/blau/android/osm/OsmElement.java
+++ b/src/main/java/de/blau/android/osm/OsmElement.java
@@ -34,7 +34,7 @@ public abstract class OsmElement implements Serializable, XmlSerializable, JosmX
     /**
      * 
      */
-    private static final long serialVersionUID = 7711945069147743674L;
+    private static final long serialVersionUID = 7711945069147743675L;
 
     public static final long NEW_OSM_ID = -1;
 
@@ -59,15 +59,15 @@ public abstract class OsmElement implements Serializable, XmlSerializable, JosmX
 
     public static final long EPOCH = 1104537600L; // 2005-01-01 00:00:00
 
-    long osmId;
+    protected long osmId;
 
-    long osmVersion;
+    protected long osmVersion;
 
-    TreeMap<String, String> tags;
+    protected TreeMap<String, String> tags;
 
-    byte state;
+    protected byte state;
 
-    private ArrayList<Relation> parentRelations;
+    private List<Relation> parentRelations;
 
     // seconds since EPOCH, negative == not set, using an int here limits dates up to 2073
     private int timestamp = -1;

--- a/src/main/java/de/blau/android/osm/OsmXml.java
+++ b/src/main/java/de/blau/android/osm/OsmXml.java
@@ -92,7 +92,7 @@ public final class OsmXml {
         List<Relation> deletedRelations = new ArrayList<>();
 
         for (Node elem : storage.getNodes()) {
-            Log.d(DEBUG_TAG, "node added to list for upload, id " + elem.osmId);
+            Log.d(DEBUG_TAG, "node added to list for upload, id " + elem.getOsmId());
             switch (elem.state) {
             case OsmElement.STATE_CREATED:
                 createdNodes.add(elem);
@@ -232,7 +232,7 @@ public final class OsmXml {
      * @param elem the OsmElement
      */
     private static void logNotModified(@NonNull OsmElement elem) {
-        Log.d(DEBUG_TAG, elem.getName() + " id " + elem.osmId + " not modified");
+        Log.d(DEBUG_TAG, elem.getName() + " id " + elem.getOsmId() + " not modified");
     }
 
     /**

--- a/src/main/java/de/blau/android/osm/StorageDelegator.java
+++ b/src/main/java/de/blau/android/osm/StorageDelegator.java
@@ -59,7 +59,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
 
     private static final String DEBUG_TAG = StorageDelegator.class.getSimpleName();
 
-    private static final long serialVersionUID = 10L;
+    private static final long serialVersionUID = 11L;
 
     public static final int MIN_NODES_CIRCLE = 3;
 
@@ -71,7 +71,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
 
     private ClipboardStorage clipboard;
 
-    private ArrayList<String> imagery;
+    private List<String> imagery;
 
     /**
      * when reading state lockout writing/reading
@@ -380,8 +380,8 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
      */
     private void invalidateWay(@NonNull Way w) {
         w.invalidateBoundingBox();
-        if (w.hasTagKey(Tags.KEY_HIGHWAY)) {
-            // we only validate way connections for highways currently
+        if (w.hasTagKey(Tags.KEY_HIGHWAY) || w.hasTagKey(Tags.KEY_WATERWAY)) {
+            // we only validate way connections for highway and waterway elements currently
             w.resetHasProblem();
         }
     }

--- a/src/main/java/de/blau/android/osm/Tags.java
+++ b/src/main/java/de/blau/android/osm/Tags.java
@@ -270,6 +270,8 @@ public final class Tags {
     public static final char   VALUE_SOUTH   = 'S';
     public static final char   VALUE_NORTH   = 'N';
 
+    public static final String KEY_AREA = "area";
+
     public static final String KEY_CONVEYING = "conveying";
     public static final String KEY_PRIORITY  = "priority";
 

--- a/src/main/java/de/blau/android/osm/UndoStorage.java
+++ b/src/main/java/de/blau/android/osm/UndoStorage.java
@@ -627,10 +627,10 @@ public class UndoStorage implements Serializable {
 
             element = originalElement;
 
-            osmId = originalElement.osmId;
-            osmVersion = originalElement.osmVersion;
-            state = originalElement.state;
-            tags = originalElement.tags == null ? new TreeMap<>() : new TreeMap<>(originalElement.tags);
+            osmId = originalElement.getOsmId();
+            osmVersion = originalElement.getOsmVersion();
+            state = originalElement.getState();
+            tags = originalElement.getTags().isEmpty() ? new TreeMap<>() : new TreeMap<>(originalElement.getTags());
 
             parentRelations = element.getParentRelations() != null ? new ArrayList<>(element.getParentRelations()) : null;
         }
@@ -664,9 +664,9 @@ public class UndoStorage implements Serializable {
             }
 
             // restore saved values
-            restored.osmId = osmId;
-            restored.osmVersion = osmVersion;
-            restored.state = state;
+            restored.setOsmId(osmId);
+            restored.setOsmVersion(osmVersion);
+            restored.setState(state);
             restored.setTags(tags);
 
             // zap error state


### PR DESCRIPTION
This make the handling of area=yes tags on objects and the similar hint derived from data styling more consistent and documents the later.

Improves highway=pedestrian styling (as an example of how this can be used).

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/2481

Note that these changes make the saved data state incompatible with previous versions.