### PR TITLE
Use common maven alias. Remove duplicate.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,7 @@ buildscript {
     repositories {
         mavenCentral()
         google()
-        maven {
-            url = uri("https://plugins.gradle.org/m2/")
-        }
+        gradlePluginPortal()
         mavenLocal()
     }
     dependencies {
@@ -50,10 +48,9 @@ apply plugin: 'com.malinskiy.marathon'
 allprojects {
     repositories {
         mavenCentral()
-        maven { url "https://maven.google.com" }
+        google()
         maven { url "https://jitpack.io" }
         mavenLocal()
-        google()
         jcenter()
     }
 }


### PR DESCRIPTION
- Wrt. `gradlePluginPortal()` see: `org.gradle.api.internal.artifacts.BaseRepositoryFactory#PLUGIN_PORTAL_DEFAULT_URL`.
- Wrt. `google()` see: `org.gradle.api.artifacts.ArtifactRepositoryContainer#GOOGLE_URL`.
- You can remove `jcenter()` as well - the service is no longer available.