### PR TITLE
Fix issue with JOSM filter language child and parent expressions

### DIFF
--- a/src/main/java/de/blau/android/search/Wrapper.java
+++ b/src/main/java/de/blau/android/search/Wrapper.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.NotNull;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import ch.poole.osm.josmfilterparser.Condition;
 import ch.poole.osm.josmfilterparser.ElementState.State;
 import ch.poole.osm.josmfilterparser.Meta;
@@ -61,8 +62,18 @@ public class Wrapper implements Meta {
     /**
      * @param element the element to set
      */
-    public void setElement(OsmElement element) {
+    public void setElement(@NonNull OsmElement element) {
         this.element = element;
+    }
+
+    /**
+     * Get the current element
+     * 
+     * @return the current element
+     */
+    @Nullable
+    public OsmElement getElement() {
+        return element;
     }
 
     @Override
@@ -413,27 +424,28 @@ public class Wrapper implements Meta {
      * @return a SearchResult object
      */
     SearchResult getMatchingElementsInternal(@NonNull Condition c) {
+        OsmElement savedElement = element; // save this instead of instantating a new wrapper
         StorageDelegator delegator = App.getDelegator();
         SearchResult result = new SearchResult();
-
         for (Node n : delegator.getCurrentStorage().getNodes()) {
-            setElement(n);
+            element = n;
             if (c.eval(Type.NODE, this, n.getTags())) {
                 result.nodes.add(n);
             }
         }
         for (Way w : delegator.getCurrentStorage().getWays()) {
-            setElement(w);
+            element = w;
             if (c.eval(Type.WAY, this, w.getTags())) {
                 result.ways.add(w);
             }
         }
         for (Relation r : delegator.getCurrentStorage().getRelations()) {
-            setElement(r);
+            element = r;
             if (c.eval(Type.RELATION, this, r.getTags())) {
                 result.relations.add(r);
             }
         }
+        element = savedElement;
         return result;
     }
 

--- a/src/test/java/de/blau/android/search/WrapperTest.java
+++ b/src/test/java/de/blau/android/search/WrapperTest.java
@@ -3,7 +3,6 @@ package de.blau.android.search;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -408,6 +407,7 @@ public class WrapperTest {
         assertNotNull(way);
         wrapper.setElement(way);
         assertTrue(wrapper.isParent(Type.NODE, wrapper, Util.wrapInList(node)));
+
         Way way2 = (Way) delegator.getOsmElement(Way.NAME, 111762730L);
         assertNotNull(way2);
         wrapper.setElement(way2);
@@ -425,8 +425,12 @@ public class WrapperTest {
      */
     @Test
     public void getMatchingElementsTest() {
+        Way way = (Way) delegator.getOsmElement(Way.NAME, 111762730L);
+        assertNotNull(way);
+        wrapper.setElement(way);
         List<Object> objects = wrapper.getMatchingElements(new Version(8));
         assertEquals(441, objects.size());
+        assertEquals(way, wrapper.getElement());
     }
 
     /**


### PR DESCRIPTION
The wrapper that contains the implementation specific methods would overwrite the element that the matching was actually being performed on and not restore it.