### PR TITLE
Inherit crs srs support crs84

### DIFF
--- a/src/main/java/de/blau/android/resources/TileLayerSource.java
+++ b/src/main/java/de/blau/android/resources/TileLayerSource.java
@@ -1919,7 +1919,7 @@ public class TileLayerSource implements Serializable {
         return builder.append(a).append(',').append(b).append(',').append(c).append(',').append(d).toString();
     }
 
-    private static final Pattern PROJ_IN_URL = Pattern.compile("[\\?\\&][sc]rs=(EPSG:[0-9]+)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern PROJ_IN_URL = Pattern.compile("[\\?\\&][sc]rs=((?:EPSG|CRS):[0-9]+)", Pattern.CASE_INSENSITIVE);
 
     /**
      * Extract the proj parameter from a WMS url

--- a/src/test/resources/wms_capabilities_1.1.1.xml
+++ b/src/test/resources/wms_capabilities_1.1.1.xml
@@ -1164,8 +1164,9 @@
         <Name>50</Name>
         <Title><![CDATA[Aguas Continentales - ACO INTERMITENTE]]></Title>
         <Abstract><![CDATA[]]></Abstract>
-<SRS>EPSG:4326</SRS>
-<SRS>EPSG:3857</SRS>
+<!--  just use inherited values -->
+<!-- <SRS>EPSG:4326</SRS> -->
+<!-- <SRS>EPSG:3857</SRS> -->
  <!-- alias 3857 -->
 <SRS>EPSG:102100</SRS>
 <SRS>EPSG:54043</SRS>


### PR DESCRIPTION
Support CRS:84 for wms endpoints and inherit CRS/SRS values, and support CRS values when extracting the projection from URLs.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/2508
