### PR TITLE
Create drop-down for Resurvey Validation key-value pairs and include checkbox

### DIFF
--- a/src/androidTest/java/de/blau/android/validation/ValidatorRulesUITest.java
+++ b/src/androidTest/java/de/blau/android/validation/ValidatorRulesUITest.java
@@ -1,0 +1,115 @@
+package de.blau.android.validation;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import android.app.Instrumentation;
+import android.content.Context;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.uiautomator.UiDevice;
+
+import de.blau.android.Main;
+import de.blau.android.R;
+import de.blau.android.prefs.PrefEditorFragment;
+import de.blau.android.prefs.Preferences;
+import de.blau.android.validation.ValidatorRulesUI;
+import de.blau.android.LayerUtils;
+import de.blau.android.TestUtils;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class ValidatorRulesUITest {
+
+    Context context = null;
+    Instrumentation.ActivityMonitor monitor = null;
+    Instrumentation instrumentation = null;
+    UiDevice device = null;
+    Main main = null;
+    ValidatorRulesUI validatorRulesUI;
+
+    @Rule
+    public ActivityTestRule<Main> mActivityRule = new ActivityTestRule<>(Main.class);
+
+    /**
+     * Pre-test setup
+     */
+    @Before
+    public void setup() {
+        instrumentation = InstrumentationRegistry.getInstrumentation();
+        device = UiDevice.getInstance(instrumentation);
+        context = instrumentation.getTargetContext();
+        monitor = instrumentation.addMonitor(ValidatorRulesUI.class.getName(), null, false);
+        main = mActivityRule.getActivity();
+        Preferences prefs = new Preferences(context);
+        LayerUtils.removeImageryLayers(context);
+
+        TestUtils.grantPermissons(device);
+        TestUtils.dismissStartUpDialogs(device, main);
+        TestUtils.stopEasyEdit(main);
+
+    }
+
+//    @After
+//    public void teardown(){ instrumentation.removeMonitor(monitor);}
+
+    @Test
+    public void addRuleset(){
+//        ValidatorRulesUI Vri = new ValidatorRulesUI();
+//        Vri.manageRulesetContents(context);
+//        TestUtils.clickText(device, false, "shop", true);
+    }
+}
+//    @Test
+//    public void testToggleHeaderCheckbox() {
+//        // Open the resurveyList and check the initial state
+//        Cursor resurveyCursor = ValidatorRulesDatabase.queryResurveyByName(writableDb, ValidatorRulesDatabase.DEFAULT_RULESET_NAME);
+//        ResurveyAdapter resurveyAdapter = new ResurveyAdapter(writableDb, context, resurveyCursor);
+//        resurveyList.setAdapter(resurveyAdapter);
+//        runUiThreadTasksIncludingDelayedTasks();
+//
+//
+//        // Click the header checkbox
+//        headerEnabled.performClick();
+//        headerEnabled.performClick();
+//        runUiThreadTasksIncludingDelayedTasks();
+//
+//        // Verify that all child checkboxes are checked
+//        assertFalse(headerEnabled.isChecked());
+//        for (int i = 0; i < resurveyList.getChildCount(); i++) {
+//        View childView = resurveyList.getChildAt(i);
+//        CheckBox childCheckBox = childView.findViewById(R.id.resurvey_enabled);
+//        assertFalse(childCheckBox.isChecked());
+//        }
+//
+//        // Click the "Done" button to save the changes
+//        // Assuming you have a method to get the "Done" button and click it
+//        clickDoneButton();
+//
+//        // Re-open the resurveyList
+//        resurveyCursor = ValidatorRulesDatabase.queryResurveyByName(writableDb, ValidatorRulesDatabase.DEFAULT_RULESET_NAME);
+//        resurveyAdapter = new ResurveyAdapter(writableDb, context, resurveyCursor);
+//        resurveyList.setAdapter(resurveyAdapter);
+//        runUiThreadTasksIncludingDelayedTasks();
+//
+//        // Verify that the changes are persisted
+//        assertFalse(headerEnabled.isChecked());
+//        for (int i = 0; i < resurveyList.getChildCount(); i++) {
+//        View childView = resurveyList.getChildAt(i);
+//        CheckBox childCheckBox = childView.findViewById(R.id.resurvey_enabled);
+//        assertFalse(childCheckBox.isChecked());
+//        }
+//        }
+//
+//// Helper method to click the "Done" button
+//private void clickDoneButton() {
+//        // Implement the logic to find and click the "Done" button
+//        // based on your application's UI structure
+//        }
+//}

--- a/src/main/java/de/blau/android/validation/ValidatorRulesDatabaseHelper.java
+++ b/src/main/java/de/blau/android/validation/ValidatorRulesDatabaseHelper.java
@@ -12,7 +12,7 @@ public class ValidatorRulesDatabaseHelper extends SQLiteOpenHelper {
     private static final String DEBUG_TAG = ValidatorRulesDatabaseHelper.class.getSimpleName().substring(0, Math.min(23, ValidatorRulesDatabaseHelper.class.getSimpleName().length()));
 
     private static final String DATABASE_NAME    = "validator_rules";
-    private static final int    DATABASE_VERSION = 3;
+    private static final int    DATABASE_VERSION = 4;
     static final int            ONE_YEAR         = 365;
 
     /**
@@ -31,18 +31,18 @@ public class ValidatorRulesDatabaseHelper extends SQLiteOpenHelper {
             ValidatorRulesDatabase.addRuleset(db, ValidatorRulesDatabase.DEFAULT_RULESET, ValidatorRulesDatabase.DEFAULT_RULESET_NAME);
 
             db.execSQL(
-                    "CREATE TABLE resurveytags (ruleset INTEGER, key TEXT, value TEXT DEFAULT NULL, is_regexp INTEGER DEFAULT 0, days INTEGER DEFAULT 365, FOREIGN KEY(ruleset) REFERENCES rulesets(id))");
-            ValidatorRulesDatabase.addResurvey(db, ValidatorRulesDatabase.DEFAULT_RULESET, Tags.KEY_SHOP, null, false, ONE_YEAR);
-            ValidatorRulesDatabase.addResurvey(db, ValidatorRulesDatabase.DEFAULT_RULESET, Tags.KEY_AMENITY, Tags.VALUE_RESTAURANT, false, ONE_YEAR);
-            ValidatorRulesDatabase.addResurvey(db, ValidatorRulesDatabase.DEFAULT_RULESET, Tags.KEY_AMENITY, Tags.VALUE_FAST_FOOD, false, ONE_YEAR);
-            ValidatorRulesDatabase.addResurvey(db, ValidatorRulesDatabase.DEFAULT_RULESET, Tags.KEY_AMENITY, Tags.VALUE_CAFE, false, ONE_YEAR);
-            ValidatorRulesDatabase.addResurvey(db, ValidatorRulesDatabase.DEFAULT_RULESET, Tags.KEY_AMENITY, Tags.VALUE_PUB, false, ONE_YEAR);
-            ValidatorRulesDatabase.addResurvey(db, ValidatorRulesDatabase.DEFAULT_RULESET, Tags.KEY_AMENITY, Tags.VALUE_BAR, false, ONE_YEAR);
-            ValidatorRulesDatabase.addResurvey(db, ValidatorRulesDatabase.DEFAULT_RULESET, Tags.KEY_AMENITY, Tags.VALUE_TOILETS, false, ONE_YEAR);
-            ValidatorRulesDatabase.addResurvey(db, ValidatorRulesDatabase.DEFAULT_RULESET, Tags.KEY_LANDUSE, Tags.VALUE_CONSTRUCTION, false, ONE_YEAR);
-            ValidatorRulesDatabase.addResurvey(db, ValidatorRulesDatabase.DEFAULT_RULESET, Tags.KEY_HIGHWAY, Tags.VALUE_CONSTRUCTION, false, ONE_YEAR);
-            ValidatorRulesDatabase.addResurvey(db, ValidatorRulesDatabase.DEFAULT_RULESET, Tags.KEY_RAILWAY, Tags.VALUE_CONSTRUCTION, false, ONE_YEAR);
-            ValidatorRulesDatabase.addResurvey(db, ValidatorRulesDatabase.DEFAULT_RULESET, Tags.KEY_BUILDING, Tags.VALUE_CONSTRUCTION, false, ONE_YEAR);
+                    "CREATE TABLE resurveytags (ruleset INTEGER, key TEXT, value TEXT DEFAULT NULL, is_regexp INTEGER DEFAULT 0, days INTEGER DEFAULT 365, enabled INTEGER DEFAULT 1, FOREIGN KEY(ruleset) REFERENCES rulesets(id))");
+            ValidatorRulesDatabase.addResurvey(db, ValidatorRulesDatabase.DEFAULT_RULESET, Tags.KEY_SHOP, null, false, ONE_YEAR, true);
+            ValidatorRulesDatabase.addResurvey(db, ValidatorRulesDatabase.DEFAULT_RULESET, Tags.KEY_AMENITY, Tags.VALUE_RESTAURANT, false, ONE_YEAR, true);
+            ValidatorRulesDatabase.addResurvey(db, ValidatorRulesDatabase.DEFAULT_RULESET, Tags.KEY_AMENITY, Tags.VALUE_FAST_FOOD, false, ONE_YEAR, true);
+            ValidatorRulesDatabase.addResurvey(db, ValidatorRulesDatabase.DEFAULT_RULESET, Tags.KEY_AMENITY, Tags.VALUE_CAFE, false, ONE_YEAR, true);
+            ValidatorRulesDatabase.addResurvey(db, ValidatorRulesDatabase.DEFAULT_RULESET, Tags.KEY_AMENITY, Tags.VALUE_PUB, false, ONE_YEAR, true);
+            ValidatorRulesDatabase.addResurvey(db, ValidatorRulesDatabase.DEFAULT_RULESET, Tags.KEY_AMENITY, Tags.VALUE_BAR, false, ONE_YEAR, true);
+            ValidatorRulesDatabase.addResurvey(db, ValidatorRulesDatabase.DEFAULT_RULESET, Tags.KEY_AMENITY, Tags.VALUE_TOILETS, false, ONE_YEAR, true);
+            ValidatorRulesDatabase.addResurvey(db, ValidatorRulesDatabase.DEFAULT_RULESET, Tags.KEY_LANDUSE, Tags.VALUE_CONSTRUCTION, false, ONE_YEAR, true);
+            ValidatorRulesDatabase.addResurvey(db, ValidatorRulesDatabase.DEFAULT_RULESET, Tags.KEY_HIGHWAY, Tags.VALUE_CONSTRUCTION, false, ONE_YEAR, true);
+            ValidatorRulesDatabase.addResurvey(db, ValidatorRulesDatabase.DEFAULT_RULESET, Tags.KEY_RAILWAY, Tags.VALUE_CONSTRUCTION, false, ONE_YEAR, true);
+            ValidatorRulesDatabase.addResurvey(db, ValidatorRulesDatabase.DEFAULT_RULESET, Tags.KEY_BUILDING, Tags.VALUE_CONSTRUCTION, false, ONE_YEAR, true);
 
             db.execSQL("CREATE TABLE checktags (ruleset INTEGER, key TEXT, optional INTEGER DEFAULT 0, FOREIGN KEY(ruleset) REFERENCES rulesets(id))");
             ValidatorRulesDatabase.addCheck(db, ValidatorRulesDatabase.DEFAULT_RULESET, Tags.KEY_OPENING_HOURS, false);
@@ -61,6 +61,9 @@ public class ValidatorRulesDatabaseHelper extends SQLiteOpenHelper {
         }
         if (oldVersion <= 2 && newVersion >= 3) {
             db.execSQL("UPDATE checktags SET key='name|ref' WHERE key='name'");
+        }
+        if (oldVersion <= 3 && newVersion >= 4) {
+            db.execSQL("ALTER TABLE resurveytags ADD COLUMN enabled INTEGER DEFAULT 1");
         }
     }
 }

--- a/src/main/res/layout/validator_ruleset_list.xml
+++ b/src/main/res/layout/validator_ruleset_list.xml
@@ -32,6 +32,14 @@
                 android:layout_marginTop="5dp"
                 android:layout_marginBottom="1dp"
                 android:orientation="horizontal">
+                <CheckBox
+                    android:id="@+id/header_enabled"
+                    android:layout_width="27dp"
+                    android:layout_height="27dp"
+                    android:layout_marginEnd="1dp"
+                    android:layout_marginBottom="1dp"
+                    android:saveEnabled="false"
+                    android:text=""/>
                 <TextView
                     android:id="@+id/key_title"
                     android:layout_width="0dp"

--- a/src/main/res/layout/validator_ruleset_list_resurvey_item.xml
+++ b/src/main/res/layout/validator_ruleset_list_resurvey_item.xml
@@ -10,6 +10,14 @@
     	android:layout_marginTop="5dp"
     	android:layout_marginBottom="1dp" 
     	android:orientation="horizontal" >
+	   <CheckBox
+		   android:id="@+id/resurvey_enabled"
+		   android:layout_width="27dp"
+		   android:layout_height="fill_parent"
+		   android:layout_marginBottom="1dp"
+		   android:paddingRight="5dp"
+		   android:saveEnabled="false"
+		   android:text=""/>
 		<TextView
         	android:id="@+id/key"
     	    android:layout_width="0dp"

--- a/src/main/res/layout/validator_ruleset_resurvey_item.xml
+++ b/src/main/res/layout/validator_ruleset_resurvey_item.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android" xmlns:numberpicker="http://schemas.android.com/apk/res-auto"
+	xmlns:tools="http://schemas.android.com/tools"
 	android:layout_width="fill_parent"
 	android:layout_height="wrap_content" 
 	android:paddingTop="?attr/dialogPreferredPadding">
@@ -14,17 +15,21 @@
 		android:layout_alignParentTop="true"
 		android:textAppearance="?android:attr/textAppearanceMedium" 
 		android:text="@string/Key"/>
-		
-	<EditText 
+
+	<AutoCompleteTextView
 		android:id="@+id/resurvey_key"
 		android:layout_width="fill_parent" 
 		android:layout_height="wrap_content"
-		android:layout_marginRight="?attr/dialogPreferredPadding"
-        android:layout_marginEnd="?attr/dialogPreferredPadding"
 		android:layout_below="@id/resurvey_key_legend"
+		android:layout_alignStart="@id/resurvey_key_legend"
 		android:layout_alignLeft="@id/resurvey_key_legend"
-        android:layout_alignStart="@id/resurvey_key_legend"
-		android:textAppearance="?android:attr/textAppearanceMedium" />
+		android:layout_marginEnd="?attr/dialogPreferredPadding"
+		android:layout_marginRight="?attr/dialogPreferredPadding"
+		android:completionThreshold="1"
+		android:dropDownWidth="wrap_content"
+		android:dropDownHeight="300dp"
+		android:inputType="textNoSuggestions"
+		android:saveEnabled="false" />
 		
 	<TextView
 		android:id="@+id/resurvey_value_legend"
@@ -36,16 +41,30 @@
 		android:layout_below="@id/resurvey_key"
 		android:textAppearance="?android:attr/textAppearanceMedium" 
 		android:text="@string/Value"/>
-		
-	<EditText 
+
+	<AutoCompleteTextView
 		android:id="@+id/resurvey_value"
-		android:layout_width="fill_parent" 
+		android:layout_width="fill_parent"
+		android:layout_height="wrap_content"
+		android:layout_below="@id/resurvey_value_legend"
+		android:layout_alignStart="@id/resurvey_value_legend"
+		android:layout_alignLeft="@id/resurvey_value_legend"
+		android:layout_marginEnd="?attr/dialogPreferredPadding"
+		android:layout_marginRight="?attr/dialogPreferredPadding"
+		android:dropDownWidth="wrap_content"
+		android:dropDownHeight="215dp"
+		android:inputType="textNoSuggestions"
+		android:completionThreshold="1"
+		android:saveEnabled="false" />
+	<LinearLayout
+		android:id="@+id/checkbox_container"
+		android:layout_width="fill_parent"
 		android:layout_height="wrap_content"
 		android:layout_marginRight="?attr/dialogPreferredPadding"
         android:layout_marginEnd="?attr/dialogPreferredPadding"
 		android:layout_below="@id/resurvey_value_legend"
-		android:layout_alignLeft="@id/resurvey_value_legend"
-        android:layout_alignStart="@id/resurvey_value_legend"
+		android:layout_alignLeft="@id/resurvey_value"
+		android:layout_alignStart="@id/resurvey_value"
 		android:textAppearance="?android:attr/textAppearanceMedium" />
         
     <TextView


### PR DESCRIPTION
Fixes #1101. Continuation of pr #2251.  

Uses a map on checkbox updates so as to not query the database on every checkbox click. 

Two questions here - 

1. It doesn't seem to me to be a good-first issue as I had to deal with cursor deadlocks and memory leaks for updating the header checkbox (but that's beside the point). I was able to fix the former but the latter issue still persists. All I could circle out was, when invoking resetValidator() after the checkbox update to db, the getDefaultValidator(c).reset(c) method makes the app ANR (Reson- Changing to new focus Window timeout) and if I run the program without the rest then, no problem while the app is open but when the app is closed and a new instance is opened it again crashes the app. Meaning there is a conflict with the updated values and the old values that were never rest. This only happens when resetValidator() is called for the checkbox update and not for any other update (like adding a ruleset or updating it). 

  

2. I would ask you to point me on how to invoke only the following page for testing the resurvey validators. All I could figure out was that as this page is part of the PerfEditorFragment, it can only be invoked when a preferenceScreen is created which itself is created by PerfEditor & PerfEditorActivity. What I can't figure out is how is _this_ created. If you could point me to a simple initialization of this page that would be helpful. 
![Validatorprefs](https://github.com/MarcusWolschon/osmeditor4android/assets/122718496/0610736b-2d69-4c42-a52b-3615c8c5eb38)
