### PR TITLE
Support settable per preset item behaviour in the property editor

### DIFF
--- a/documentation/docs/help/en/Property editor.md
+++ b/documentation/docs/help/en/Property editor.md
@@ -2,8 +2,8 @@
 
 The property editor screen is the central place for changing object attributes and relation memberships. To exit and save your changes tap the check mark icon in the upper left hand corner, pressing the device back button will give you the option of exiting without saving. Tags with empty value fields will not be saved.
 
-Most of the fields use context sensitive auto complete provided by the active presets. Clicking twice (with a short pause) will re-display the auto complete menu. 
-
+Many of the fields use context sensitive auto complete provided by the active presets and previously used tags. Clicking twice (with a short pause) will re-display the auto complete menu. 
+ 
 Depending on size and orientation of your device the layout will change to make maximum use of the space available.
  
  * small devices: tab layout with _Presets_, _Properties_ (including the recently used presets), _Details_ and _Relations_ tabs. If the selected object is a relation a further _Members_ tab will be available. 
@@ -17,11 +17,15 @@ In the tabs tapping the checkbox in the header row will select/de-select all ele
 
 ## Properties Tab
 
-This tab gives a simplified, preset-driven, editing screen for the tags on the selected object on which the keys are represented by their description. To remove individual attributes you can simply remove or reset the value (or delete them in the _Details_ tab).
+This tab gives a simplified, preset-driven, editing screen for the tags for the selected object. Instead of displaying the raw keys, they are represented by their description, which, if available will be translated. To remove individual attributes you can simply remove or reset the value (or delete them in the _Details_ tab).
 
 Fields are added by applying presets, either via the _Preset_ tab or via the ![Apply preset](../images/preset.png) _Apply best preset_ or ![Apply preset with optional tags](../images/tag_menu_apply_preset.png) _Apply best preset with optional tags_ buttons. The later will add fields for any optional tags that are present in the preset.
 
-If alternative tagging is available for the main object, the alternative presets will be displayed before those in the most recently used list.
+If alternative tagging is available for the main object, the alternative presets will be displayed before those in the most recently used list. Long pressing on an item in the MRU preset view will display a menu allowing to
+
+* Set _Apply with last values_, after setting this, further use of the preset will use the most recently used tag values as defaults. If this is not set (_default_) the use of the last value is determined by the *use_last_as_default* attribute in the preset.
+* Set _Apply with optional tags_, after setting this, optional tags will be added when you apply the preset to an object, the same behaviour as pressing the ![Apply preset with optional tags](../images/tag_menu_apply_preset.png), but this will work when auto-applying the best matching preset on startup of the property editor too.
+* _Remove_ remove the item from the MRU preset view. Note that the above settings are persistent and will remain in force even if the preset item is removed.  
 
 Further behaviour and menu items are similar or the same as for the _Details_ tab, the _Add language tags_ menu item will add local language variants of the name and similar keys to the preset if configured for the region (see [the GeoContext repository](https://github.com/simonpoole/geocontext)).
 
@@ -142,7 +146,7 @@ Scroll the screen to the bottom.
 
 Start the on device help browser.
 
-## Preset display
+## Preset tab
 
 Find, select and apply a [preset](Presets.md). Groups of presets have a light background, presets a dark one. The on device presets can be searched for terms, if enabled and network connectivity is available you can try and construct additional presets by querying the Taginfo service, when the results from the internal search are displayed.
 

--- a/src/main/assets/help/en/Property editor.html
+++ b/src/main/assets/help/en/Property editor.html
@@ -7,7 +7,7 @@
 <body>
 <h1>Vespucci Property Editor</h1>
 <p>The property editor screen is the central place for changing object attributes and relation memberships. To exit and save your changes tap the check mark icon in the upper left hand corner, pressing the device back button will give you the option of exiting without saving. Tags with empty value fields will not be saved.</p>
-<p>Most of the fields use context sensitive auto complete provided by the active presets. Clicking twice (with a short pause) will re-display the auto complete menu.</p>
+<p>Many of the fields use context sensitive auto complete provided by the active presets and previously used tags. Clicking twice (with a short pause) will re-display the auto complete menu.</p>
 <p>Depending on size and orientation of your device the layout will change to make maximum use of the space available.</p>
 <ul>
 <li>small devices: tab layout with <em>Presets</em>, <em>Properties</em> (including the recently used presets), <em>Details</em> and <em>Relations</em> tabs. If the selected object is a relation a further <em>Members</em> tab will be available.</li>
@@ -17,9 +17,14 @@
 <p>If the <em>Display tag form</em> preference in the <em><a href="Advanced%20preferences.md">Advanced preferences</a></em> has been disabled pre-0.9.8 behaviour is enabled and the <em>Details</em> tab will have the heading <em>Properties</em>.</p>
 <p>In the tabs tapping the checkbox in the header row will select/de-select all elements.</p>
 <h2>Properties Tab</h2>
-<p>This tab gives a simplified, preset-driven, editing screen for the tags on the selected object on which the keys are represented by their description. To remove individual attributes you can simply remove or reset the value (or delete them in the <em>Details</em> tab).</p>
+<p>This tab gives a simplified, preset-driven, editing screen for the tags for the selected object. Instead of displaying the raw keys, they are represented by their description, which, if available will be translated. To remove individual attributes you can simply remove or reset the value (or delete them in the <em>Details</em> tab).</p>
 <p>Fields are added by applying presets, either via the <em>Preset</em> tab or via the <img src="../images/preset.png" alt="Apply preset" /> <em>Apply best preset</em> or <img src="../images/tag_menu_apply_preset.png" alt="Apply preset with optional tags" /> <em>Apply best preset with optional tags</em> buttons. The later will add fields for any optional tags that are present in the preset.</p>
-<p>If alternative tagging is available for the main object, the alternative presets will be displayed before those in the most recently used list.</p>
+<p>If alternative tagging is available for the main object, the alternative presets will be displayed before those in the most recently used list. Long pressing on an item in the MRU preset view will display a menu allowing to</p>
+<ul>
+<li>Set <em>Apply with last values</em>, after setting this, further use of the preset will use the most recently used tag values as defaults. If this is not set (<em>default</em>) the use of the last value is determined by the <em>use_last_as_default</em> attribute in the preset.</li>
+<li>Set <em>Apply with optional tags</em>, after setting this, optional tags will be added when you apply the preset to an object, the same behaviour as pressing the <img src="../images/tag_menu_apply_preset.png" alt="Apply preset with optional tags" />, but this will work when auto-applying the best matching preset on startup of the property editor too.</li>
+<li><em>Remove</em> remove the item from the MRU preset view. Note that the above settings are persistent and will remain in force even if the preset item is removed.</li>
+</ul>
 <p>Further behaviour and menu items are similar or the same as for the <em>Details</em> tab, the <em>Add language tags</em> menu item will add local language variants of the name and similar keys to the preset if configured for the region (see <a href="https://github.com/simonpoole/geocontext">the GeoContext repository</a>).</p>
 <h2>Details Tab</h2>
 <p>Display of the key - value attributes of the edited object.</p>
@@ -90,7 +95,7 @@
 <p>Scroll the screen to the bottom.</p>
 <h3><img src="../images/menu_help.png" alt="Help" /> Help</h3>
 <p>Start the on device help browser.</p>
-<h2>Preset display</h2>
+<h2>Preset tab</h2>
 <p>Find, select and apply a <a href="Presets.md">preset</a>. Groups of presets have a light background, presets a dark one. The on device presets can be searched for terms, if enabled and network connectivity is available you can try and construct additional presets by querying the Taginfo service, when the results from the internal search are displayed.</p>
 <p>Presets in the &quot;Auto-presets&quot; group, that is such generated from taginfo or custom presets, can be removed from the configuration by long-pressing the respective icon.</p>
 <h3>Top</h3>

--- a/src/main/java/de/blau/android/filter/PresetFilterActivity.java
+++ b/src/main/java/de/blau/android/filter/PresetFilterActivity.java
@@ -1,5 +1,7 @@
 package de.blau.android.filter;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
@@ -14,6 +16,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import de.blau.android.App;
 import de.blau.android.HelpViewer;
+import de.blau.android.Main;
 import de.blau.android.R;
 import de.blau.android.presets.Preset;
 import de.blau.android.presets.PresetClickHandler;
@@ -33,7 +36,8 @@ import de.blau.android.util.ScreenMessage;
  */
 public class PresetFilterActivity extends ConfigurationChangeAwareActivity implements PresetClickHandler {
 
-    private static final String DEBUG_TAG = PresetFilterActivity.class.getSimpleName().substring(0, Math.min(23, PresetFilterActivity.class.getSimpleName().length()));
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, Main.class.getSimpleName().length());
+    private static final String DEBUG_TAG = PresetFilterActivity.class.getSimpleName().substring(0, TAG_LEN);
 
     private static final String FILTER_NULL_OR_NOT_A_PRESET_FILTER = "filter null or not a PresetFilter";
 
@@ -184,7 +188,7 @@ public class PresetFilterActivity extends ConfigurationChangeAwareActivity imple
      * Handle clicks on icons representing an item (closing the dialog with the item as a result)
      */
     @Override
-    public void onItemClick(PresetItem item) {
+    public void onItemClick(View view, PresetItem item) {
         onPresetElementSelected(item);
     }
 
@@ -192,7 +196,7 @@ public class PresetFilterActivity extends ConfigurationChangeAwareActivity imple
      * for now do the same
      */
     @Override
-    public boolean onItemLongClick(PresetItem item) {
+    public boolean onItemLongClick(View view, PresetItem item) {
         onPresetElementSelected(item);
         return true;
     }
@@ -201,7 +205,7 @@ public class PresetFilterActivity extends ConfigurationChangeAwareActivity imple
      * Handle clicks on icons representing a group (changing to that group)
      */
     @Override
-    public void onGroupClick(PresetGroup group) {
+    public void onGroupClick(View view, PresetGroup group) {
         if (!(App.getLogic().getFilter() instanceof PresetFilter)) {
             Log.e(DEBUG_TAG, FILTER_NULL_OR_NOT_A_PRESET_FILTER);
             return;
@@ -214,7 +218,7 @@ public class PresetFilterActivity extends ConfigurationChangeAwareActivity imple
     }
 
     @Override
-    public boolean onGroupLongClick(PresetGroup group) {
+    public boolean onGroupLongClick(View view, PresetGroup group) {
         onPresetElementSelected(group);
         return true;
     }

--- a/src/main/java/de/blau/android/presets/PresetClickHandler.java
+++ b/src/main/java/de/blau/android/presets/PresetClickHandler.java
@@ -1,5 +1,6 @@
 package de.blau.android.presets;
 
+import android.view.View;
 import androidx.annotation.NonNull;
 
 /** Interface for handlers handling clicks on item or group icons */
@@ -8,36 +9,42 @@ public interface PresetClickHandler {
     /**
      * Called for a normal click on a button showing a PresetItem
      * 
+     * @param view the clicked View
      * @param item the PresetItem
      */
-    void onItemClick(@NonNull PresetItem item);
+    void onItemClick(@NonNull View view, @NonNull PresetItem item);
 
     /**
      * Called for a long click on a button showing a PresetItem
      * 
+     * @param view the clicked View
      * @param item the PresetItem
+     * 
      * @return true if consumed
      */
-    default boolean onItemLongClick(@NonNull PresetItem item) {
+    default boolean onItemLongClick(@NonNull View view, @NonNull PresetItem item) {
         return false;
     }
 
     /**
      * Called for a normal click on a button showing a PresetGroup
      * 
+     * @param view the clicked View
      * @param group the PresetGroup
      */
-    default void onGroupClick(@NonNull PresetGroup group) {
+    default void onGroupClick(@NonNull View view, @NonNull PresetGroup group) {
         // do nothing
     }
 
     /**
      * Called for a long click on a button showing a PresetGroup
      * 
+     * @param view the clicked View
      * @param group the PresetGroup
+     * 
      * @return true if consumed
      */
-    default boolean onGroupLongClick(@NonNull PresetGroup group) {
+    default boolean onGroupLongClick(@NonNull View view, @NonNull PresetGroup group) {
         return false;
     }
 }

--- a/src/main/java/de/blau/android/presets/PresetGroup.java
+++ b/src/main/java/de/blau/android/presets/PresetGroup.java
@@ -1,5 +1,7 @@
 package de.blau.android.presets;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -17,6 +19,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
+import de.blau.android.Main;
 import de.blau.android.R;
 import de.blau.android.osm.OsmElement.ElementType;
 import de.blau.android.views.WrappingLayout;
@@ -26,7 +29,10 @@ import de.blau.android.views.WrappingLayout;
  */
 public class PresetGroup extends PresetElement {
 
-    private static final String DEBUG_TAG = PresetGroup.class.getSimpleName().substring(0, Math.min(23, PresetGroup.class.getSimpleName().length()));
+    private static final long serialVersionUID = 1L;
+
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, Main.class.getSimpleName().length());
+    private static final String DEBUG_TAG = PresetGroup.class.getSimpleName().substring(0, TAG_LEN);
 
     private boolean itemSort = true;
 
@@ -106,8 +112,8 @@ public class PresetGroup extends PresetElement {
         TextView v = super.getBaseView(ctx, selected);
         v.setTypeface(null, Typeface.BOLD);
         if (handler != null) {
-            v.setOnClickListener(view -> handler.onGroupClick(PresetGroup.this));
-            v.setOnLongClickListener(view -> handler.onGroupLongClick(PresetGroup.this));
+            v.setOnClickListener(view -> handler.onGroupClick(v, PresetGroup.this));
+            v.setOnLongClickListener(view -> handler.onGroupLongClick(v, PresetGroup.this));
         }
         v.setBackgroundColor(ContextCompat.getColor(ctx, selected ? R.color.material_deep_teal_200 : R.color.dark_grey));
         return v;

--- a/src/main/java/de/blau/android/presets/PresetItem.java
+++ b/src/main/java/de/blau/android/presets/PresetItem.java
@@ -1,5 +1,7 @@
 package de.blau.android.presets;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -27,6 +29,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 import ch.poole.osm.josmfilterparser.JosmFilterParser;
+import de.blau.android.Main;
 import de.blau.android.R;
 import de.blau.android.contract.Schemes;
 import de.blau.android.contract.Urls;
@@ -45,7 +48,8 @@ public class PresetItem extends PresetElement {
 
     private static final long serialVersionUID = 1L;
 
-    private static final String DEBUG_TAG = PresetItem.class.getSimpleName().substring(0, Math.min(23, PresetItem.class.getSimpleName().length()));
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, Main.class.getSimpleName().length());
+    private static final String DEBUG_TAG = PresetItem.class.getSimpleName().substring(0, TAG_LEN);
 
     /**
      * All fields in the order they are in the Preset file
@@ -1216,8 +1220,8 @@ public class PresetItem extends PresetElement {
     public View getView(Context ctx, final PresetClickHandler handler, boolean selected) {
         View v = super.getBaseView(ctx, selected);
         if (handler != null) {
-            v.setOnClickListener(view -> handler.onItemClick(PresetItem.this));
-            v.setOnLongClickListener(view -> handler.onItemLongClick(PresetItem.this));
+            v.setOnClickListener(view -> handler.onItemClick(v, PresetItem.this));
+            v.setOnLongClickListener(view -> handler.onItemLongClick(v, PresetItem.this));
         }
         v.setBackgroundColor(ContextCompat.getColor(ctx, selected ? R.color.material_deep_teal_500 : R.color.preset_bg));
         return v;

--- a/src/main/java/de/blau/android/propertyeditor/AlternativePresetItemsFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/AlternativePresetItemsFragment.java
@@ -1,5 +1,7 @@
 package de.blau.android.propertyeditor;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import java.util.List;
 
 import android.content.Context;
@@ -13,6 +15,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import de.blau.android.App;
+import de.blau.android.Main;
 import de.blau.android.R;
 import de.blau.android.dialogs.Tip;
 import de.blau.android.presets.Preset;
@@ -29,7 +32,8 @@ import de.blau.android.util.Util;
 
 public class AlternativePresetItemsFragment extends ImmersiveDialogFragment {
 
-    private static final String DEBUG_TAG = AlternativePresetItemsFragment.class.getSimpleName().substring(0, Math.min(23, AlternativePresetItemsFragment.class.getSimpleName().length()));
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, Main.class.getSimpleName().length());
+    private static final String DEBUG_TAG = AlternativePresetItemsFragment.class.getSimpleName().substring(0, TAG_LEN);
 
     private static final String ITEM_PATH_KEY = "itemPath";
     public static final String  TAG           = "alternative_preset_item_fragment";
@@ -111,9 +115,9 @@ public class AlternativePresetItemsFragment extends ImmersiveDialogFragment {
     @NonNull
     private View getAlternativesView(@NonNull final LinearLayout presetLayout, @NonNull PresetItem presetItem) {
 
-        final PresetClickHandler presetClickHandler = (PresetItem item) -> {
+        final PresetClickHandler presetClickHandler = (View view, PresetItem item) -> {
             Log.d(DEBUG_TAG, "normal click");
-            presetSelectedListener.onPresetSelected(item, false, true);
+            presetSelectedListener.onPresetSelected(item, false, true, Prefill.PRESET);
         };
         PresetGroup alternatives = Preset.dummyInstance().getRootGroup();
         List<PresetItemLink> links = presetItem.getAlternativePresetItems();

--- a/src/main/java/de/blau/android/propertyeditor/Prefill.java
+++ b/src/main/java/de/blau/android/propertyeditor/Prefill.java
@@ -1,0 +1,19 @@
+package de.blau.android.propertyeditor;
+
+/**
+ * Determine the how empty value fields should be treated when applying a preset
+ */
+public enum Prefill {
+    /**
+     * Don't prefill tag value
+     */
+    NEVER, 
+    /**
+     * Use preset default or useLastAsDefault value to determine if the tag value should be prefilled
+     */
+    PRESET, 
+    /**
+     * If available  use the last used value 
+     */
+    FORCE_LAST 
+}

--- a/src/main/java/de/blau/android/propertyeditor/PresetFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/PresetFragment.java
@@ -1,5 +1,7 @@
 package de.blau.android.propertyeditor;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,6 +41,7 @@ import de.blau.android.BuildConfig;
 import de.blau.android.Feedback;
 import de.blau.android.HelpViewer;
 import de.blau.android.Logic;
+import de.blau.android.Main;
 import de.blau.android.R;
 import de.blau.android.contract.Flavors;
 import de.blau.android.contract.Github;
@@ -60,7 +63,8 @@ import de.blau.android.util.Util;
 
 public class PresetFragment extends BaseFragment implements PresetUpdate, PresetClickHandler {
 
-    private static final String DEBUG_TAG = PresetFragment.class.getSimpleName().substring(0, Math.min(23, PresetFragment.class.getSimpleName().length()));
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, Main.class.getSimpleName().length());
+    private static final String DEBUG_TAG = PresetFragment.class.getSimpleName().substring(0, TAG_LEN);
 
     static final int         MAX_SEARCHRESULTS      = 10;
     private static final int MAX_DISTANCE           = 2;
@@ -90,8 +94,9 @@ public class PresetFragment extends BaseFragment implements PresetUpdate, Preset
          * @param item the PresetItem
          * @param applyOptional if true apply optional fields
          * @param isAlternative if true if the item is an alternative to the existing tagging
+         * @param prefill how to prefill empty values
          */
-        void onPresetSelected(@NonNull PresetItem item, boolean applyOptional, boolean isAlternative);
+        void onPresetSelected(@NonNull PresetItem item, boolean applyOptional, boolean isAlternative, @NonNull Prefill prefill);
     }
 
     private OnPresetSelectedListener mListener;
@@ -427,7 +432,7 @@ public class PresetFragment extends BaseFragment implements PresetUpdate, Preset
      * Handle clicks on icons representing an item
      */
     @Override
-    public void onItemClick(PresetItem item) {
+    public void onItemClick(View view, PresetItem item) {
         if (enabled) {
             mListener.onPresetSelected(item);
         }
@@ -437,7 +442,7 @@ public class PresetFragment extends BaseFragment implements PresetUpdate, Preset
      * Handle long clicks on icons representing an item
      */
     @Override
-    public boolean onItemLongClick(PresetItem item) {
+    public boolean onItemLongClick(View view, PresetItem item) {
         if (enabled) {
             Preset preset = item.getPreset();
             Preset[] presets = propertyEditorListener.getPresets();
@@ -464,7 +469,7 @@ public class PresetFragment extends BaseFragment implements PresetUpdate, Preset
      * Handle clicks on icons representing a group (changing to that group)
      */
     @Override
-    public void onGroupClick(PresetGroup group) {
+    public void onGroupClick(View view, PresetGroup group) {
         ScrollView scrollView = (ScrollView) getOurView();
         if (scrollView != null) {
             currentGroup = group;

--- a/src/main/java/de/blau/android/propertyeditor/PresetSearchResultsFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/PresetSearchResultsFragment.java
@@ -1,5 +1,7 @@
 package de.blau.android.propertyeditor;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,6 +26,7 @@ import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import de.blau.android.App;
+import de.blau.android.Main;
 import de.blau.android.R;
 import de.blau.android.dialogs.Progress;
 import de.blau.android.dialogs.ProgressDialog;
@@ -44,10 +47,11 @@ import de.blau.android.util.Util;
 
 public class PresetSearchResultsFragment extends DialogFragment implements UpdatePresetSearchResult {
 
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, Main.class.getSimpleName().length());
+    private static final String DEBUG_TAG = PresetSearchResultsFragment.class.getSimpleName().substring(0, TAG_LEN);
+    
     private static final String SEARCH_RESULTS_KEY = "searchResults";
     private static final String SEARCH_TERM_KEY    = "searchTerm";
-
-    private static final String DEBUG_TAG = PresetSearchResultsFragment.class.getSimpleName().substring(0, Math.min(23, PresetSearchResultsFragment.class.getSimpleName().length()));
 
     private OnPresetSelectedListener mOnPresetSelectedListener; // NOSONAR we want to fail in onAttach
     private PresetUpdate             mPresetUpdateListener;     // NOSONAR
@@ -147,7 +151,7 @@ public class PresetSearchResultsFragment extends DialogFragment implements Updat
         return dialog;
     }
 
-    final PresetClickHandler presetClickHandler = (PresetItem item) -> {
+    final PresetClickHandler presetClickHandler = (View view, PresetItem item) -> {
         if (!enabled) {
             return;
         }

--- a/src/main/java/de/blau/android/propertyeditor/PropertyEditorFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/PropertyEditorFragment.java
@@ -1,5 +1,7 @@
 package de.blau.android.propertyeditor;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -92,6 +94,9 @@ public class PropertyEditorFragment<M extends Map<String, String> & Serializable
         extends BaseFragment implements PropertyEditorListener, OnPresetSelectedListener, EditorUpdate, FormUpdate, PresetUpdate, NameAdapters, OnSaveListener,
         ch.poole.openinghoursfragment.OnSaveListener {
 
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, Main.class.getSimpleName().length());
+    private static final String DEBUG_TAG = PropertyEditorFragment.class.getSimpleName().substring(0, TAG_LEN);
+
     private static final String CURRENTITEM            = "current_item";
     static final String         PANELAYOUT             = "pane_layout";
     static final String         PRESET_FRAGMENT        = "preset_fragment";
@@ -118,12 +123,6 @@ public class PropertyEditorFragment<M extends Map<String, String> & Serializable
 
     RelationMembershipFragment relationMembershipFragment;
     RelationMembersFragment    relationMembersFragment;
-
-    /**
-     * The tag we use for Android-logging.
-     */
-    private static final String DEBUG_TAG = PropertyEditorFragment.class.getSimpleName().substring(0,
-            Math.min(23, PropertyEditorFragment.class.getSimpleName().length()));
 
     private long[] osmIds;
 
@@ -1152,13 +1151,13 @@ public class PropertyEditorFragment<M extends Map<String, String> & Serializable
 
     @Override
     public void onPresetSelected(PresetItem item) {
-        onPresetSelected(item, false, false);
+        onPresetSelected(item, false, false, Prefill.PRESET);
     }
 
     @Override
-    public void onPresetSelected(PresetItem item, boolean applyOptional, boolean isAlternative) {
+    public void onPresetSelected(PresetItem item, boolean applyOptional, boolean isAlternative, Prefill prefill) {
         if (item != null && tagEditorFragment != null) {
-            tagEditorFragment.applyPreset(item, applyOptional, isAlternative, true);
+            tagEditorFragment.applyPreset(item, applyOptional, isAlternative, true, prefill);
             if (mViewPager.getCurrentItem() != tagEditorFragmentPosition) {
                 if (tagFormFragment != null) {
                     tagFormFragment.update();
@@ -1167,8 +1166,8 @@ public class PropertyEditorFragment<M extends Map<String, String> & Serializable
                     mViewPager.setCurrentItem(tagEditorFragmentPosition);
                 }
             }
-            // utility presets need to be explicitly added, while this duplicates adding item in other cases
-            // it has the nice side effect of moving item to the top
+            // utility presets need to be explicitly added, while this duplicates adding the item in other cases
+            // it has the nice side effect of moving the item to the top
             tagEditorFragment.addToMru(presets, item);
             updateRecentPresets();
         }

--- a/src/main/java/de/blau/android/propertyeditor/tagform/TagFormFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/TagFormFragment.java
@@ -1,5 +1,7 @@
 package de.blau.android.propertyeditor.tagform;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import java.io.ByteArrayInputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -42,6 +44,7 @@ import ch.poole.android.checkbox.IndeterminateCheckBox;
 import ch.poole.conditionalrestrictionparser.ConditionalRestrictionParser;
 import de.blau.android.App;
 import de.blau.android.HelpViewer;
+import de.blau.android.Main;
 import de.blau.android.R;
 import de.blau.android.address.Address;
 import de.blau.android.measure.Length;
@@ -74,6 +77,7 @@ import de.blau.android.presets.ValueType;
 import de.blau.android.propertyeditor.EditorUpdate;
 import de.blau.android.propertyeditor.FormUpdate;
 import de.blau.android.propertyeditor.NameAdapters;
+import de.blau.android.propertyeditor.Prefill;
 import de.blau.android.propertyeditor.PresetFragment.OnPresetSelectedListener;
 import de.blau.android.propertyeditor.PropertyEditorListener;
 import de.blau.android.propertyeditor.TagChanged;
@@ -89,7 +93,9 @@ import de.blau.android.util.Util;
 import de.blau.android.views.CustomAutoCompleteTextView;
 
 public class TagFormFragment extends BaseFragment implements FormUpdate {
-    private static final String DEBUG_TAG = TagFormFragment.class.getSimpleName().substring(0, Math.min(23, TagFormFragment.class.getSimpleName().length()));
+
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, Main.class.getSimpleName().length());
+    private static final String DEBUG_TAG = TagFormFragment.class.getSimpleName().substring(0, TAG_LEN);
 
     private static final String FRAGMENT_CONDITIONAL_RESTRICTION_TAG = "fragment_conditional_restriction";
 
@@ -491,7 +497,8 @@ public class TagFormFragment extends BaseFragment implements FormUpdate {
             if (pi != null) {
                 boolean withOptional = item.getItemId() == R.id.tag_menu_apply_preset_with_optional;
                 displayOptional.put(pi, withOptional);
-                presetSelectedListener.onPresetSelected(pi, withOptional, false);
+                presetSelectedListener.onPresetSelected(pi, withOptional, false,
+                        prefs.applyWithLastValues(getContext(), pi) ? Prefill.FORCE_LAST : Prefill.PRESET);
             }
             return true;
         case R.id.tag_menu_revert:
@@ -539,7 +546,6 @@ public class TagFormFragment extends BaseFragment implements FormUpdate {
                             if (!allTags.containsKey(languageKey)) {
                                 result.put(languageKey, "");
                             }
-
                         }
                     }
                 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -907,6 +907,9 @@
     <string name="default_checkgroup_hint">Additional attributes</string>
     <string name="tag_form_unknown_element">Unknown element (no preset found)</string>
     <string name="tag_form_untagged_element">Untagged element</string>
+    <!--  preset item menu in preset MRU -->
+    <string name="apply_with_last_values">Apply with last values</string>
+    <string name="apply_with_optional_tags">Apply with optional tags</string>
     <!-- Custom preset creation -->
     <string name="tag_menu_create_preset">Create custom preset</string>
     <string name="create_preset_title">Custom preset name</string>


### PR DESCRIPTION
This adds support for per preset behaviour settings for both using the last tag values as default and optional tags when applying a preset to an element in the property editor. The later will change the behaviour when auto-applying the preset on property editor startup.

Currently the way to set this is via a long press on the preset button in the MRU preset view, suggestions for more discoverable ways to do this are welcome.