### PR TITLE
Geojson labels for linestrings and polygons

### DIFF
--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -5159,11 +5159,7 @@ public class Logic {
      */
     private void setRelationType(@Nullable String type, @NonNull Relation relation) {
         SortedMap<String, String> tags = new TreeMap<>(relation.getTags());
-        if (type != null) {
-            tags.put(Tags.KEY_TYPE, type);
-        } else {
-            tags.put(Tags.KEY_TYPE, "");
-        }
+        tags.put(Tags.KEY_TYPE, type != null ? type : "");
         getDelegator().setTags(relation, tags);
     }
 

--- a/src/main/java/de/blau/android/util/Coordinates.java
+++ b/src/main/java/de/blau/android/util/Coordinates.java
@@ -31,6 +31,17 @@ public class Coordinates implements IPoint {
     }
 
     /**
+     * Set new coordinates
+     * 
+     * @param x screen x coordinate
+     * @param y screen y coordinate
+     */
+    public void set(double x, double y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    /**
      * Subtract Coordinates from this object
      * 
      * @param s the Coordinates to subtract

--- a/src/main/java/de/blau/android/util/Geometry.java
+++ b/src/main/java/de/blau/android/util/Geometry.java
@@ -488,7 +488,7 @@ public final class Geometry {
      * 
      * See https://www.scribd.com/document/14819165/Regressions-coniques-quadriques-circulaire-spherique
      * 
-     * @param coords a list on non-colinear coordinates
+     * @param coords a list of non-colinear coordinates
      * @return a Circle object
      */
     @NonNull
@@ -524,6 +524,76 @@ public final class Geometry {
         double r = Math.sqrt(c + x * x + y * y);
 
         return new Circle(new Coordinates(x + coords[0].x, y + coords[0].y), r);
+    }
+
+    /**
+     * Calculate on screen centroid from a list of coordinates of a polygon
+     * 
+     * While this duplicates code from above, this makes sense in situations in which the coordinates are in the float
+     * array format.
+     * 
+     * @param linePoints an array holding the coordinates
+     * @param length the length of the usable data in the array
+     * @param centroid a preallocated Coordinates object
+     * @return the provided Coordinates object or null
+     */
+    @Nullable
+    public static Coordinates centroidFromPointlist(@NonNull float[] linePoints, int length, @NonNull Coordinates centroid) {
+        double area = 0;
+        double y = 0;
+        double x = 0;
+        double x1 = linePoints[0];
+        double y1 = linePoints[1];
+        for (int i = 0; i < length; i = i + 2) {
+            double x2 = linePoints[(i + 2) % length];
+            double y2 = linePoints[(i + 3) % length];
+            double d = x1 * y2 - x2 * y1;
+            area = area + d;
+            x = x + (x1 + x2) * d;
+            y = y + (y1 + y2) * d;
+            x1 = x2;
+            y1 = y2;
+        }
+        if (Util.notZero(area)) {
+            centroid.set(x / (3 * area), y / (3 * area)); // NOSONAR nonZero tests for zero
+            return centroid;
+        }
+        return null;
+    }
+
+    /**
+     * Calculate on screen midpoint from a list of coordinates of a line
+     * 
+     * While this duplicates code from above, this makes sense in situations in which the coordinates are in the float
+     * array format.
+     * 
+     * @param linePoints an array holding the coordinates
+     * @param length the length of the usable data in the array
+     * @param midpoint a preallocated Coordinates object
+     * @return the provided Coordinates object or null
+     */
+    @Nullable
+    public static Coordinates midpointFromPointlist(@NonNull float[] linePoints, int length, @NonNull Coordinates midpoint) {
+        double y = 0;
+        double x = 0;
+        double x1 = linePoints[0];
+        double y1 = linePoints[1];
+        double l = 0;
+        for (int i = 0; i < length - 2; i = i + 2) {
+            double x2 = linePoints[i + 2];
+            double y2 = linePoints[i + 3];
+            double len = Math.sqrt((x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1));
+            l += len;
+            x += len * (x1 + x2) / 2;
+            y += len * (y1 + y2) / 2;
+            x1 = x2;
+            y1 = y2;
+        }
+        if (Util.notZero(l)) {
+            midpoint.set(x / l, y / l); // NOSONAR nonZero tests for zero
+            return midpoint;
+        }
+        return null;
     }
 
     interface Op {

--- a/src/test/java/de/blau/android/util/GeometryTest.java
+++ b/src/test/java/de/blau/android/util/GeometryTest.java
@@ -4,8 +4,6 @@ import static de.blau.android.osm.DelegatorUtil.toE7;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -87,5 +85,27 @@ public class GeometryTest {
         assertEquals(2, centroid.length);
         assertEquals(centroid[0], -0.1417412D, 0.0000001);
         assertEquals(centroid[1], 51.5019094D, 0.0000001);
+    }
+    
+    /**
+     * Calculate the centroid of a list of screen coordinates of a polygon
+     */
+    @Test
+    public void centroidFromPointlist() {
+        float[] pointlist = new float[] {2,2,2,0,0,0,0,2};
+        Coordinates c = Geometry.centroidFromPointlist(pointlist, pointlist.length, new Coordinates(0,0));
+        assertEquals(1D, c.x, 0.000001);
+        assertEquals(1D, c.y, 0.000001);     
+    }
+    
+    /**
+     * Calculate the midpoint of a list of screen coordinates of a linestring
+     */
+    @Test
+    public void midpointFromPointlist() {
+        float[] pointlist = new float[] {-1,0,0,1,2,-1,3,0};
+        Coordinates c = Geometry.midpointFromPointlist(pointlist, pointlist.length, new Coordinates(0,0));
+        assertEquals(1D, c.x, 0.000001);
+        assertEquals(0D, c.y, 0.000001);     
     }
 }


### PR DESCRIPTION
This adds support for labels on linestrings and polygons (and the multi- versions of them) geometries. Note that to keep things simply we display a single label at the midpoint of linestrings. 