### PR TITLE
Fix weird behaviour when deleting a relation member in easy edit mode

### DIFF
--- a/src/androidTest/java/de/blau/android/easyedit/RelationTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/RelationTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.After;
@@ -340,5 +341,46 @@ public class RelationTest {
         outer = outerMembers.get(2);
         assertEquals(1, outer.getElement().getTags().size());
         assertTrue(outer.getElement().hasTagWithValue(Tags.KEY_ADDR_HOUSENUMBER, "38"));
+    }
+    
+    /**
+     * Edit route relation
+     */
+    // @SdkSuppress(minSdkVersion = 26)
+    @Test
+    public void editRoute() {
+        map.getDataLayer().setVisible(true);
+        TestUtils.unlock(device);
+        TestUtils.zoomToLevel(device, main, 22);
+        //
+        TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
+        TestUtils.clickText(device, true, context.getString(R.string.okay), true, false); // Tip
+        assertTrue(TestUtils.clickText(device, false, "↓ Hiking route", false, false));
+        List<Relation> relations = App.getLogic().getSelectedRelations();
+        assertNotNull(relations);
+        assertEquals(1, relations.size());
+        Relation relation = relations.get(0);
+       
+        assertEquals(6490362L, relation.getOsmId());
+        assertNotNull(relation.getMember(Way.NAME, 104148456L));
+        assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_relationselect)));
+
+        assertTrue(TestUtils.clickOverflowButton(device));
+        assertTrue(TestUtils.clickText(device, false, context.getString(R.string.menu_add_relation_member), true, true));
+       
+        assertTrue(TestUtils.findText(device, false, context.getString(R.string.menu_add_relation_member)));
+        
+        TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
+        
+        assertTrue(TestUtils.findText(device, false, context.getString(R.string.duplicate_relation_member_title, 5000)));
+        TestUtils.clickButton(device, "android:id/button2", true);
+       
+        TestUtils.sleep(2000);
+        TestUtils.clickAtCoordinates(device, map, 8.3893820, 47.3895626, true);
+        TestUtils.sleep(2000);
+        
+        TestUtils.clickButton(device, device.getCurrentPackageName() + ":id/simpleButton", true);
+        TestUtils.sleep(2000);
+        assertNotNull(relation.getMember(Way.NAME, 104148456L));
     }
 }

--- a/src/main/java/de/blau/android/easyedit/EditRelationMembersActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/EditRelationMembersActionModeCallback.java
@@ -1,5 +1,7 @@
 package de.blau.android.easyedit;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -52,8 +54,9 @@ import de.blau.android.util.collections.MultiHashMap;
  *
  */
 public class EditRelationMembersActionModeCallback extends BuilderActionModeCallback {
-    private static final String DEBUG_TAG = EditRelationMembersActionModeCallback.class.getSimpleName().substring(0,
-            Math.min(23, EditRelationMembersActionModeCallback.class.getSimpleName().length()));
+
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, EditRelationMembersActionModeCallback.class.getSimpleName().length());
+    private static final String DEBUG_TAG = EditRelationMembersActionModeCallback.class.getSimpleName().substring(0, TAG_LEN);
 
     private static final int MENUITEM_REVERT = 1;
 
@@ -111,7 +114,6 @@ public class EditRelationMembersActionModeCallback extends BuilderActionModeCall
             @NonNull List<OsmElement> selection) {
         super(manager);
         this.presetPath = presetPath;
-        determineRelationPreset();
         for (OsmElement e : selection) {
             addElement(e);
         }
@@ -127,7 +129,6 @@ public class EditRelationMembersActionModeCallback extends BuilderActionModeCall
     public EditRelationMembersActionModeCallback(@NonNull EasyEditManager manager, @Nullable PresetElementPath presetPath, @NonNull OsmElement element) {
         super(manager);
         this.presetPath = presetPath;
-        determineRelationPreset();
         addElement(element);
     }
 
@@ -142,7 +143,6 @@ public class EditRelationMembersActionModeCallback extends BuilderActionModeCall
     public EditRelationMembersActionModeCallback(@NonNull EasyEditManager manager, @NonNull Relation relation, @Nullable OsmElement element) {
         super(manager);
         this.relation = relation;
-        determineRelationPreset();
         if (element != null) {
             addElement(element);
         }
@@ -159,7 +159,6 @@ public class EditRelationMembersActionModeCallback extends BuilderActionModeCall
     public EditRelationMembersActionModeCallback(@NonNull EasyEditManager manager, @NonNull Relation relation, @NonNull List<OsmElement> selection) {
         super(manager);
         this.relation = relation;
-        determineRelationPreset();
         for (OsmElement e : selection) {
             addElement(e);
         }
@@ -261,6 +260,9 @@ public class EditRelationMembersActionModeCallback extends BuilderActionModeCall
         } else if (presetPath != null) {
             relationPreset = (PresetItem) Preset.getElementByPath(App.getCurrentRootPreset(main).getRootGroup(), presetPath);
         }
+        if (getRoles() == null) {
+            ScreenMessage.toastTopWarning(main, relationPreset == null ? R.string.toast_no_preset_found : R.string.toast_no_roles_found);
+        }
     }
 
     /**
@@ -302,6 +304,22 @@ public class EditRelationMembersActionModeCallback extends BuilderActionModeCall
     }
 
     /**
+     * Check if a OsmElement is in a Collection of members
+     * 
+     * @param members the RelationMembers
+     * @param memberElement the OsmElement to check
+     * @return true if the member is present
+     */
+    private boolean contains(@NonNull Collection<RelationMember> members, @NonNull OsmElement memberElement) {
+        for (RelationMember member : members) {
+            if (member.getRef() == memberElement.getOsmId() && member.getType().equals(memberElement.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Pretend that the element is already a member and highlight it
      * 
      * @param element the element
@@ -331,26 +349,27 @@ public class EditRelationMembersActionModeCallback extends BuilderActionModeCall
             List<Relation> relationRelations = logic.getSelectedRelationRelations();
             // new members might be downloaded
             for (RelationMember rm : relation.getMembers()) {
-                if (rm.downloaded()) {
-                    switch (rm.getType()) {
-                    case Way.NAME:
-                        if (relationWays != null && !relationWays.contains(rm.getElement())) {
-                            logic.addSelectedRelationWay((Way) rm.getElement());
-                        }
-                        break;
-                    case Node.NAME:
-                        if (relationNodes != null && !relationNodes.contains(rm.getElement())) {
-                            logic.addSelectedRelationNode((Node) rm.getElement());
-                        }
-                        break;
-                    case Relation.NAME:
-                        if (relationRelations != null && !relationRelations.contains(rm.getElement())) {
-                            logic.addSelectedRelationRelation((Relation) rm.getElement());
-                        }
-                        break;
-                    default:
-                        // do nothing
+                if (!rm.downloaded()) {
+                    continue;
+                }
+                switch (rm.getType()) {
+                case Way.NAME:
+                    if (inList(relationWays, rm)) {
+                        logic.addSelectedRelationWay((Way) rm.getElement());
                     }
+                    break;
+                case Node.NAME:
+                    if (inList(relationNodes, rm)) {
+                        logic.addSelectedRelationNode((Node) rm.getElement());
+                    }
+                    break;
+                case Relation.NAME:
+                    if (inList(relationRelations, rm)) {
+                        logic.addSelectedRelationRelation((Relation) rm.getElement());
+                    }
+                    break;
+                default:
+                    // do nothing
                 }
             }
         }
@@ -361,6 +380,17 @@ public class EditRelationMembersActionModeCallback extends BuilderActionModeCall
             arrangeMenu(menu);
         }
         return updated;
+    }
+
+    /**
+     * A "contains" that checks if the List is null
+     * 
+     * @param list the List
+     * @param rm the RelationMember
+     * @return true if the element of the memer is present in the list
+     */
+    private <T extends OsmElement> boolean inList(@Nullable List<T> list, @NonNull RelationMember rm) {
+        return list != null && !list.contains(rm.getElement());
     }
 
     @Override
@@ -393,8 +423,16 @@ public class EditRelationMembersActionModeCallback extends BuilderActionModeCall
         List<Way> relationWays = logic.getSelectedRelationWays();
         List<Node> relationNodes = logic.getSelectedRelationNodes();
         List<Relation> relationRelations = logic.getSelectedRelationRelations();
-        if ((relationWays != null && relationWays.contains(element)) || (relationNodes != null && relationNodes.contains(element))
-                || (relationRelations != null && relationRelations.contains(element))) {
+        final long osmId = element.getOsmId();
+        Set<RelationMember> toRemove = removeMembers.get(osmId);
+        if (contains(toRemove, element)) {
+            // removed element being added back
+            if (toRemove.size() > 1) {
+                ScreenMessage.toastTopWarning(main, R.string.toast_undeleting_all_members);
+            }
+            removeMembers.removeKey(osmId);
+        } else if (((relationWays != null && relationWays.contains(element)) || (relationNodes != null && relationNodes.contains(element))
+                || (relationRelations != null && relationRelations.contains(element)))) {
             new AlertDialog.Builder(main).setTitle(R.string.duplicate_relation_member_title).setMessage(R.string.duplicate_relation_member_message)
                     .setPositiveButton(R.string.duplicate_route_segment_button, (dialog, which) -> addElement(element))
                     .setNegativeButton(R.string.duplicate_relation_member_remove_button, (dialog, which) -> removeElement(element))
@@ -413,73 +451,88 @@ public class EditRelationMembersActionModeCallback extends BuilderActionModeCall
      */
     private void setClickableElements() {
         BoundingBox viewBox = main.getMap().getViewBox();
+        List<PresetRole> roles = getRoles();
+        if (roles == null) {
+            // make everything selectable
+            logic.setClickableElements(null);
+            return;
+        }
+        for (PresetRole role : roles) {
+            if (role.appliesTo(ElementType.RELATION) || role.appliesTo(ElementType.AREA)) {
+                logic.setReturnRelations(true);
+                break;
+            }
+        }
+        Set<OsmElement> elements = new HashSet<>();
+        final Storage currentStorage = App.getDelegator().getCurrentStorage();
+        elements.addAll(currentStorage.getNodes(viewBox));
+        elements.addAll(currentStorage.getWays(viewBox));
+        elements.addAll(currentStorage.getRelations());
+        Set<OsmElement> clickable = new HashSet<>();
+        Wrapper wrapper = new Wrapper(main);
+        Map<String, Condition> conditionCache = new HashMap<>();
+        for (OsmElement e : elements) {
+            for (PresetRole role : roles) {
+                if (role.appliesTo(e.getType())) {
+                    String memberExpression = role.getMemberExpression();
+                    if (memberExpression == null) {
+                        clickable.add(e);
+                        break;
+                    }
+                    memberExpression = memberExpression.trim();
+                    wrapper.setElement(e);
+                    Condition condition = getCondition(conditionCache, memberExpression);
+                    if (condition != null && condition.eval(Wrapper.toJosmFilterType(e), wrapper, e.getTags())) {
+                        clickable.add(e);
+                        break;
+                    }
+                }
+            }
+        }
+        logic.setClickableElements(clickable);
+
+    }
+
+    /**
+     * Get the Condition object for a memberExpression, caching it
+     * 
+     * @param conditionCache the cache
+     * @param memberExpression the
+     * @return the Condition or null
+     */
+    @Nullable
+    private Condition getCondition(@NonNull Map<String, Condition> conditionCache, @NonNull String memberExpression) {
+        Condition condition = conditionCache.get(memberExpression); // NOSONAR
+        if (condition == null) {
+            try {
+                JosmFilterParser parser = new JosmFilterParser(new ByteArrayInputStream(memberExpression.getBytes()));
+                condition = parser.condition();
+            } catch (ch.poole.osm.josmfilterparser.ParseException | IllegalArgumentException ex) {
+                Log.e(DEBUG_TAG, "member_expression " + memberExpression + " caused " + ex.getMessage());
+                try {
+                    JosmFilterParser parser = new JosmFilterParser(new ByteArrayInputStream("".getBytes()));
+                    condition = parser.condition();
+                } catch (ch.poole.osm.josmfilterparser.ParseException | IllegalArgumentException ex2) {
+                    Log.e(DEBUG_TAG, "member_expression dummy caused " + ex2.getMessage());
+                }
+            }
+            conditionCache.put(memberExpression, condition);
+        }
+        return condition;
+    }
+
+    /**
+     * If a preset match has been found return any roles
+     * 
+     * @return a List of roles or null
+     */
+    @Nullable
+    private List<PresetRole> getRoles() {
         List<PresetRole> roles = null;
         if (relationPreset != null) {
             roles = relationPreset.getRoles();
         }
-
-        if (roles != null) {
-            for (PresetRole role : roles) {
-                if (role.appliesTo(ElementType.RELATION) || role.appliesTo(ElementType.AREA)) {
-                    logic.setReturnRelations(true);
-                    break;
-                }
-            }
-            Set<OsmElement> elements = new HashSet<>();
-            final Storage currentStorage = App.getDelegator().getCurrentStorage();
-            elements.addAll(currentStorage.getNodes(viewBox));
-            elements.addAll(currentStorage.getWays(viewBox));
-            elements.addAll(currentStorage.getRelations());
-            Set<OsmElement> clickable = new HashSet<>();
-            Wrapper wrapper = new Wrapper(main);
-            Map<String, Condition> conditionCache = new HashMap<>();
-            for (OsmElement e : elements) {
-                for (PresetRole role : roles) {
-                    if (role.appliesTo(e.getType())) {
-                        String memberExpression = role.getMemberExpression();
-                        if (memberExpression != null) {
-                            memberExpression = memberExpression.trim();
-                            wrapper.setElement(e);
-                            Condition condition = conditionCache.get(memberExpression); // NOSONAR
-                            if (condition == null) {
-                                try {
-                                    JosmFilterParser parser = new JosmFilterParser(new ByteArrayInputStream(memberExpression.getBytes()));
-                                    condition = parser.condition();
-                                    conditionCache.put(memberExpression, condition);
-                                } catch (ch.poole.osm.josmfilterparser.ParseException | IllegalArgumentException ex) {
-                                    Log.e(DEBUG_TAG, "member_expression " + memberExpression + " caused " + ex.getMessage());
-                                    try {
-                                        JosmFilterParser parser = new JosmFilterParser(new ByteArrayInputStream("".getBytes()));
-                                        condition = parser.condition();
-                                        conditionCache.put(memberExpression, condition);
-                                    } catch (ch.poole.osm.josmfilterparser.ParseException | IllegalArgumentException ex2) {
-                                        Log.e(DEBUG_TAG, "member_expression dummy caused " + ex2.getMessage());
-                                    }
-                                }
-                            }
-                            if (condition != null && condition.eval(Wrapper.toJosmFilterType(e), wrapper, e.getTags())) {
-                                clickable.add(e);
-                                break;
-                            }
-                        } else {
-                            clickable.add(e);
-                            break;
-                        }
-                    }
-                }
-            }
-            logic.setClickableElements(clickable);
-        } else {
-            List<OsmElement> excludes = new ArrayList<>();
-            for (RelationMember member : newMembers) {
-                excludes.add(member.getElement());
-            }
-            if (relation != null) {
-                logic.setSelectedRelationMembers(relation);
-                excludes.addAll(relation.getMemberElements());
-            }
-            logic.setClickableElements(logic.findClickableElements(viewBox, excludes));
-        }
+        return roles;
     }
 
     @Override

--- a/src/main/java/de/blau/android/presets/Preset.java
+++ b/src/main/java/de/blau/android/presets/Preset.java
@@ -1,5 +1,7 @@
 package de.blau.android.presets;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileFilter;
@@ -84,6 +86,9 @@ public class Preset implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, Preset.class.getSimpleName().length());
+    private static final String DEBUG_TAG = Preset.class.getSimpleName().substring(0, TAG_LEN);
+
     static final String COMBO_DELIMITER       = ",";
     static final String MULTISELECT_DELIMITER = ";";
 
@@ -94,9 +99,6 @@ public class Preset implements Serializable {
 
     // hardwired layout stuff
     public static final int SPACING = 5;
-
-    //
-    private static final String DEBUG_TAG = Preset.class.getSimpleName().substring(0, Math.min(23, Preset.class.getSimpleName().length()));
 
     /** The directory containing all data (xml, MRU data, images) about this preset */
     private File directory;
@@ -1072,6 +1074,10 @@ public class Preset implements Serializable {
         return findBestMatch(presets, tags, regions, null, false, ignoreTags);
     }
 
+    private static final int FIXED_TAG_WEIGHT = 1000;                 // weight per fixed tag
+    private static final int RELATION_WEIGHT  = 2 * FIXED_TAG_WEIGHT; // additional weight for relations
+    private static final int DOWNGRADE_WEIGHT = 200;
+
     /**
      * Finds the preset item best matching a certain tag set, or null if no preset item matches. To match, all
      * (mandatory) tags of the preset item need to be in the tag set. The preset item does NOT need to have all tags in
@@ -1107,9 +1113,10 @@ public class Preset implements Serializable {
             buildPossibleMatches(possibleMatches, presets, tags, true, ignoreTags);
         }
         // Find best
-        final int FIXED_WEIGHT = 1000; // always prioritize presets with fixed keys
+        // always prioritize presets with fixed keys that match
         for (PresetItem possibleMatch : possibleMatches) {
-            int fixedTagCount = possibleMatch.getFixedTagCount(regions) * FIXED_WEIGHT;
+            int fixedTagCount = possibleMatch.getFixedTagCount(regions) * FIXED_TAG_WEIGHT
+                    + (ElementType.RELATION == elementType && possibleMatch.isFixedTag(Tags.KEY_TYPE) ? RELATION_WEIGHT : 0);
             int recommendedTagCount = possibleMatch.getRecommendedKeyCount();
             if (fixedTagCount + recommendedTagCount >= bestMatchStrength) {
                 int matches = 0;
@@ -1122,15 +1129,11 @@ public class Preset implements Serializable {
                 }
                 if (regions != null && !possibleMatch.appliesIn(regions)) {
                     // downgrade so much that recommended tags can't compensate
-                    matches -= 200;
+                    matches -= DOWNGRADE_WEIGHT;
                 }
-                if (elementType != null) {
-                    if (!possibleMatch.appliesTo(elementType)) {
-                        // downgrade even more
-                        matches -= 200;
-                    } else if (ElementType.RELATION == elementType && possibleMatch.isFixedTag(Tags.KEY_TYPE)) {
-                        matches += 2 * FIXED_WEIGHT; // prioritize actual relation presets
-                    }
+                if (elementType != null && !possibleMatch.appliesTo(elementType)) {
+                    // downgrade even more
+                    matches -= DOWNGRADE_WEIGHT;
                 }
                 if (recommendedTagCount > 0) {
                     matches = matches + possibleMatch.matchesRecommended(tags, regions);

--- a/src/main/java/de/blau/android/tasks/Todo.java
+++ b/src/main/java/de/blau/android/tasks/Todo.java
@@ -148,7 +148,7 @@ public final class Todo extends Bug implements Serializable {
     }
     
     /**
-     * Construct a todo with just a list name and id
+     * Construct a todo with just a list name and id //NOSONAR
      * 
      * @param listName the name of the todo list to add this to // NOSONAR
      * 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -796,6 +796,9 @@
     <string name="toast_note_not_found">Note #%1$d not found</string>
     <string name="toast_pressure_calibration">New height %1$fm\nCurrent pressure  %2$fhPa\nReference pressure %3$fhPa"</string>
     <string name="toast_no_compass">Device has no compass!</string>
+    <string name="toast_no_roles_found">No roles found, all elements can be selected</string>
+    <string name="toast_no_preset_found">No matching preset found, all elements can be selected</string>
+    <string name="toast_undeleting_all_members">Undeleting all relation members with this element</string>
     <!-- Error messages -->
     <string name="error_mapsplit_missing_zoom">MapSplit sources must have min and max zoom set</string>
     <string name="error_pbf_no_version">Version information missing in PBF file</string>

--- a/src/test/java/de/blau/android/presets/PresetTest.java
+++ b/src/test/java/de/blau/android/presets/PresetTest.java
@@ -149,6 +149,19 @@ public class PresetTest {
         assertNotNull(match);
         assertTrue(match.hasKeyValue(Tags.KEY_SHOP, "supermarket"));
     }
+    
+    /**
+     * Test that we match a bicycle route relation
+     */
+    @Test
+    public void matching5() {
+        //
+        Map<String, String> tags = new HashMap<>();
+        tags.put(Tags.KEY_TYPE, Tags.VALUE_ROUTE);
+        tags.put(Tags.VALUE_ROUTE, "bicycle");
+        PresetItem match = Preset.findBestMatch(presets, tags, null, ElementType.RELATION, false, null);
+        assertEquals("Bicycle Route", match.getName());
+    }
 
     /**
      * Remove an item


### PR DESCRIPTION
There are two independent issues that add up to the reported problem

+ Relations would not match properly leading to the 1st of all potential matches being returned. For example the generic route preset for a bicycle route. The relation editing easy edit mode assumed however that there are roles present and if not would fall back to a generic mode in which elements could just be added.

+ Minor logic issues in handling deleted members, in particular highlighting them.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/2582 