### PR TITLE
Check that any relation changes are actually real

### DIFF
--- a/src/main/java/de/blau/android/osm/RelationMemberDescription.java
+++ b/src/main/java/de/blau/android/osm/RelationMemberDescription.java
@@ -104,10 +104,10 @@ public class RelationMemberDescription extends RelationMember {
     /**
      * Set the position of the member in the Relation
      * 
-     * @param postiion the position to set
+     * @param postion the position to set
      */
-    public void setPosition(int postiion) {
-        this.position = postiion;
+    public void setPosition(int postion) {
+        this.position = postion;
     }
 
     @Override
@@ -135,7 +135,7 @@ public class RelationMemberDescription extends RelationMember {
      * @throws IOException if writing fails
      */
     private void writeObject(java.io.ObjectOutputStream out) throws IOException {
-        super.setElement(null); // don't save the actual relation ref
+        super.setElement(null); // don't save the actual object
         out.defaultWriteObject();
     }
 

--- a/src/main/java/de/blau/android/propertyeditor/PropertyEditorData.java
+++ b/src/main/java/de/blau/android/propertyeditor/PropertyEditorData.java
@@ -26,7 +26,8 @@ import de.blau.android.util.collections.MultiHashMap;
 public class PropertyEditorData implements Serializable {
     private static final long serialVersionUID = 5L;
 
-    private static final String DEBUG_TAG = PropertyEditorData.class.getSimpleName().substring(0, Math.min(23, PropertyEditorData.class.getSimpleName().length()));
+    private static final String DEBUG_TAG = PropertyEditorData.class.getSimpleName().substring(0,
+            Math.min(23, PropertyEditorData.class.getSimpleName().length()));
 
     public final long                                       osmId;
     public final String                                     type;
@@ -100,9 +101,12 @@ public class PropertyEditorData implements Serializable {
      * @return the List
      */
     static <T extends List<RelationMemberDescription>> T getRelationMemberDescriptions(@NonNull Relation relation, @NonNull T members) {
+        int position = 0;
         for (RelationMember rm : relation.getMembers()) {
             RelationMemberDescription newRm = new RelationMemberDescription(rm);
+            newRm.setPosition(position);
             members.add(newRm);
+            position++;
         }
         return members;
     }

--- a/src/main/java/de/blau/android/propertyeditor/RelationMembersFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/RelationMembersFragment.java
@@ -240,15 +240,18 @@ public class RelationMembersFragment extends SelectableRowsFragment implements P
     public void onDataUpdate() {
         Log.d(DEBUG_TAG, "onDataUpdate");
         Relation r = (Relation) propertyEditorListener.getElement();
-        List<MemberEntry> tempEntries = new ArrayList<>();
+        List<MemberEntry> currentEntries = new ArrayList<>();
         final ArrayList<RelationMemberDescription> currentMembers = PropertyEditorData.getRelationMemberDescriptions(r, new ArrayList<>());
-        getMemberEntries(currentMembers, tempEntries);
-        setIcons(tempEntries);
-        if (!tempEntries.equals(membersInternal)) {
+        getMemberEntries(currentMembers, currentEntries);
+        setIcons(currentEntries);
+        // relations can be very large and this might cause issues on the stack
+        List<RelationMemberDescription> origMembers = savingHelper.load(getContext(), Long.toString(id) + FILENAME_ORIG_MEMBERS, true);
+        // only update our copy if the relation members have actually changed from the original state
+        if (!currentMembers.equals(origMembers) && !currentEntries.equals(membersInternal)) {
             Log.d(DEBUG_TAG, "onDataUpdate current members have changed");
             ScreenMessage.toastTopInfo(getContext(), R.string.toast_updating_members);
             membersInternal.clear();
-            membersInternal.addAll(tempEntries);
+            membersInternal.addAll(currentEntries);
             adapter.notifyDataSetChanged();
             savingHelper.save(getContext(), Long.toString(id) + FILENAME_ORIG_MEMBERS, currentMembers, true);
         }


### PR DESCRIPTION
We were overwriting changes to roles when launching the property editor from the relation member fragment.