### PR TITLE
Launcher state loss

### DIFF
--- a/documentation/docs/help/en/Advanced preferences.md
+++ b/documentation/docs/help/en/Advanced preferences.md
@@ -400,3 +400,7 @@ Do not use, may cause hangs of the app and other problems.
 ### Enable split window property editor
 
 Enable displaying the property editor in a separate window if available. Default: _off_
+
+### Use "new task" mode for property editor
+
+Set FLAG_ACTIVITY_NEW_TASK when starting the property editor, this may improve the behaviour of certain launchers when resuming the app. Default: _off_

--- a/documentation/docs/tutorials/faq.md
+++ b/documentation/docs/tutorials/faq.md
@@ -311,6 +311,12 @@ On Android versions between 4.1 and 4.4 the app can be used without issues, exce
 * go to _Preferences_ -> _Advanced preferences_ -> _Server settings_ and set login and password under the _User account_ entry.
 * in the layer control select the _Configure_ menu entry for the data layer entry, edit the active entry, and uncheck OAuth support.   
 
+### Resuming the app doesn't bring me back to the property editor
+
+Depending on the device, Android version and the phase of the moon, some Android launchers will restart the app instead of resuming it if you click on the icon in the app draw instead of selecting the app from the current application list. This will lead to any state/edit in the property editor being lost if you had navigated away from it, for example recent Samsung devices exhibit this behaviour. 
+
+If you are experiencing this issue, setting _Use "new task" mode for property editor_ in the experimental section of the _Advanced preferences_ may help.
+
 ## Performance
 
 ### Vespucci is getting slower and slower

--- a/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
+++ b/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
@@ -271,8 +271,9 @@ public class PropertyEditorTest {
         direction.clickAndWait(Until.newWindow(), 2000);
         TestUtils.clickText(device, true, main.getString(R.string.save), true, false);
         TestUtils.clickHome(device, true);
+        TestUtils.sleep(5000);
         try {
-            assertTrue(Integer.parseInt(direction.getText()) >= 0);
+            assertTrue(Integer.parseInt(n.getTagWithKey("direction")) >= 0);
         } catch (NumberFormatException nfex) {
             fail(nfex.getMessage());
         }
@@ -320,7 +321,7 @@ public class PropertyEditorTest {
         TestUtils.clickText(device, true, "Forward", false, false);
         TestUtils.clickText(device, true, main.getString(R.string.save), true, false);
         TestUtils.clickHome(device, true);
-        assertEquals("forward", direction.getText());
+        assertEquals("forward", n.getTagWithKey("direction"));
     }
 
     @Test

--- a/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest2.java
+++ b/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest2.java
@@ -1,0 +1,42 @@
+package de.blau.android.propertyeditor;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import de.blau.android.App;
+import de.blau.android.prefs.Preferences;
+
+/**
+ * Run all tests in PropertyEditorTest with new task flag
+ */
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class PropertyEditorTest2 extends PropertyEditorTest {
+
+    /**
+     * Pre-test setup
+     */
+    @Override
+    @Before
+    public void setup() {
+        super.setup();
+        Preferences prefs = new Preferences(context);
+        prefs.setNewTaskForPropertyEditor(true);
+        App.getLogic().setPrefs(prefs);
+    }
+
+    /**
+     * Post-test teardown
+     */
+    @Override
+    @After
+    public void teardown() {
+        super.setup();
+        Preferences prefs = new Preferences(context);
+        prefs.setNewTaskForPropertyEditor(false);
+        App.getLogic().setPrefs(prefs);
+    }
+}

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -61,7 +61,8 @@
         <activity
             android:name=".Splash"
             android:exported="true"
-            android:theme="@style/SplashTheme" >
+            android:theme="@style/SplashTheme" 
+            android:alwaysRetainTaskState="true">"
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -79,7 +80,8 @@
             android:configChanges="orientation|screenSize|keyboardHidden|density|screenLayout|uiMode|fontScale"
             android:exported="true"
             android:launchMode="singleInstance"
-            android:theme="@style/Theme.customMain" >
+            android:theme="@style/Theme.customMain" 
+            android:alwaysRetainTaskState="true">
             <meta-data
                 android:name="com.samsung.android.keepalive.density"
                 android:value="true" />
@@ -134,7 +136,8 @@
             android:name=".propertyeditor.PropertyEditorActivity"
             android:configChanges="orientation|screenSize|keyboardHidden|density|screenLayout|uiMode|fontScale"
             android:launchMode="singleTask"
-            android:theme="@style/Theme.customTagEditor" />
+            android:theme="@style/Theme.customTagEditor" 
+            android:alwaysRetainTaskState="true"/>
         <activity
             android:name=".prefs.APIEditorActivity"
             android:configChanges="orientation|screenSize|keyboardHidden|density|screenLayout|uiMode|fontScale"

--- a/src/main/assets/help/en/Advanced preferences.html
+++ b/src/main/assets/help/en/Advanced preferences.html
@@ -206,6 +206,8 @@
 <p>Do not use, may cause hangs of the app and other problems.</p>
 <h3>Enable split window property editor</h3>
 <p>Enable displaying the property editor in a separate window if available. Default: <em>off</em></p>
+<h3>Use &quot;new task&quot; mode for property editor</h3>
+<p>Set FLAG_ACTIVITY_NEW_TASK when starting the property editor, this may improve the behaviour of certain launchers when resuming the app. Default: <em>off</em></p>
 
 </body>
 </html>

--- a/src/main/java/de/blau/android/Main.java
+++ b/src/main/java/de/blau/android/Main.java
@@ -1030,6 +1030,7 @@ public class Main extends FullScreenAppCompatActivity
                     while (stack.size() > 1) {
                         logic.popSelection();
                     }
+                    handlePropertyEditorResult();
                     break;
                 default:
                     // carry on
@@ -3089,10 +3090,8 @@ public class Main extends FullScreenAppCompatActivity
             // visual state
             logic.deselectAll();
         } else {
-            // invalidate the action mode menu ... updates the state of the undo
-            // button
-            // for visual feedback reasons we leave selected elements selected
-            // (tag edit mode)
+            // invalidate the action mode menu ... updates the state of the undo button
+            // for visual feedback reasons we leave selected elements selected (tag edit mode)
             invalidateOptionsMenu();
             if (easyEditManager != null) {
                 easyEditManager.invalidate();

--- a/src/main/java/de/blau/android/prefs/Preferences.java
+++ b/src/main/java/de/blau/android/prefs/Preferences.java
@@ -134,6 +134,7 @@ public class Preferences {
     private final int         autoNameCap;
     private boolean           wayNodeDragging;
     private final boolean     splitWindowForPropertyEditor;
+    private boolean           newTaskForPropertyEditor;
     private final boolean     useImperialUnits;
     private final boolean     supportPresetLabels;
     private final int         longStringLimit;
@@ -329,6 +330,7 @@ public class Preferences {
         wayNodeDragging = prefs.getBoolean(r.getString(R.string.config_wayNodeDragging_key), false);
 
         splitWindowForPropertyEditor = prefs.getBoolean(r.getString(R.string.config_splitWindowForPropertyEditor_key), false);
+        newTaskForPropertyEditor = prefs.getBoolean(r.getString(R.string.config_newTaskForPropertyEditor_key), false);
 
         useImperialUnits = prefs.getBoolean(r.getString(R.string.config_useImperialUnits_key), false);
 
@@ -362,7 +364,7 @@ public class Preferences {
     /**
      * Check if we should prefer removable storage over built in for tiles
      * 
-     * @return true id er should prefer removable storage
+     * @return true if we should prefer removable storage
      */
     public boolean preferRemovableStorage() {
         return preferRemovableStorage;
@@ -1715,6 +1717,25 @@ public class Preferences {
      */
     public boolean useSplitWindowForPropertyEditor() {
         return splitWindowForPropertyEditor;
+    }
+
+    /**
+     * Enable or disable using FLAG_ACTIVITY_NEW_TASK for the PropertyEditor
+     * 
+     * @param enabled if true set FLAG_ACTIVITY_NEW_TASK for the PropertyEditor
+     */
+    public void setNewTaskForPropertyEditor(boolean enabled) {
+        newTaskForPropertyEditor = enabled;
+        prefs.edit().putBoolean(r.getString(R.string.config_newTaskForPropertyEditor_key), enabled).commit();
+    }
+
+    /**
+     * Check if we should set FLAG_ACTIVITY_NEW_TASK for the PropertyEditor
+     * 
+     * @return true if we should set FLAG_ACTIVITY_NEW_TASK
+     */
+    public boolean useNewTaskForPropertyEditor() {
+        return newTaskForPropertyEditor;
     }
 
     /**

--- a/src/main/res/values/prefkeys.xml
+++ b/src/main/res/values/prefkeys.xml
@@ -104,6 +104,7 @@
     <string name="config_indexMediaStore_key">indexMediaStore</string>
     <string name="config_wayNodeDragging_key">wayNodeDragging</string>
     <string name="config_splitWindowForPropertyEditor_key">splitWindowForPropertyEditor</string>
+    <string name="config_newTaskForPropertyEditor_key">newTaskForPropertyEditor</string>
     <string name="config_useImperialUnits_key">useImperialUnits</string>
     <string name="config_supportPresetLabels_key">supportPresetLabels</string>
     <string name="config_zoomWithKeys_key">zoomWithKeys</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1506,6 +1506,8 @@
     <string name="config_voiceCommandsEnabled_summary">Enable voice command support.</string>
     <string name="config_splitWindowForPropertyEditor_summary">Enable displaying the property editor in a separate window if available.</string>
     <string name="config_splitWindowForPropertyEditor_title">Enable split window property editor</string>
+    <string name="config_newTaskForPropertyEditor_summary">Set FLAG_ACTIVITY_NEW_TASK when starting the property editor, this may improve the behaviour of certain launchers when resuming the app.</string>
+    <string name="config_newTaskForPropertyEditor_title">Use \"new task\" mode for property editor</string>
     <!--  -->
     <string name="manage_apis">Manage APIs</string>
     <string name="config_api_url_title">API URL</string>

--- a/src/main/res/xml-v24/advancedpreferences.xml
+++ b/src/main/res/xml-v24/advancedpreferences.xml
@@ -749,5 +749,10 @@
             android:key="@string/config_splitWindowForPropertyEditor_key"
             android:summary="@string/config_splitWindowForPropertyEditor_summary"
             android:title="@string/config_splitWindowForPropertyEditor_title" />
+        <androidx.preference.CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/config_newTaskForPropertyEditor_key"
+            android:summary="@string/config_newTaskForPropertyEditor_summary"
+            android:title="@string/config_newTaskForPropertyEditor_title" />
     </androidx.preference.PreferenceScreen>
 </androidx.preference.PreferenceScreen>

--- a/src/main/res/xml-v29/advancedpreferences.xml
+++ b/src/main/res/xml-v29/advancedpreferences.xml
@@ -749,5 +749,10 @@
             android:key="@string/config_splitWindowForPropertyEditor_key"
             android:summary="@string/config_splitWindowForPropertyEditor_summary"
             android:title="@string/config_splitWindowForPropertyEditor_title" />
+        <androidx.preference.CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/config_newTaskForPropertyEditor_key"
+            android:summary="@string/config_newTaskForPropertyEditor_summary"
+            android:title="@string/config_newTaskForPropertyEditor_title" />
     </androidx.preference.PreferenceScreen>
 </androidx.preference.PreferenceScreen>

--- a/src/main/res/xml/advancedpreferences.xml
+++ b/src/main/res/xml/advancedpreferences.xml
@@ -744,5 +744,10 @@
             android:key="@string/config_splitWindowForPropertyEditor_key"
             android:summary="@string/config_splitWindowForPropertyEditor_summary"
             android:title="@string/config_splitWindowForPropertyEditor_title" />
+        <androidx.preference.CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/config_newTaskForPropertyEditor_key"
+            android:summary="@string/config_newTaskForPropertyEditor_summary"
+            android:title="@string/config_newTaskForPropertyEditor_title" />
     </androidx.preference.PreferenceScreen>
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
This adds a cargo-cultish workaround for faulty launcher behaviour that has plagued Android since day one and google seems to be incapable  of getting a handle on.