### PR TITLE
Use a custom view for titles of preferences

### DIFF
--- a/src/main/java/de/blau/android/prefs/ExtendedPreferenceFragment.java
+++ b/src/main/java/de/blau/android/prefs/ExtendedPreferenceFragment.java
@@ -1,8 +1,9 @@
 package de.blau.android.prefs;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import android.os.Bundle;
 import android.util.Log;
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.DialogFragment;
 import androidx.preference.ListPreference;
 import androidx.preference.MultiSelectListPreference;
@@ -16,7 +17,8 @@ import de.blau.android.util.ScreenMessage;
 
 public abstract class ExtendedPreferenceFragment extends PreferenceFragmentCompat {
 
-    protected static final String DEBUG_TAG = ExtendedPreferenceFragment.class.getSimpleName().substring(0, Math.min(23, ExtendedPreferenceFragment.class.getSimpleName().length()));
+    private static final int      TAG_LEN   = Math.min(LOG_TAG_LEN, ExtendedPreferenceFragment.class.getSimpleName().length());
+    protected static final String DEBUG_TAG = ExtendedPreferenceFragment.class.getSimpleName().substring(0, TAG_LEN);
 
     @Override
     public abstract void onCreatePreferences(Bundle savedInstanceState, String rootKey);
@@ -45,9 +47,9 @@ public abstract class ExtendedPreferenceFragment extends PreferenceFragmentCompa
      * Set the action bar title of the activity calling us to the PreferenceScreen title
      */
     protected void setTitle() {
-        AppCompatActivity activity = ((AppCompatActivity) getActivity());
+        PrefEditorActivity activity = ((PrefEditorActivity) getActivity());
         if (activity != null) {
-            activity.getSupportActionBar().setTitle(getPreferenceScreen().getTitle());
+            activity.setTitle(getPreferenceScreen().getTitle());
         }
     }
 

--- a/src/main/java/de/blau/android/prefs/PrefEditorActivity.java
+++ b/src/main/java/de/blau/android/prefs/PrefEditorActivity.java
@@ -1,10 +1,14 @@
 package de.blau.android.prefs;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.fragment.app.FragmentTransaction;
@@ -25,9 +29,12 @@ import de.blau.android.util.ThemeUtils;
  */
 public abstract class PrefEditorActivity extends ConfigurationChangeAwareActivity implements PreferenceFragmentCompat.OnPreferenceStartScreenCallback {
 
-    private static final String DEBUG_TAG = PrefEditorActivity.class.getSimpleName().substring(0, Math.min(23, PrefEditorActivity.class.getSimpleName().length()));
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, PrefEditorActivity.class.getSimpleName().length());
+    private static final String DEBUG_TAG = PrefEditorActivity.class.getSimpleName().substring(0, TAG_LEN);
 
     protected static final int MENUITEM_HELP = 1;
+
+    private TextView titleView;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -38,9 +45,25 @@ public abstract class PrefEditorActivity extends ConfigurationChangeAwareActivit
         }
         super.onCreate(savedInstanceState);
 
-        ActionBar actionbar = getSupportActionBar();
-        actionbar.setDisplayHomeAsUpEnabled(true);
+        ActionBar actionBar = getSupportActionBar();
+        actionBar.setDisplayHomeAsUpEnabled(true);
+        actionBar.setDisplayShowCustomEnabled(true);
+        actionBar.setCustomView(R.layout.actionbar_title_layout);
+        titleView = findViewById(R.id.actionbar_title);
+    }
 
+    /**
+     * Set the title in the actionbar
+     * 
+     * @param title the title to set
+     */
+    @Override
+    public void setTitle(@NonNull CharSequence title) {
+        if (titleView == null) {
+            Log.e(DEBUG_TAG, "TitleView is null");
+            return;
+        }
+        titleView.setText(title);
     }
 
     @Override

--- a/src/main/res/layout/actionbar_title_layout.xml
+++ b/src/main/res/layout/actionbar_title_layout.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+<TextView
+    android:id="@+id/actionbar_title"
+    style="@style/TextAppearance.AppCompat.Title"
+    android:layout_height="match_parent"
+    android:layout_width="wrap_content"
+    android:gravity="center_vertical"
+    android:ellipsize="end"
+    android:maxLines="2"/>
+
+</LinearLayout>


### PR DESCRIPTION
This uses a two line custom view for the title of preferences.

Resolves https://github.com/MarcusWolschon/osmeditor4android/issues/2208