### PR TITLE
Fix deleted relation members being re-highlighted

### DIFF
--- a/src/androidTest/java/de/blau/android/NewVersionTest.java
+++ b/src/androidTest/java/de/blau/android/NewVersionTest.java
@@ -101,36 +101,4 @@ public class NewVersionTest {
         assertTrue(TestUtils.clickMenuButton(device, "Back", false, true));
         assertFalse(TestUtils.findText(device, false, main.getString(R.string.upgrade_title)));
     }
-
-    /**
-     * No migration test
-     */
-    @Test
-    public void migration() {
-        KeyDatabaseHelper.readKeysFromAssets(ApplicationProvider.getApplicationContext());
-        try (KeyDatabaseHelper keyDatabase = new KeyDatabaseHelper(ApplicationProvider.getApplicationContext())) {
-            KeyDatabaseHelper.replaceOrDeleteKey(keyDatabase.getWritableDatabase(), "OpenStreetMap", EntryType.API_OAUTH2_KEY, "123456", false, false, "empty",
-                    mockServer.server().url("/").toString());
-        }
-        try (AdvancedPrefDatabase db = new AdvancedPrefDatabase(main)) {
-            API api = db.getCurrentAPI();
-            db.setAPIDescriptors(api.id, api.name, api.url, api.readonlyurl, api.notesurl, Auth.OAUTH1A);
-        }
-        NewVersion.showDialog(main);
-        assertTrue(TestUtils.findText(device, false, main.getString(R.string.upgrade_title)));
-        UiObject b2 = TestUtils.findObjectWithResourceId(device, "android:id/button1", 0);
-        try {
-            assertEquals(main.getString(R.string.migrate_now).toUpperCase(), b2.getText().toUpperCase());
-            mockServer.enqueue("200");
-            assertTrue(b2.clickAndWaitForNewWindow());
-        } catch (UiObjectNotFoundException ex) {
-            fail(ex.getMessage());
-        }
-        device.pressBack();
-        try (AdvancedPrefDatabase db = new AdvancedPrefDatabase(main)) {
-            API api = db.getCurrentAPI();
-            assertEquals(Auth.OAUTH2, api.auth);
-        }
-        TestUtils.sleep(10000);
-    }
 }

--- a/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
+++ b/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
@@ -364,7 +364,7 @@ public class PropertyEditorTest {
         TestUtils.clickText(device, true, main.getString(R.string.save), true, false);
         TestUtils.clickHome(device, true);
         try {
-            assertTrue(Integer.parseInt(direction.getText()) >= 0);
+            assertTrue(Integer.parseInt(n.getTagWithKey(Tags.KEY_DIRECTION)) >= 0);
         } catch (NumberFormatException nfex) {
             fail(nfex.getMessage());
         }

--- a/src/main/java/de/blau/android/dialogs/NewVersion.java
+++ b/src/main/java/de/blau/android/dialogs/NewVersion.java
@@ -1,26 +1,15 @@
 package de.blau.android.dialogs;
 
-import android.content.DialogInterface;
 import android.os.Bundle;
 import android.util.Log;
-import android.view.View;
-import android.widget.Button;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AlertDialog.Builder;
 import androidx.appcompat.app.AppCompatDialog;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
-import de.blau.android.App;
-import de.blau.android.Authorize;
 import de.blau.android.HelpViewer;
 import de.blau.android.R;
-import de.blau.android.contract.Urls;
-import de.blau.android.osm.Server;
-import de.blau.android.prefs.API;
-import de.blau.android.prefs.API.Auth;
-import de.blau.android.prefs.AdvancedPrefDatabase;
-import de.blau.android.prefs.Preferences;
 import de.blau.android.util.ImmersiveDialogFragment;
 import de.blau.android.util.Util;
 
@@ -77,7 +66,6 @@ public class NewVersion extends ImmersiveDialogFragment {
         final FragmentActivity activity = getActivity();
         Builder builder = new AlertDialog.Builder(getActivity());
         builder.setTitle(R.string.upgrade_title);
-        Preferences prefs = App.getPreferences(getContext());
         String message = getString(R.string.upgrade_message);
         builder.setMessage(Util.fromHtml(message));
         builder.setNegativeButton(R.string.skip, (d, which) -> dismiss());
@@ -85,7 +73,6 @@ public class NewVersion extends ImmersiveDialogFragment {
             dismiss();
             HelpViewer.start(activity, R.string.help_upgrade);
         });
-        final AlertDialog dialog = builder.create();
-        return dialog;
+        return builder.create();
     }
 }

--- a/src/main/java/de/blau/android/easyedit/EditRelationMembersActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/EditRelationMembersActionModeCallback.java
@@ -342,37 +342,9 @@ public class EditRelationMembersActionModeCallback extends BuilderActionModeCall
 
     @Override
     public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
+        Log.d(DEBUG_TAG, "onPrepareActionMode");
         setClickableElements();
-        if (relation != null) {
-            List<Way> relationWays = logic.getSelectedRelationWays();
-            List<Node> relationNodes = logic.getSelectedRelationNodes();
-            List<Relation> relationRelations = logic.getSelectedRelationRelations();
-            // new members might be downloaded
-            for (RelationMember rm : relation.getMembers()) {
-                if (!rm.downloaded()) {
-                    continue;
-                }
-                switch (rm.getType()) {
-                case Way.NAME:
-                    if (inList(relationWays, rm)) {
-                        logic.addSelectedRelationWay((Way) rm.getElement());
-                    }
-                    break;
-                case Node.NAME:
-                    if (inList(relationNodes, rm)) {
-                        logic.addSelectedRelationNode((Node) rm.getElement());
-                    }
-                    break;
-                case Relation.NAME:
-                    if (inList(relationRelations, rm)) {
-                        logic.addSelectedRelationRelation((Relation) rm.getElement());
-                    }
-                    break;
-                default:
-                    // do nothing
-                }
-            }
-        }
+        highlightAll();
         menu = replaceMenu(menu, mode, this);
         boolean updated = super.onPrepareActionMode(mode, menu);
         updated |= ElementSelectionActionModeCallback.setItemVisibility(!newMembers.isEmpty(), revertItem, false);
@@ -380,17 +352,6 @@ public class EditRelationMembersActionModeCallback extends BuilderActionModeCall
             arrangeMenu(menu);
         }
         return updated;
-    }
-
-    /**
-     * A "contains" that checks if the List is null
-     * 
-     * @param list the List
-     * @param rm the RelationMember
-     * @return true if the element of the memer is present in the list
-     */
-    private <T extends OsmElement> boolean inList(@Nullable List<T> list, @NonNull RelationMember rm) {
-        return list != null && !list.contains(rm.getElement());
     }
 
     @Override


### PR DESCRIPTION
Dragging the map invalidates any active EasyEditActionModes causing onPrepareActionMode to be called, in the case of the EditRelationMembersActionModeCallback this caused the members to be highlighted without considering the deleted members.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/2582