### PR TITLE
Catch OOM when (re-)creating the current presets object

### DIFF
--- a/src/main/java/de/blau/android/App.java
+++ b/src/main/java/de/blau/android/App.java
@@ -59,6 +59,7 @@ import de.blau.android.util.FileUtil;
 import de.blau.android.util.GeoContext;
 import de.blau.android.util.NotificationCache;
 import de.blau.android.util.SavingHelper;
+import de.blau.android.util.ScreenMessage;
 import de.blau.android.util.TagClipboard;
 import de.blau.android.util.Util;
 import de.blau.android.util.collections.MultiHashMap;
@@ -310,13 +311,18 @@ public class App extends Application implements android.app.Application.Activity
     public static Preset[] getCurrentPresets(@NonNull Context ctx) {
         synchronized (currentPresetsLock) {
             if (currentPresets == null) {
-                currentPresets = getPreferences(ctx).getPreset();
-                mruTags = new MRUTags();
-                mruTags.load(ctx);
-                if (logic != null && logic.getFilter() instanceof PresetFilter) {
-                    // getCurrentPresets will be called if the presets have been
-                    // changed and the preset need to be re-referenced
-                    logic.getFilter().init(ctx);
+                try {
+                    Util.clearDataLayerIconCaches(false);
+                    currentPresets = getPreferences(ctx).getPreset();
+                    mruTags = new MRUTags();
+                    mruTags.load(ctx);
+                    if (logic != null && logic.getFilter() instanceof PresetFilter) {
+                        // getCurrentPresets will be called if the presets have been
+                        // changed and the preset need to be re-referenced
+                        logic.getFilter().init(ctx);
+                    }
+                } catch (OutOfMemoryError oome) {
+                    Util.runOnUiThread(ctx, () -> ScreenMessage.toastTopError(ctx, R.string.out_of_memory_title));
                 }
             }
             return currentPresets;

--- a/src/main/java/de/blau/android/dialogs/bookmarks/BookmarksDialog.java
+++ b/src/main/java/de/blau/android/dialogs/bookmarks/BookmarksDialog.java
@@ -21,6 +21,7 @@ import de.blau.android.bookmarks.BookmarkStorage;
 import de.blau.android.layer.bookmarks.MapOverlay;
 import de.blau.android.util.ScreenMessage;
 import de.blau.android.util.ThemeUtils;
+import de.blau.android.util.Util;
 
 /**
  * Display a dialog showing the saved bookmarks
@@ -130,9 +131,7 @@ public class BookmarksDialog implements BookmarkListAdapter.Listeners {
 
             @Override
             public void onError(Context context) {
-                if (context instanceof Activity) {
-                    ((Activity) context).runOnUiThread(() -> ScreenMessage.toastTopError(context, R.string.toast_error_saving_bookmark));
-                }
+                Util.runOnUiThread(context, () -> ScreenMessage.toastTopError(context, R.string.toast_error_saving_bookmark));
             }
         });
 

--- a/src/main/java/de/blau/android/layer/geojson/MapOverlay.java
+++ b/src/main/java/de/blau/android/layer/geojson/MapOverlay.java
@@ -32,7 +32,6 @@ import com.mapbox.geojson.Polygon;
 import com.mapbox.turf.TurfException;
 import com.mapbox.turf.TurfJoins;
 
-import android.app.Activity;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Paint;
@@ -78,6 +77,7 @@ import de.blau.android.util.GeoMath;
 import de.blau.android.util.SavingHelper;
 import de.blau.android.util.ScreenMessage;
 import de.blau.android.util.SerializableTextPaint;
+import de.blau.android.util.Util;
 import de.blau.android.util.collections.FloatPrimitiveList;
 import de.blau.android.util.rtree.BoundedObject;
 import de.blau.android.util.rtree.RTree;
@@ -524,32 +524,20 @@ public class MapOverlay extends StyleableFileLayer
             }
         } catch (OutOfMemoryError oom) {
             data = null;
-            runOnUiThread(ctx, () -> ScreenMessage.toastTopError(ctx, R.string.out_of_memory_title));
+            Util.runOnUiThread(ctx, () -> ScreenMessage.toastTopError(ctx, R.string.out_of_memory_title));
             Log.e(DEBUG_TAG, "Out of memory error " + oom.getMessage());
         } catch (com.google.gson.JsonSyntaxException jsex) {
-            runOnUiThread(ctx, () -> ScreenMessage.toastTopError(ctx, jsex.getLocalizedMessage()));
+            Util.runOnUiThread(ctx, () -> ScreenMessage.toastTopError(ctx, jsex.getLocalizedMessage()));
             Log.e(DEBUG_TAG, "Syntax error " + jsex.getMessage());
         } catch (Exception e) {
             // never crash
             data = null;
-            runOnUiThread(ctx, () -> ScreenMessage.toastTopError(ctx, e.getLocalizedMessage()));
+            Util.runOnUiThread(ctx, () -> ScreenMessage.toastTopError(ctx, e.getLocalizedMessage()));
             Log.e(DEBUG_TAG, "Exception " + e.getMessage());
         }
         // re-enable drawing
         setVisible(true);
         return successful;
-    }
-
-    /**
-     * Run action on the UI thread
-     * 
-     * @param ctx an Android Context
-     * @param action the runnable
-     */
-    private void runOnUiThread(@NonNull Context ctx, @NonNull final Runnable action) {
-        if (ctx instanceof Activity) {
-            ((Activity) ctx).runOnUiThread(action);
-        }
     }
 
     /**

--- a/src/main/java/de/blau/android/util/Util.java
+++ b/src/main/java/de/blau/android/util/Util.java
@@ -508,6 +508,16 @@ public final class Util {
                 p.clearIcons();
             }
         }
+        clearDataLayerIconCaches(true);
+        TileLayerSource.clearLogos();
+    }
+
+    /**
+     * Clear the icon caches in the data layer if it exists
+     * 
+     * @param invalidate invalidate the layer after clearing the caches
+     */
+    public static void clearDataLayerIconCaches(boolean invalidate) {
         Logic logic = App.getLogic();
         if (logic != null) {
             de.blau.android.Map map = logic.getMap();
@@ -515,11 +525,12 @@ public final class Util {
                 de.blau.android.layer.data.MapOverlay<OsmElement> dataLayer = map.getDataLayer();
                 if (dataLayer != null) {
                     dataLayer.clearCaches();
-                    dataLayer.invalidate();
+                    if (invalidate) {
+                        dataLayer.invalidate();
+                    }
                 }
             }
         }
-        TileLayerSource.clearLogos();
     }
 
     /**
@@ -922,5 +933,17 @@ public final class Util {
      */
     public static boolean isInMultiWindowModeCompat(@NonNull FragmentActivity activity) {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && activity.isInMultiWindowMode();
+    }
+
+    /**
+     * Run action on the UI thread
+     * 
+     * @param ctx an Android Context
+     * @param action the runnable
+     */
+    public static void runOnUiThread(@NonNull Context ctx, @NonNull final Runnable action) {
+        if (ctx instanceof Activity) {
+            ((Activity) ctx).runOnUiThread(action);
+        }
     }
 }


### PR DESCRIPTION
This stops crashing due to the OOM, but this is naturally still fatal. Clearing the data layer caches before recreating the presets may help with avoiding this in the first place.

See https://github.com/MarcusWolschon/osmeditor4android/issues/2614#issuecomment-2219787100