### PR TITLE
Bump API target in build script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -276,7 +276,7 @@ android {
             dimension "api"
             multiDexEnabled true
             minSdkVersion 21
-            targetSdkVersion 33
+            targetSdkVersion 34
             applicationIdSuffix ""
             versionNameSuffix ""
             resValue "string", "content_provider", "de.blau.android.provider"

--- a/src/test/java/de/blau/android/BookmarkStorageTest.java
+++ b/src/test/java/de/blau/android/BookmarkStorageTest.java
@@ -18,7 +18,7 @@ import de.blau.android.bookmarks.Bookmark;
 import de.blau.android.osm.ViewBox;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowWorkManager.class })
+@Config(shadows = { ShadowWorkManager.class }, sdk=33)
 public class BookmarkStorageTest {
     Context         context;
     Activity        activity;

--- a/src/test/java/de/blau/android/LogicTest.java
+++ b/src/test/java/de/blau/android/LogicTest.java
@@ -19,7 +19,7 @@ import de.blau.android.osm.OsmElement;
 import de.blau.android.osm.Way;
 import de.blau.android.util.Util;
 
-@Config(shadows = { ShadowWorkManager.class })
+@Config(shadows = { ShadowWorkManager.class }, sdk=33)
 @RunWith(RobolectricTestRunner.class)
 @LargeTest
 public class LogicTest {

--- a/src/test/java/de/blau/android/MapTest.java
+++ b/src/test/java/de/blau/android/MapTest.java
@@ -12,6 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import android.database.sqlite.SQLiteDatabase;
 import androidx.test.core.app.ApplicationProvider;
@@ -25,6 +26,7 @@ import de.blau.android.resources.TileLayerDatabase;
 import de.blau.android.resources.TileLayerSource;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class MapTest {
 

--- a/src/test/java/de/blau/android/MigrationTest.java
+++ b/src/test/java/de/blau/android/MigrationTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
@@ -17,6 +18,7 @@ import de.blau.android.contract.Paths;
 import de.blau.android.util.FileUtil;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 public class MigrationTest {
     private static final String TEST_STYLE = "test-style.xml";
     private static final String TEST_JPG   = "test.jpg";

--- a/src/test/java/de/blau/android/SaveLoadStateTest.java
+++ b/src/test/java/de/blau/android/SaveLoadStateTest.java
@@ -16,7 +16,7 @@ import de.blau.android.osm.Storage;
 import de.blau.android.osm.StorageDelegator;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowWorkManager.class })
+@Config(shadows = { ShadowWorkManager.class }, sdk=33)
 @LargeTest
 public class SaveLoadStateTest {
     Main    main    = null;

--- a/src/test/java/de/blau/android/SelectionTest.java
+++ b/src/test/java/de/blau/android/SelectionTest.java
@@ -17,7 +17,7 @@ import de.blau.android.osm.StorageDelegator;
 import de.blau.android.osm.Way;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowWorkManager.class })
+@Config(shadows = { ShadowWorkManager.class }, sdk=33)
 public class SelectionTest {
     Context  context;
 

--- a/src/test/java/de/blau/android/address/PredictionTest.java
+++ b/src/test/java/de/blau/android/address/PredictionTest.java
@@ -43,7 +43,7 @@ import de.blau.android.util.StreetPlaceNamesAdapter;
 import de.blau.android.util.Util;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowWorkManager.class })
+@Config(shadows = { ShadowWorkManager.class }, sdk=33)
 @LargeTest
 public class PredictionTest {
 

--- a/src/test/java/de/blau/android/filter/IndoorFilterTest.java
+++ b/src/test/java/de/blau/android/filter/IndoorFilterTest.java
@@ -31,7 +31,7 @@ import de.blau.android.osm.Way;
  *
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowWorkManager.class })
+@Config(shadows = { ShadowWorkManager.class }, sdk=33)
 @LargeTest
 public class IndoorFilterTest {
 

--- a/src/test/java/de/blau/android/filter/TagFilterTest.java
+++ b/src/test/java/de/blau/android/filter/TagFilterTest.java
@@ -35,7 +35,7 @@ import de.blau.android.osm.Way;
  *
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowWorkManager.class })
+@Config(shadows = { ShadowWorkManager.class }, sdk=33)
 @LargeTest
 public class TagFilterTest {
 

--- a/src/test/java/de/blau/android/layer/LayerDBTest.java
+++ b/src/test/java/de/blau/android/layer/LayerDBTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
@@ -16,6 +17,7 @@ import androidx.test.filters.LargeTest;
 import de.blau.android.prefs.AdvancedPrefDatabase;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class LayerDBTest {
 

--- a/src/test/java/de/blau/android/layer/data/LayerComparatorTest.java
+++ b/src/test/java/de/blau/android/layer/data/LayerComparatorTest.java
@@ -9,6 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import androidx.test.filters.LargeTest;
 import de.blau.android.UnitTestUtils;
@@ -18,6 +19,7 @@ import de.blau.android.osm.Tags;
 import de.blau.android.osm.Way;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class LayerComparatorTest {
 

--- a/src/test/java/de/blau/android/net/OAuth2Test.java
+++ b/src/test/java/de/blau/android/net/OAuth2Test.java
@@ -37,7 +37,7 @@ import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.RecordedRequest;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowWorkManager.class })
+@Config(shadows = { ShadowWorkManager.class }, sdk=33)
 @LargeTest
 public class OAuth2Test {
 

--- a/src/test/java/de/blau/android/nsi/NamesTest.java
+++ b/src/test/java/de/blau/android/nsi/NamesTest.java
@@ -11,6 +11,7 @@ import java.util.TreeMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.filters.LargeTest;
@@ -20,6 +21,7 @@ import de.blau.android.util.SearchIndexUtils;
 import de.blau.android.util.collections.MultiHashMap;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class NamesTest {
 

--- a/src/test/java/de/blau/android/osm/ApiErrorTest.java
+++ b/src/test/java/de/blau/android/osm/ApiErrorTest.java
@@ -38,7 +38,7 @@ import de.blau.android.prefs.Preferences;
 import okhttp3.HttpUrl;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowWorkManager.class })
+@Config(shadows = { ShadowWorkManager.class }, sdk=33)
 @LargeTest
 public class ApiErrorTest {
 

--- a/src/test/java/de/blau/android/osm/ApiResponseTest.java
+++ b/src/test/java/de/blau/android/osm/ApiResponseTest.java
@@ -9,10 +9,12 @@ import java.net.HttpURLConnection;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import androidx.test.filters.LargeTest;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class ApiResponseTest {
 

--- a/src/test/java/de/blau/android/osm/ApiTest.java
+++ b/src/test/java/de/blau/android/osm/ApiTest.java
@@ -49,7 +49,7 @@ import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.RecordedRequest;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowWorkManager.class })
+@Config(shadows = { ShadowWorkManager.class }, sdk=33)
 @LargeTest
 public class ApiTest {
 

--- a/src/test/java/de/blau/android/osm/BasicStuffTest.java
+++ b/src/test/java/de/blau/android/osm/BasicStuffTest.java
@@ -25,7 +25,7 @@ import de.blau.android.SignalHandler;
 import de.blau.android.exception.OsmIllegalOperationException;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowWorkManager.class })
+@Config(shadows = { ShadowWorkManager.class }, sdk=33)
 @LargeTest
 public class BasicStuffTest {
 

--- a/src/test/java/de/blau/android/osm/DiscardedTagsTest.java
+++ b/src/test/java/de/blau/android/osm/DiscardedTagsTest.java
@@ -10,11 +10,13 @@ import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.filters.LargeTest;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class DiscardedTagsTest {
 

--- a/src/test/java/de/blau/android/osm/GpxApiTest.java
+++ b/src/test/java/de/blau/android/osm/GpxApiTest.java
@@ -13,6 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import com.orhanobut.mockwebserverplus.MockWebServerPlus;
 
@@ -27,6 +28,7 @@ import de.blau.android.prefs.Preferences;
 import okhttp3.HttpUrl;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class GpxApiTest {
 

--- a/src/test/java/de/blau/android/osm/MiscApiTest.java
+++ b/src/test/java/de/blau/android/osm/MiscApiTest.java
@@ -30,7 +30,7 @@ import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.RecordedRequest;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowWorkManager.class })
+@Config(shadows = { ShadowWorkManager.class }, sdk=33)
 @LargeTest
 public class MiscApiTest {
 

--- a/src/test/java/de/blau/android/osm/NotesApiTest.java
+++ b/src/test/java/de/blau/android/osm/NotesApiTest.java
@@ -46,7 +46,7 @@ import de.blau.android.tasks.TransferTasks;
 import okhttp3.HttpUrl;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowWorkManager.class })
+@Config(shadows = { ShadowWorkManager.class }, sdk=33)
 @LargeTest
 public class NotesApiTest {
 

--- a/src/test/java/de/blau/android/osm/OscTest.java
+++ b/src/test/java/de/blau/android/osm/OscTest.java
@@ -13,6 +13,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 import org.xml.sax.SAXException;
 
 import androidx.test.core.app.ApplicationProvider;
@@ -21,6 +22,7 @@ import de.blau.android.OscTestCommon;
 import de.blau.android.util.SavingHelper;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class OscTest {
 

--- a/src/test/java/de/blau/android/osm/OverpassApiTest.java
+++ b/src/test/java/de/blau/android/osm/OverpassApiTest.java
@@ -46,7 +46,7 @@ import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.RecordedRequest;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowWorkManager.class })
+@Config(shadows = { ShadowWorkManager.class }, sdk=33)
 @LargeTest
 public class OverpassApiTest {
 

--- a/src/test/java/de/blau/android/osm/RelationUtilTest.java
+++ b/src/test/java/de/blau/android/osm/RelationUtilTest.java
@@ -15,6 +15,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import android.util.Log;
 import androidx.annotation.NonNull;
@@ -24,6 +25,7 @@ import de.blau.android.UnitTestUtils;
 import de.blau.android.util.Util;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class RelationUtilTest {
 

--- a/src/test/java/de/blau/android/osm/StorageDelegatorRoboelectricTest.java
+++ b/src/test/java/de/blau/android/osm/StorageDelegatorRoboelectricTest.java
@@ -9,6 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import android.view.ViewGroup.LayoutParams;
 import androidx.annotation.NonNull;
@@ -18,6 +19,7 @@ import de.blau.android.App;
 import de.blau.android.Map;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class StorageDelegatorRoboelectricTest {
 

--- a/src/test/java/de/blau/android/osm/StorageDelegatorTest.java
+++ b/src/test/java/de/blau/android/osm/StorageDelegatorTest.java
@@ -19,6 +19,7 @@ import java.util.TreeMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.filters.LargeTest;
@@ -33,6 +34,7 @@ import de.blau.android.util.Geometry;
 import de.blau.android.util.Util;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class StorageDelegatorTest {
 

--- a/src/test/java/de/blau/android/osm/StorageTest.java
+++ b/src/test/java/de/blau/android/osm/StorageTest.java
@@ -12,12 +12,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import android.util.Log;
 import androidx.test.filters.LargeTest;
 import de.blau.android.exception.OsmException;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class StorageTest {
 

--- a/src/test/java/de/blau/android/osm/UndoStorageTest.java
+++ b/src/test/java/de/blau/android/osm/UndoStorageTest.java
@@ -12,6 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.filters.LargeTest;
@@ -22,6 +23,7 @@ import de.blau.android.osm.UndoStorage.UndoWay;
 import de.blau.android.util.Util;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class UndoStorageTest {
 

--- a/src/test/java/de/blau/android/osm/ViewBoxTest.java
+++ b/src/test/java/de/blau/android/osm/ViewBoxTest.java
@@ -20,7 +20,7 @@ import de.blau.android.Map;
 import de.blau.android.ShadowWorkManager;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowWorkManager.class })
+@Config(shadows = { ShadowWorkManager.class }, sdk=33)
 @LargeTest
 public class ViewBoxTest {
 

--- a/src/test/java/de/blau/android/osm/WayTest.java
+++ b/src/test/java/de/blau/android/osm/WayTest.java
@@ -15,11 +15,13 @@ import java.util.TreeMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import androidx.test.filters.LargeTest;
 import de.blau.android.osm.OsmElement.ElementType;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class WayTest {
 

--- a/src/test/java/de/blau/android/osm/XmlTest.java
+++ b/src/test/java/de/blau/android/osm/XmlTest.java
@@ -18,6 +18,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 import org.xml.sax.SAXException;
 import org.xmlpull.v1.XmlPullParserException;
 
@@ -25,6 +26,7 @@ import androidx.test.filters.LargeTest;
 import de.blau.android.util.Hash;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class XmlTest {
 

--- a/src/test/java/de/blau/android/prefs/AdvancedPrefDatabaseTest.java
+++ b/src/test/java/de/blau/android/prefs/AdvancedPrefDatabaseTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNull;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
@@ -15,6 +16,7 @@ import androidx.test.filters.LargeTest;
 import de.blau.android.prefs.API.Auth;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class AdvancedPrefDatabaseTest {
 

--- a/src/test/java/de/blau/android/prefs/PreferenceTest.java
+++ b/src/test/java/de/blau/android/prefs/PreferenceTest.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.filters.SmallTest;
@@ -15,6 +16,7 @@ import de.blau.android.R;
  *
  */
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @SmallTest
 public class PreferenceTest {
 

--- a/src/test/java/de/blau/android/presets/PresetTest.java
+++ b/src/test/java/de/blau/android/presets/PresetTest.java
@@ -30,6 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowContentResolver;
 import org.xml.sax.SAXException;
 
@@ -57,6 +58,7 @@ import de.blau.android.util.SearchIndexUtils;
  *
  */
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class PresetTest {
 

--- a/src/test/java/de/blau/android/presets/SynonymsTest.java
+++ b/src/test/java/de/blau/android/presets/SynonymsTest.java
@@ -25,7 +25,7 @@ import de.blau.android.util.SearchIndexUtils;
  *
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowWorkManager.class })
+@Config(shadows = { ShadowWorkManager.class }, sdk=33)
 @LargeTest
 public class SynonymsTest {
     

--- a/src/test/java/de/blau/android/presets/TaginfoDump.java
+++ b/src/test/java/de/blau/android/presets/TaginfoDump.java
@@ -7,6 +7,7 @@ import java.io.File;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import android.content.Context;
 import android.net.Uri;
@@ -23,6 +24,7 @@ import de.blau.android.prefs.PresetLoader;
  *
  */
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class TaginfoDump { // NOSONAR
 

--- a/src/test/java/de/blau/android/propertyeditor/PropertyEditorDataTest.java
+++ b/src/test/java/de/blau/android/propertyeditor/PropertyEditorDataTest.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import androidx.test.filters.LargeTest;
 import de.blau.android.App;
@@ -24,6 +25,7 @@ import de.blau.android.osm.StorageDelegator;
 import de.blau.android.osm.Way;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class PropertyEditorDataTest {
 

--- a/src/test/java/de/blau/android/resources/DataStyleTest.java
+++ b/src/test/java/de/blau/android/resources/DataStyleTest.java
@@ -15,6 +15,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.filters.LargeTest;
@@ -28,6 +29,7 @@ import de.blau.android.osm.Way;
 import de.blau.android.resources.DataStyle.FeatureStyle;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class DataStyleTest {
 

--- a/src/test/java/de/blau/android/resources/EliTest.java
+++ b/src/test/java/de/blau/android/resources/EliTest.java
@@ -14,6 +14,7 @@ import java.nio.charset.Charset;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import androidx.annotation.NonNull;
 import androidx.test.filters.LargeTest;
@@ -23,6 +24,7 @@ import de.blau.android.util.FileUtil;
 import de.blau.android.util.Version;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class EliTest {
 

--- a/src/test/java/de/blau/android/resources/ImageryOffsetIdTest.java
+++ b/src/test/java/de/blau/android/resources/ImageryOffsetIdTest.java
@@ -8,10 +8,12 @@ import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import androidx.test.filters.LargeTest;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class ImageryOffsetIdTest {
 // @formatter:off

--- a/src/test/java/de/blau/android/resources/KeyDatabaseTest.java
+++ b/src/test/java/de/blau/android/resources/KeyDatabaseTest.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.filters.LargeTest;
@@ -20,6 +21,7 @@ import de.blau.android.prefs.API.Auth;
 import de.blau.android.resources.KeyDatabaseHelper.EntryType;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class KeyDatabaseTest {
 

--- a/src/test/java/de/blau/android/resources/MapTileTesterTest.java
+++ b/src/test/java/de/blau/android/resources/MapTileTesterTest.java
@@ -35,7 +35,7 @@ import okhttp3.mockwebserver.MockWebServer;
  *
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowWorkManager.class, ShadowSQLiteStatement.class, ShadowSQLiteProgram.class, ShadowSQLiteCloseable.class })
+@Config(shadows = { ShadowWorkManager.class, ShadowSQLiteStatement.class, ShadowSQLiteProgram.class, ShadowSQLiteCloseable.class }, sdk=33)
 @LargeTest
 public class MapTileTesterTest {
 

--- a/src/test/java/de/blau/android/resources/TileLayerServerTest.java
+++ b/src/test/java/de/blau/android/resources/TileLayerServerTest.java
@@ -40,7 +40,7 @@ import okio.Buffer;
  *
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowWorkManager.class })
+@Config(shadows = { ShadowWorkManager.class }, sdk=33)
 @LargeTest
 public class TileLayerServerTest {
 

--- a/src/test/java/de/blau/android/resources/TileLayerSourceTest.java
+++ b/src/test/java/de/blau/android/resources/TileLayerSourceTest.java
@@ -37,7 +37,7 @@ import okhttp3.mockwebserver.MockResponse;
 import okio.Buffer;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowWorkManager.class })
+@Config(shadows = { ShadowWorkManager.class }, sdk=33)
 @LargeTest
 public class TileLayerSourceTest {
     TileLayerDatabase db;

--- a/src/test/java/de/blau/android/search/WrapperTest.java
+++ b/src/test/java/de/blau/android/search/WrapperTest.java
@@ -38,7 +38,7 @@ import de.blau.android.presets.PresetItem;
 import de.blau.android.util.Util;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowWorkManager.class })
+@Config(shadows = { ShadowWorkManager.class }, sdk=33)
 @LargeTest
 public class WrapperTest {
 

--- a/src/test/java/de/blau/android/services/util/ExtendedLocationTest.java
+++ b/src/test/java/de/blau/android/services/util/ExtendedLocationTest.java
@@ -6,12 +6,14 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import android.location.LocationManager;
 import android.os.Parcel;
 import androidx.test.filters.LargeTest;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class ExtendedLocationTest {
 

--- a/src/test/java/de/blau/android/services/util/MBTMapTileFilesystemProviderTest.java
+++ b/src/test/java/de/blau/android/services/util/MBTMapTileFilesystemProviderTest.java
@@ -30,7 +30,7 @@ import de.blau.android.views.util.MapTileProviderCallback;
 import okhttp3.mockwebserver.MockWebServer;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowSQLiteStatement.class, ShadowSQLiteProgram.class, ShadowSQLiteCloseable.class })
+@Config(shadows = { ShadowSQLiteStatement.class, ShadowSQLiteProgram.class, ShadowSQLiteCloseable.class }, sdk=33)
 @LargeTest
 public class MBTMapTileFilesystemProviderTest {
 

--- a/src/test/java/de/blau/android/services/util/MapTileFilesystemProviderLocalTest.java
+++ b/src/test/java/de/blau/android/services/util/MapTileFilesystemProviderLocalTest.java
@@ -31,7 +31,7 @@ import de.blau.android.util.FileUtil;
 import de.blau.android.views.util.MapTileProviderCallback;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowSQLiteStatement.class, ShadowSQLiteProgram.class, ShadowSQLiteCloseable.class })
+@Config(shadows = { ShadowSQLiteStatement.class, ShadowSQLiteProgram.class, ShadowSQLiteCloseable.class }, sdk=33)
 @LargeTest
 public class MapTileFilesystemProviderLocalTest {
 

--- a/src/test/java/de/blau/android/services/util/MapTileFilesystemProviderTest.java
+++ b/src/test/java/de/blau/android/services/util/MapTileFilesystemProviderTest.java
@@ -37,7 +37,7 @@ import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowSQLiteStatement.class, ShadowSQLiteProgram.class, ShadowSQLiteCloseable.class })
+@Config(shadows = { ShadowSQLiteStatement.class, ShadowSQLiteProgram.class, ShadowSQLiteCloseable.class }, sdk=33)
 @LargeTest
 public class MapTileFilesystemProviderTest {
 

--- a/src/test/java/de/blau/android/services/util/MapTileProviderDataBaseTest.java
+++ b/src/test/java/de/blau/android/services/util/MapTileProviderDataBaseTest.java
@@ -24,7 +24,7 @@ import de.blau.android.exception.InvalidTileException;
 import de.blau.android.services.exceptions.EmptyCacheException;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowSQLiteStatement.class, ShadowSQLiteProgram.class, ShadowSQLiteCloseable.class })
+@Config(shadows = { ShadowSQLiteStatement.class, ShadowSQLiteProgram.class, ShadowSQLiteCloseable.class }, sdk=33)
 @LargeTest
 public class MapTileProviderDataBaseTest {
 

--- a/src/test/java/de/blau/android/util/BentleyOttmannForOsmTest.java
+++ b/src/test/java/de/blau/android/util/BentleyOttmannForOsmTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import androidx.test.filters.LargeTest;
 import de.blau.android.App;
@@ -18,6 +19,7 @@ import de.blau.android.osm.StorageDelegator;
 import de.blau.android.osm.Way;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class BentleyOttmannForOsmTest {
 

--- a/src/test/java/de/blau/android/util/BrokenAndroidTest.java
+++ b/src/test/java/de/blau/android/util/BrokenAndroidTest.java
@@ -7,11 +7,13 @@ import static org.junit.Assert.assertNull;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.filters.LargeTest;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class BrokenAndroidTest {
 

--- a/src/test/java/de/blau/android/util/ExecutorTaskTest.java
+++ b/src/test/java/de/blau/android/util/ExecutorTaskTest.java
@@ -17,6 +17,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import android.os.Looper;
 import androidx.test.filters.LargeTest;
@@ -24,6 +25,7 @@ import de.blau.android.App;
 import de.blau.android.Logic;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class ExecutorTaskTest {
 

--- a/src/test/java/de/blau/android/util/GeoContextTest.java
+++ b/src/test/java/de/blau/android/util/GeoContextTest.java
@@ -12,6 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.filters.LargeTest;
@@ -23,6 +24,7 @@ import de.blau.android.osm.Node;
 import de.blau.android.osm.Way;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class GeoContextTest {
 

--- a/src/test/java/de/blau/android/util/GeometryTest.java
+++ b/src/test/java/de/blau/android/util/GeometryTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import de.blau.android.App;
 import de.blau.android.osm.Node;
@@ -17,6 +18,7 @@ import de.blau.android.osm.StorageDelegator;
 import de.blau.android.osm.Way;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 public class GeometryTest {
 
     /**

--- a/src/test/java/de/blau/android/util/collections/LowAllocArrayListTest.java
+++ b/src/test/java/de/blau/android/util/collections/LowAllocArrayListTest.java
@@ -10,10 +10,12 @@ import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import androidx.test.filters.LargeTest;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class LowAllocArrayListTest {
 

--- a/src/test/java/de/blau/android/util/mvt/ColorTest.java
+++ b/src/test/java/de/blau/android/util/mvt/ColorTest.java
@@ -5,12 +5,14 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import androidx.test.filters.LargeTest;
 import de.blau.android.util.IntegerUtil;
 import de.blau.android.util.mvt.style.Color;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class ColorTest {
 

--- a/src/test/java/de/blau/android/util/mvt/style/CollisionDetectionTest.java
+++ b/src/test/java/de/blau/android/util/mvt/style/CollisionDetectionTest.java
@@ -6,11 +6,13 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import android.graphics.Rect;
 import androidx.test.filters.LargeTest;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class CollisionDetectionTest {
 

--- a/src/test/java/de/blau/android/util/mvt/style/ExpressionTest.java
+++ b/src/test/java/de/blau/android/util/mvt/style/ExpressionTest.java
@@ -12,6 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import com.google.gson.JsonArray;
 import com.mapbox.geojson.Point;
@@ -22,6 +23,7 @@ import de.blau.android.resources.DataStyle;
 import de.blau.android.util.mvt.VectorTileDecoder;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class ExpressionTest {
 

--- a/src/test/java/de/blau/android/util/mvt/style/FilterTest.java
+++ b/src/test/java/de/blau/android/util/mvt/style/FilterTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import com.google.gson.JsonArray;
 import com.mapbox.geojson.Point;
@@ -20,6 +21,7 @@ import de.blau.android.resources.DataStyle;
 import de.blau.android.util.mvt.VectorTileDecoder;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class FilterTest {
 

--- a/src/test/java/de/blau/android/util/mvt/style/StyleTest.java
+++ b/src/test/java/de/blau/android/util/mvt/style/StyleTest.java
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
@@ -23,6 +24,7 @@ import de.blau.android.resources.DataStyle;
 import de.blau.android.util.GeoMath;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk=33)
 @LargeTest
 public class StyleTest {
 

--- a/src/test/java/de/blau/android/validation/BaseValidatorTest.java
+++ b/src/test/java/de/blau/android/validation/BaseValidatorTest.java
@@ -35,7 +35,7 @@ import de.blau.android.prefs.Preferences;
 import de.blau.android.resources.DataStyle;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowWorkManager.class })
+@Config(shadows = { ShadowWorkManager.class }, sdk=33)
 @LargeTest
 public class BaseValidatorTest {
 

--- a/src/test/java/de/blau/android/validation/ExtendedValidatorTest.java
+++ b/src/test/java/de/blau/android/validation/ExtendedValidatorTest.java
@@ -27,7 +27,7 @@ import de.blau.android.osm.Tags;
 import de.blau.android.osm.Way;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowWorkManager.class })
+@Config(shadows = { ShadowWorkManager.class }, sdk=33)
 @LargeTest
 public class ExtendedValidatorTest {
 

--- a/src/test/java/de/blau/android/validation/ValidatorTest.java
+++ b/src/test/java/de/blau/android/validation/ValidatorTest.java
@@ -53,7 +53,7 @@ import de.blau.android.presets.Preset;
  *
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = { ShadowWorkManager.class })
+@Config(shadows = { ShadowWorkManager.class }, sdk=33)
 @LargeTest
 public class ValidatorTest {
 


### PR DESCRIPTION
Effects of this should largely be limited to image selection according to https://developer.android.com/about/versions/14/changes/partial-photo-video-access However, as normal, google contradicts itself in the document and is very unclear if the compatible mode it supposedly uses will go away at some time in the future and if it is any different to the previous behaviour. In any case at least on Android 14 emulators there currently doesn't seem to be any impact.

Resolves: https://github.com/MarcusWolschon/osmeditor4android/issues/2595