### PR TITLE
Parse 409 with changeset locked message

### DIFF
--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -4378,11 +4378,13 @@ public class Logic {
                                 this.execute(); // restart new changeset will be opened automatically
                                 return;
                             } else if (conflict instanceof ApiResponse.BoundingBoxTooLargeError) {
-                                if (!closeOpenChangeset) { 
+                                if (!closeOpenChangeset) {
                                     // we've potentially already uploaded something, so don't reuse this changeset
                                     server.resetChangeset();
                                 }
                                 ErrorAlert.showDialog(activity, ErrorCodes.UPLOAD_BOUNDING_BOX_TOO_LARGE, result.getMessage());
+                            } else if (conflict instanceof ApiResponse.ChangesetLocked) {
+                                ErrorAlert.showDialog(activity, ErrorCodes.UPLOAD_PROBLEM, result.getMessage());
                             } else {
                                 UploadConflict.showDialog(activity, conflict);
                             }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
     <string name="transfer_download_current_download">Discard &amp; download</string>
     <string name="transfer_download_current_back">Back (don\'t do anything)</string>
     <string name="upload_problem_title">Could not upload</string>
-    <string name="upload_problem_message">Some or all the data was not uploaded. Try again later.</string>
+    <string name="upload_problem_message">Some of or all the data was not uploaded. Try again later.</string>
     <string name="bad_request_message">The API responded with an error, please save your data and report the issue:\n\n</string>
     <!-- Upload conflict -->
     <string name="upload_conflict_title">Upload conflict</string>

--- a/src/test/java/de/blau/android/osm/ApiResponseTest.java
+++ b/src/test/java/de/blau/android/osm/ApiResponseTest.java
@@ -50,6 +50,8 @@ public class ApiResponseTest {
     private static final String ERROR_MESSAGE_CLOSED_CHANGESET = "The changeset 123456 was closed at 2022-01-12T06:06:08.";
     
     private static final String ERROR_MESSAGE_BOUNDING_BOX_TOO_LARGE = "Changeset bounding box size limit exceeded.";
+    
+    private static final String ERROR_MESSAGE_CHANGESET_LOCKED = "Changeset 123456 is currently locked by another process.";
 
     /**
      */
@@ -252,6 +254,15 @@ public class ApiResponseTest {
     public void closedChangeset() {
         ApiResponse.Conflict conflict = ApiResponse.parseConflictResponse(HttpURLConnection.HTTP_CONFLICT, ERROR_MESSAGE_CLOSED_CHANGESET);
         assertTrue(conflict instanceof ApiResponse.ClosedChangesetConflict);
+        assertEquals(123456L, conflict.getElementId());
+    }
+    
+    /**
+     */
+    @Test
+    public void changesetLocked() {
+        ApiResponse.Conflict conflict = ApiResponse.parseConflictResponse(HttpURLConnection.HTTP_CONFLICT, ERROR_MESSAGE_CHANGESET_LOCKED);
+        assertTrue(conflict instanceof ApiResponse.ChangesetLocked);
         assertEquals(123456L, conflict.getElementId());
     }
     


### PR DESCRIPTION
This avoids showing the conflict dialog for this, which is however likely never going to happen.

Resolves: https://github.com/MarcusWolschon/osmeditor4android/issues/2618