### PR TITLE
Proguard/R8 was removing the turf class referenced in the Rhino setup

### DIFF
--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -74,6 +74,9 @@
 -keep,includedescriptorclasses class com.mapbox.geojson.** {
   public protected private *;
 }
+-keep,includedescriptorclasses classcom.mapbox.turf.** {
+  public protected private *;
+}
 
 -keep class sun.misc.Unsafe { *; }
 


### PR DESCRIPTION
Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/2613