### PR TITLE
Use API URL for web history

### DIFF
--- a/src/main/java/de/blau/android/easyedit/ElementSelectionActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/ElementSelectionActionModeCallback.java
@@ -48,6 +48,7 @@ import de.blau.android.osm.OsmElement.ElementType;
 import de.blau.android.osm.Relation;
 import de.blau.android.osm.RelationMember;
 import de.blau.android.osm.RelationUtils;
+import de.blau.android.osm.Server;
 import de.blau.android.osm.Tags;
 import de.blau.android.osm.Way;
 import de.blau.android.prefs.PrefEditor;
@@ -573,10 +574,14 @@ public abstract class ElementSelectionActionModeCallback extends EasyEditActionM
 
     /**
      * Opens the history page of the selected element in a browser
+     *
+     * FIXME To avoid being caught by the pathPatterns in the manifest we use the API url, that is redirected 
+     * to the website in this special case, this is a hack that will require API 31 with better pattern support
+     * to fix properly.
      */
     private void showHistory() {
         Intent intent = new Intent(Intent.ACTION_VIEW);
-        intent.setData(Uri.parse(prefs.getServer().getWebsiteBaseUrl() + element.getName() + "/" + element.getOsmId() + "/history"));
+        intent.setData(Uri.parse(Server.getBaseUrl(prefs.getServer().getReadWriteUrl()) + element.getName() + "/" + element.getOsmId() + "/history"));
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         main.startActivity(intent);
     }


### PR DESCRIPTION
The path patterns currently catch OSM URLs which doesn't allow the "web history" function to work. However api.openstreetmap.org without the api path is currently redirected to openstreetmap.org.

To properly fix this would require the "advancedPathPattern"s introduced with Android 12/API 31.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/2634