### PR TITLE
More onbackpressed cleanup

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -58,6 +58,7 @@
         android:requestLegacyExternalStorage="true"
         android:resizeableActivity="true"
         android:supportsRtl="true"
+        android:enableOnBackInvokedCallback="false"
         android:theme="@style/Theme.AppCompat" >
         <activity
             android:name=".Splash"

--- a/src/main/java/de/blau/android/HelpViewer.java
+++ b/src/main/java/de/blau/android/HelpViewer.java
@@ -368,7 +368,7 @@ public class HelpViewer extends WebViewActivity {
                 webView.goBack();
                 invalidateOptionsMenu();
             } else {
-                onBackPressed(); // return to caller
+                getOnBackPressedDispatcher().onBackPressed(); // return to caller
             }
             return true;
 

--- a/src/main/java/de/blau/android/filter/TagFilterActivity.java
+++ b/src/main/java/de/blau/android/filter/TagFilterActivity.java
@@ -1,5 +1,7 @@
 package de.blau.android.filter;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import android.content.ContentValues;
@@ -25,6 +27,7 @@ import android.widget.ImageButton;
 import android.widget.ListView;
 import android.widget.Spinner;
 import android.widget.TextView;
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
@@ -43,7 +46,8 @@ import de.blau.android.prefs.ListActivity;
  */
 public class TagFilterActivity extends ListActivity {
 
-    private static final String DEBUG_TAG  = TagFilterActivity.class.getSimpleName().substring(0, Math.min(23, TagFilterActivity.class.getSimpleName().length()));
+    private static final int    TAG_LEN    = Math.min(LOG_TAG_LEN, TagFilterActivity.class.getSimpleName().length());
+    private static final String DEBUG_TAG  = TagFilterActivity.class.getSimpleName().substring(0, TAG_LEN);
     private static final String FILTER_KEY = "FILTER";
 
     static final String FILTERENTRIES_TABLE = "filterentries";
@@ -127,6 +131,8 @@ public class TagFilterActivity extends ListActivity {
         getListView().setItemsCanFocus(true);
         // Attach cursor adapter to the ListView
         getListView().setAdapter(filterAdapter);
+
+        getOnBackPressedDispatcher().addCallback(this, onBackPressedCallback);
     }
 
     @Override
@@ -230,11 +236,19 @@ public class TagFilterActivity extends ListActivity {
         return super.onOptionsItemSelected(item);
     }
 
-    @Override
-    public void onBackPressed() {
-        updateDatabaseFromList();
-        super.onBackPressed();
-    }
+    /**
+     * Update database if exiting via back button
+     */
+    private OnBackPressedCallback onBackPressedCallback = new OnBackPressedCallback(true) {
+
+        @Override
+        public void handleOnBackPressed() {
+            Log.d(DEBUG_TAG, "onBackPressed()");
+            updateDatabaseFromList();
+            onBackPressedCallback.setEnabled(false);
+            getOnBackPressedDispatcher().onBackPressed();
+        }
+    };
 
     /**
      * Update the database from the whole view


### PR DESCRIPTION
Remove two occasions of onBackPressed being used and turn off generation of predicitive back navigation animations which seems to be the cause for a large number of ANRs on Android 14.