### PR TITLE
Replace synchronized by an ReentrantLock in StorageDelegator

### DIFF
--- a/src/main/java/de/blau/android/osm/StorageDelegator.java
+++ b/src/main/java/de/blau/android/osm/StorageDelegator.java
@@ -1,5 +1,6 @@
 package de.blau.android.osm;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
 import static de.blau.android.util.Winding.COLINEAR;
 import static de.blau.android.util.Winding.COUNTERCLOCKWISE;
 import static de.blau.android.util.Winding.winding;
@@ -59,7 +60,8 @@ import de.blau.android.validation.BaseValidator;
 
 public class StorageDelegator implements Serializable, Exportable, DataStorage {
 
-    private static final String DEBUG_TAG = StorageDelegator.class.getSimpleName().substring(0, Math.min(23, StorageDelegator.class.getSimpleName().length()));
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, StorageDelegator.class.getSimpleName().length());
+    private static final String DEBUG_TAG = StorageDelegator.class.getSimpleName().substring(0, TAG_LEN);
 
     private static final long serialVersionUID = 11L;
 
@@ -3929,7 +3931,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
     }
 
     /**
-     * Free the reading lock
+     * Free the reading lock checking if it is currently held
      */
     public void unlock() {
         if (readingLock.isHeldByCurrentThread()) {

--- a/src/main/java/de/blau/android/osm/UndoStorage.java
+++ b/src/main/java/de/blau/android/osm/UndoStorage.java
@@ -541,7 +541,8 @@ public class UndoStorage implements Serializable {
             boolean ok = true;
             List<UndoElement> list = new ArrayList<>(elements.values());
             final StorageDelegator delegator = App.getDelegator();
-            synchronized (delegator) {
+            try {
+                delegator.lock();
                 if (redoCheckpoint != null) {
                     for (UndoElement ue : list) {
                         redoCheckpoint.add(getUptodateElement(ue.element)); // save current state
@@ -567,6 +568,8 @@ public class UndoStorage implements Serializable {
                 }
 
                 delegator.fixupBacklinks();
+            } finally {
+                delegator.unlock();
             }
             return ok;
         }


### PR DESCRIPTION
Use the already existing lock in StorageDelegator instead of synchronized, this allows other parts of the app to determine if the delegator is actually currently locked or not, in particular the rendering code.