### PR TITLE
Add image orientation to photo index and some minor image viewer fixes

### DIFF
--- a/documentation/docs/help/en/Main map display.md
+++ b/documentation/docs/help/en/Main map display.md
@@ -78,9 +78,12 @@ The layer dialog supports the following actions on the layer entries:
         * __Start playback__ Playback the current file, this behaves similar to recording tracks, the display will be centered on the current track point, then the following on and so on. *(not available on the recording layer)*
         * __Pause playback__ Temporarily pause the playback. *(not available on the recording layer)*
         * __Stop playback__ Stop the playback. *(not available on the recording layer)*
-    * Photo, Grid and Task layers:
-        * __Configure...__ (for the Grid and Task layers)
-        * __Disable__ Turn this layer off. For the tasks and photo layers this will free resources if the app is exited and re-started.
+    * Photo layer:
+        * __Reindex__ clear the current index data and reindex images on the device.
+        * __Discard__ Turn this layer off. This will free resources if the app is exited and re-started.
+    * Grid and Task layers:
+        * __Configure...__ Change layer settings
+        * __Discard__ Turn this layer off. For the task layer this will free resources if the app is exited and re-started.
     * Data layer:
         * __Configure...__ Select the API instance, configure the URLs including read-only sources and authentication method. Basic Authentication, OAuth 1.0a and OAuth 2 are supported, however the API instance on openstreetmap.org only supports OAuth 2 since June 2024.
     * Data and Tasks layers:

--- a/src/main/assets/help/en/Main map display.html
+++ b/src/main/assets/help/en/Main map display.html
@@ -86,10 +86,16 @@
 <li><strong>Stop playback</strong> Stop the playback. <em>(not available on the recording layer)</em></li>
 </ul>
 </li>
-<li>Photo, Grid and Task layers:
+<li>Photo layer:
 <ul>
-<li><strong>Configure...</strong> (for the Grid and Task layers)</li>
-<li><strong>Disable</strong> Turn this layer off. For the tasks and photo layers this will free resources if the app is exited and re-started.</li>
+<li><strong>Reindex</strong> clear the current index data and reindex images on the device.</li>
+<li><strong>Discard</strong> Turn this layer off. This will free resources if the app is exited and re-started.</li>
+</ul>
+</li>
+<li>Grid and Task layers:
+<ul>
+<li><strong>Configure...</strong> Change layer settings</li>
+<li><strong>Discard</strong> Turn this layer off. For the task layer this will free resources if the app is exited and re-started.</li>
 </ul>
 </li>
 <li>Data layer:

--- a/src/main/java/de/blau/android/dialogs/ImageInfo.java
+++ b/src/main/java/de/blau/android/dialogs/ImageInfo.java
@@ -115,7 +115,8 @@ public class ImageInfo extends InfoDialogFragment {
             try {
                 FragmentActivity activity = getActivity();
                 Photo image = new Photo(getContext(), uri, null);
-                tl.addView(TableLayoutUtils.createRow(activity, ContentResolverUtil.getPath(getContext(), uri), null, tp));
+                String path = ContentResolverUtil.getPath(getContext(), uri);
+                tl.addView(TableLayoutUtils.createRow(activity, path == null ? uri.toString() : path, null, tp));
                 long size = ContentResolverUtil.getSizeColumn(getContext(), uri);
                 if (size > -1) {
                     tl.addView(TableLayoutUtils.createRow(activity, R.string.file_size, getString(R.string.file_size_kB, size / 1024), tp));

--- a/src/main/java/de/blau/android/dialogs/Layers.java
+++ b/src/main/java/de/blau/android/dialogs/Layers.java
@@ -998,6 +998,17 @@ public class Layers extends AbstractConfigurationDialog implements OnUpdateListe
                 });
             }
 
+            if (layer instanceof de.blau.android.layer.photos.MapOverlay) {
+                MenuItem item = menu.add(R.string.layer_photos_reindex);
+                item.setOnMenuItemClickListener(unused -> {
+                    if (layer != null) {
+                        ((de.blau.android.layer.photos.MapOverlay) layer).reIndex();
+                        layer.invalidate();
+                    }
+                    return true;
+                });
+            }
+
             if (layer instanceof LayerInfoInterface) {
                 MenuItem item = menu.add(R.string.menu_information);
                 item.setOnMenuItemClickListener(unused -> {

--- a/src/main/java/de/blau/android/photos/MapillaryViewerActivity.java
+++ b/src/main/java/de/blau/android/photos/MapillaryViewerActivity.java
@@ -14,7 +14,7 @@ import de.blau.android.util.ImageLoader;
  * @author simon
  *
  */
-public class MapillaryViewerActivity extends PhotoViewerActivity {
+public class MapillaryViewerActivity extends PhotoViewerActivity<String> {
 
     /**
      * Start a new activity with the PhotoViewer as the contents

--- a/src/main/java/de/blau/android/photos/Photo.java
+++ b/src/main/java/de/blau/android/photos/Photo.java
@@ -135,6 +135,19 @@ public class Photo implements BoundedObject, GeoPoint, Serializable {
         lat = (int) (latf * 1E7d);
         lon = (int) (lonf * 1E7d);
 
+        String orientationStr = exif.getAttribute(ExifInterface.TAG_ORIENTATION);
+        if (orientationStr != null) {
+            try {
+                orientation = Integer.parseInt(orientationStr);
+            } catch (NumberFormatException nfex) {
+                Log.w(DEBUG_TAG, "Unable to parse orientation " + nfex.getMessage());
+            }
+        }
+
+        captureDate = exif.getDateTime();
+        creator = exif.getAttribute(ExifInterface.TAG_ARTIST);
+
+        // don't add anything after this section that needs to be processed in any case
         String dir = exif.getAttribute(ExifInterface.TAG_GPS_IMG_DIRECTION);
         if (dir != null) {
             String[] r = dir.split("/");
@@ -148,18 +161,6 @@ public class Photo implements BoundedObject, GeoPoint, Serializable {
                 Log.w(DEBUG_TAG, "Unable to parse cardinal direction " + nfex.getMessage());
             }
         }
-
-        String orientationStr = exif.getAttribute(ExifInterface.TAG_ORIENTATION);
-        if (orientationStr != null) {
-            try {
-                orientation = Integer.parseInt(orientationStr);
-            } catch (NumberFormatException nfex) {
-                Log.w(DEBUG_TAG, "Unable to parse orientation " + nfex.getMessage());
-            }
-        }
-
-        captureDate = exif.getDateTime();
-        creator = exif.getAttribute(ExifInterface.TAG_ARTIST);
     }
 
     /**
@@ -169,12 +170,11 @@ public class Photo implements BoundedObject, GeoPoint, Serializable {
      * @param lon longitude in WGS84*1E7 degrees
      * @param ref the path of the file
      * @param displayName a short name for the Photo
+     * @param orientation image orientation
      */
-    public Photo(int lat, int lon, @NonNull String ref, @Nullable String displayName) {
-        this.lat = lat;
-        this.lon = lon;
-        this.ref = ref;
-        this.displayName = displayName;
+    public Photo(int lat, int lon, @NonNull String ref, @Nullable String displayName, int orientation) {
+        this(lat, lon, 0, ref, displayName, orientation);
+        this.directionRef = null;
     }
 
     /**
@@ -185,14 +185,16 @@ public class Photo implements BoundedObject, GeoPoint, Serializable {
      * @param direction in degrees
      * @param ref the path of the file
      * @param displayName a short name for the Photo
+     * @param orientation image orientation
      */
-    public Photo(int lat, int lon, int direction, @NonNull String ref, @Nullable String displayName) {
+    public Photo(int lat, int lon, int direction, @NonNull String ref, @Nullable String displayName, int orientation) {
         this.lat = lat;
         this.lon = lon;
         this.direction = direction;
         this.directionRef = ExifInterface.GPS_DIRECTION_MAGNETIC;
         this.ref = ref;
         this.displayName = displayName;
+        this.orientation = orientation;
     }
 
     /**

--- a/src/main/java/de/blau/android/photos/PhotoIndex.java
+++ b/src/main/java/de/blau/android/photos/PhotoIndex.java
@@ -48,8 +48,9 @@ import de.blau.android.util.rtree.RTree;
  */
 public class PhotoIndex extends SQLiteOpenHelper {
 
-    private static final int    DATA_VERSION = 6;
+    private static final int    DATA_VERSION = 7;
     public static final String  DB_NAME      = PhotoIndex.class.getSimpleName();
+    
     private static final int    TAG_LEN      = Math.min(LOG_TAG_LEN, PhotoIndex.class.getSimpleName().length());
     private static final String DEBUG_TAG    = PhotoIndex.class.getSimpleName().substring(0, TAG_LEN);
 
@@ -90,7 +91,7 @@ public class PhotoIndex extends SQLiteOpenHelper {
     public synchronized void onCreate(SQLiteDatabase db) {
         Log.d(DEBUG_TAG, "Creating photo index DB");
         db.execSQL("CREATE TABLE IF NOT EXISTS " + PHOTOS_TABLE
-                + " (lat int, lon int, direction int DEFAULT NULL, dir VARCHAR, name VARCHAR, source VARCHAR DEFAULT NULL);");
+                + " (lat int, lon int, direction int DEFAULT NULL, dir VARCHAR, name VARCHAR, source VARCHAR DEFAULT NULL, orientation int DEFAULT 0);");
         db.execSQL("CREATE INDEX latidx ON " + PHOTOS_TABLE + " (lat)");
         db.execSQL("CREATE INDEX lonidx ON " + PHOTOS_TABLE + " (lon)");
         db.execSQL("CREATE TABLE IF NOT EXISTS " + SOURCES_TABLE + " (dir VARCHAR, last_scan int8, tag VARCHAR DEFAULT NULL);");
@@ -124,6 +125,10 @@ public class PhotoIndex extends SQLiteOpenHelper {
             db.execSQL(ALTER_TABLE + PHOTOS_TABLE + " ADD source VARCHAR DEFAULT NULL");
             db.execSQL(ALTER_TABLE + SOURCES_TABLE + " ADD tag VARCHAR DEFAULT NULL");
             initSource(db, MEDIA_STORE, "");
+            db.execSQL("DELETE FROM " + PHOTOS_TABLE);
+        }
+        if (oldVersion <= 6) {
+            db.execSQL(ALTER_TABLE + PHOTOS_TABLE + " ADD orientation int DEFAULT 0");
             db.execSQL("DELETE FROM " + PHOTOS_TABLE);
         }
     }

--- a/src/main/java/de/blau/android/photos/PhotoIndex.java
+++ b/src/main/java/de/blau/android/photos/PhotoIndex.java
@@ -48,11 +48,11 @@ import de.blau.android.util.rtree.RTree;
  */
 public class PhotoIndex extends SQLiteOpenHelper {
 
-    private static final int    DATA_VERSION = 7;
-    public static final String  DB_NAME      = PhotoIndex.class.getSimpleName();
-    
-    private static final int    TAG_LEN      = Math.min(LOG_TAG_LEN, PhotoIndex.class.getSimpleName().length());
-    private static final String DEBUG_TAG    = PhotoIndex.class.getSimpleName().substring(0, TAG_LEN);
+    private static final int   DATA_VERSION = 7;
+    public static final String DB_NAME      = PhotoIndex.class.getSimpleName();
+
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, PhotoIndex.class.getSimpleName().length());
+    private static final String DEBUG_TAG = PhotoIndex.class.getSimpleName().substring(0, TAG_LEN);
 
     private static final String NOVESPUCCI = ".novespucci";
 
@@ -60,20 +60,29 @@ public class PhotoIndex extends SQLiteOpenHelper {
     private static final String OSMTRACKER  = "osmtracker";
     private static final String DCIM        = "DCIM";
 
-    private static final String SOURCES_TABLE    = "directories";
-    private static final String PHOTOS_TABLE     = "photos";
-    private static final String NAME_COLUMN      = "name";
-    private static final String SOURCE_COLUMN    = "source";
-    private static final String LAT_COLUMN       = "lat";
-    private static final String LON_COLUMN       = "lon";
-    private static final String DIRECTION_COLUMN = "direction";
-    private static final String URI_COLUMN       = "dir";        // historically this was the dir
-    private static final String URI_WHERE        = "dir = ?";
-    private static final String LAST_SCAN_COLUMN = "last_scan";
-    private static final String TAG_COLUMN       = "tag";
+    private static final String SOURCES_TABLE      = "directories";
+    private static final String PHOTOS_TABLE       = "photos";
+    private static final String NAME_COLUMN        = "name";
+    private static final String SOURCE_COLUMN      = "source";
+    private static final String LAT_COLUMN         = "lat";
+    private static final String LON_COLUMN         = "lon";
+    private static final String DIRECTION_COLUMN   = "direction";
+    private static final String ORIENTATION_COLUMN = "orientation";
+    private static final String URI_COLUMN         = "dir";        // historically this was the dir
+    private static final String URI_WHERE          = "dir = ?";
+    private static final String LAST_SCAN_COLUMN   = "last_scan";
+    private static final String TAG_COLUMN         = "tag";
 
     private static final String INSERT_INTO = "INSERT INTO ";
     private static final String ALTER_TABLE = "ALTER TABLE ";
+    private static final String DELETE_FROM = "DELETE FROM ";
+
+    private static final int LAT_INDEX         = 0;
+    private static final int LON_INDEX         = 1;
+    private static final int DIRECTION_INDEX   = 2;
+    private static final int DIR_INDEX         = 3;
+    private static final int NAME_INDEX        = 4;
+    private static final int ORIENTATION_INDEX = 5;
 
     private final Context context;
 
@@ -119,17 +128,18 @@ public class PhotoIndex extends SQLiteOpenHelper {
             db.execSQL(ALTER_TABLE + PHOTOS_TABLE + " ADD direction int DEFAULT NULL");
         }
         if (oldVersion <= 4) {
-            db.execSQL("DELETE FROM " + PHOTOS_TABLE); // this should force a complete reindex
+            db.execSQL(DELETE_FROM + PHOTOS_TABLE); // this should force a complete reindex
         }
         if (oldVersion <= 5) {
             db.execSQL(ALTER_TABLE + PHOTOS_TABLE + " ADD source VARCHAR DEFAULT NULL");
             db.execSQL(ALTER_TABLE + SOURCES_TABLE + " ADD tag VARCHAR DEFAULT NULL");
             initSource(db, MEDIA_STORE, "");
-            db.execSQL("DELETE FROM " + PHOTOS_TABLE);
+            db.execSQL(DELETE_FROM + PHOTOS_TABLE);
         }
         if (oldVersion <= 6) {
             db.execSQL(ALTER_TABLE + PHOTOS_TABLE + " ADD orientation int DEFAULT 0");
-            db.execSQL("DELETE FROM " + PHOTOS_TABLE);
+            db.execSQL(DELETE_FROM + PHOTOS_TABLE);
+            updateSources(db, MEDIA_STORE, null, System.currentTimeMillis());
         }
     }
 
@@ -156,15 +166,21 @@ public class PhotoIndex extends SQLiteOpenHelper {
                 indexMediaStore();
             } else {
                 // delete scanned photos from index
-                SQLiteDatabase db = null;
-                try {
-                    db = getWritableDatabase();
+                try (SQLiteDatabase db = getWritableDatabase()) {
                     db.delete(PHOTOS_TABLE, SOURCE_COLUMN + "= ?", new String[] { MEDIA_STORE });
                     updateSources(db, MEDIA_STORE, "", 0);
-                } finally {
-                    SavingHelper.close(db);
                 }
             }
+        }
+    }
+
+    /**
+     * Remove all information from the index
+     */
+    public synchronized void resetIndex() {
+        try (SQLiteDatabase db = getWritableDatabase()) {
+            db.execSQL(DELETE_FROM + PHOTOS_TABLE);
+            db.execSQL(DELETE_FROM + SOURCES_TABLE);
         }
     }
 
@@ -232,22 +248,7 @@ public class PhotoIndex extends SQLiteOpenHelper {
      */
     private void indexDirectories() {
         Log.d(DEBUG_TAG, "scanning directories");
-        // determine at least a few of the possible mount points
-        File sdcard = Environment.getExternalStorageDirectory(); // NOSONAR
-        List<String> mountPoints = new ArrayList<>();
-        mountPoints.add(sdcard.getAbsolutePath());
-        mountPoints.add(sdcard.getAbsolutePath() + Paths.DIRECTORY_PATH_EXTERNAL_SD_CARD);
-        mountPoints.add(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).getAbsolutePath()); // NOSONAR
-        File storageDir = new File(Paths.DIRECTORY_PATH_STORAGE);
-        File[] list = storageDir.listFiles();
-        if (list != null) {
-            for (File f : list) {
-                if (f.exists() && f.isDirectory() && !sdcard.getAbsolutePath().equals(f.getAbsolutePath())) {
-                    Log.d(DEBUG_TAG, "Adding mount point " + f.getAbsolutePath());
-                    mountPoints.add(f.getAbsolutePath());
-                }
-            }
-        }
+        List<String> mountPoints = getMountPoints(Environment.getExternalStorageDirectory()); // NOSONAR
 
         try (SQLiteDatabase db = getWritableDatabase();
                 Cursor dbresult = db.query(SOURCES_TABLE, new String[] { URI_COLUMN, LAST_SCAN_COLUMN, TAG_COLUMN }, TAG_COLUMN + " is NULL", null, null, null,
@@ -263,29 +264,28 @@ public class PhotoIndex extends SQLiteOpenHelper {
                 for (String m : mountPoints) {
                     File indir = new File(m, dir);
                     Log.d(DEBUG_TAG, "Scanning directory " + indir.getAbsolutePath());
-                    if (indir.exists()) {
-                        try (Cursor dbresult2 = db.query(PHOTOS_TABLE, new String[] { "distinct dir" }, "dir LIKE '" + indir.getAbsolutePath() + "%'", null,
-                                null, null, null, null)) {
-                            int dirCount2 = dbresult2.getCount();
-                            dbresult2.moveToFirst();
-                            for (int j = 0; j < dirCount2; j++) {
-                                String photo = dbresult2.getString(0);
-                                File pDir = new File(photo);
-                                if (!pDir.exists()) {
-                                    Log.d(DEBUG_TAG, "Deleting entries for gone photo " + photo);
-                                    db.delete(PHOTOS_TABLE, URI_WHERE, new String[] { photo });
-                                }
-                                dbresult2.moveToNext();
-                            }
-                            scanDir(db, indir.getAbsolutePath(), lastScan);
-                            updateSources(db, indir.getName(), null, System.currentTimeMillis());
-                        }
+                    if (!indir.exists()) {
+                        Log.d(DEBUG_TAG, "Directory " + indir.getAbsolutePath() + " doesn't exist");
+                        // remove all entries for this directory
+                        db.delete(PHOTOS_TABLE, URI_WHERE, new String[] { indir.getAbsolutePath() });
+                        db.delete(PHOTOS_TABLE, "dir LIKE ?", new String[] { indir.getAbsolutePath() + "/%" });
                         continue;
                     }
-                    Log.d(DEBUG_TAG, "Directory " + indir.getAbsolutePath() + " doesn't exist");
-                    // remove all entries for this directory
-                    db.delete(PHOTOS_TABLE, URI_WHERE, new String[] { indir.getAbsolutePath() });
-                    db.delete(PHOTOS_TABLE, "dir LIKE ?", new String[] { indir.getAbsolutePath() + "/%" });
+                    try (Cursor dbresult2 = db.query(PHOTOS_TABLE, new String[] { "distinct dir" }, "dir LIKE '" + indir.getAbsolutePath() + "%'", null, null,
+                            null, null, null)) {
+                        int dirCount2 = dbresult2.getCount();
+                        dbresult2.moveToFirst();
+                        for (int j = 0; j < dirCount2; j++) {
+                            String photo = dbresult2.getString(0);
+                            if (!new File(photo).exists()) {
+                                Log.d(DEBUG_TAG, "Deleting entries for gone photo " + photo);
+                                db.delete(PHOTOS_TABLE, URI_WHERE, new String[] { photo });
+                            }
+                            dbresult2.moveToNext();
+                        }
+                        scanDir(db, indir.getAbsolutePath(), lastScan);
+                        updateSources(db, indir.getName(), null, System.currentTimeMillis());
+                    }
                 }
                 dbresult.moveToNext();
             }
@@ -293,6 +293,30 @@ public class PhotoIndex extends SQLiteOpenHelper {
             // Don't crash just report
             ACRAHelper.nocrashReport(ex, ex.getMessage());
         }
+    }
+
+    /**
+     * Determine at least a few of the possible mount points
+     * 
+     * @param extStorage location of external storage
+     * @return list of directories
+     */
+    private List<String> getMountPoints(File extStorage) {
+        List<String> mountPoints = new ArrayList<>();
+        mountPoints.add(extStorage.getAbsolutePath());
+        mountPoints.add(extStorage.getAbsolutePath() + Paths.DIRECTORY_PATH_EXTERNAL_SD_CARD);
+        mountPoints.add(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).getAbsolutePath()); // NOSONAR
+        File storageDir = new File(Paths.DIRECTORY_PATH_STORAGE);
+        File[] list = storageDir.listFiles();
+        if (list != null) {
+            for (File f : list) {
+                if (f.exists() && f.isDirectory() && !extStorage.getAbsolutePath().equals(f.getAbsolutePath())) {
+                    Log.d(DEBUG_TAG, "Adding mount point " + f.getAbsolutePath());
+                    mountPoints.add(f.getAbsolutePath());
+                }
+            }
+        }
+        return mountPoints;
     }
 
     /**
@@ -526,6 +550,7 @@ public class PhotoIndex extends SQLiteOpenHelper {
             if (source != null) {
                 values.put(SOURCE_COLUMN, source);
             }
+            values.put(ORIENTATION_COLUMN, photo.getOrientation());
             db.insert(PHOTOS_TABLE, null, values);
         } catch (SQLiteException sqex) {
             Log.d(DEBUG_TAG, sqex.toString());
@@ -635,20 +660,21 @@ public class PhotoIndex extends SQLiteOpenHelper {
         }
         try {
             SQLiteDatabase db = getReadableDatabase();
-            Cursor dbresult = db.query(PHOTOS_TABLE, new String[] { LAT_COLUMN, LON_COLUMN, DIRECTION_COLUMN, URI_COLUMN, NAME_COLUMN }, null, null, null, null,
-                    null, null);
+            Cursor dbresult = db.query(PHOTOS_TABLE, new String[] { LAT_COLUMN, LON_COLUMN, DIRECTION_COLUMN, URI_COLUMN, NAME_COLUMN, ORIENTATION_COLUMN },
+                    null, null, null, null, null, null);
             int photoCount = dbresult.getCount();
             dbresult.moveToFirst();
             Log.i(DEBUG_TAG, "Query returned " + photoCount + " photos");
             //
             for (int i = 0; i < photoCount; i++) {
-                String name = dbresult.getString(4);
-                String dir = dbresult.getString(3);
+                String name = dbresult.getString(NAME_INDEX);
+                String dir = dbresult.getString(DIR_INDEX);
                 Photo newPhoto;
-                if (dbresult.isNull(2)) { // no direction
-                    newPhoto = new Photo(dbresult.getInt(0), dbresult.getInt(1), dir, name);
+                if (dbresult.isNull(DIRECTION_INDEX)) { // no direction
+                    newPhoto = new Photo(dbresult.getInt(LAT_INDEX), dbresult.getInt(LON_INDEX), dir, name, dbresult.getInt(ORIENTATION_INDEX));
                 } else {
-                    newPhoto = new Photo(dbresult.getInt(0), dbresult.getInt(1), dbresult.getInt(2), dir, name);
+                    newPhoto = new Photo(dbresult.getInt(LAT_INDEX), dbresult.getInt(LON_INDEX), dbresult.getInt(DIRECTION_INDEX), dir, name,
+                            dbresult.getInt(ORIENTATION_INDEX));
                 }
                 if (!index.contains(newPhoto)) {
                     index.insert(newPhoto);

--- a/src/main/java/de/blau/android/photos/PhotoViewerActivity.java
+++ b/src/main/java/de/blau/android/photos/PhotoViewerActivity.java
@@ -1,5 +1,8 @@
 package de.blau.android.photos;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
+import java.io.Serializable;
 import java.util.ArrayList;
 
 import android.content.Context;
@@ -23,14 +26,14 @@ import de.blau.android.util.Util;
  * @author simon
  *
  */
-public class PhotoViewerActivity extends ConfigurationChangeAwareActivity {
+public class PhotoViewerActivity<T extends Serializable> extends ConfigurationChangeAwareActivity {
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, PhotoViewerActivity.class.getSimpleName().length());
+    private static final String DEBUG_TAG = PhotoViewerActivity.class.getSimpleName().substring(0, TAG_LEN);
 
-    private static final String DEBUG_TAG = PhotoViewerActivity.class.getSimpleName().substring(0, Math.min(23, PhotoViewerActivity.class.getSimpleName().length()));
-
-    ArrayList<String> photoList   = null;
-    int               startPos    = 0;
-    ImageLoader       photoLoader = null;
-    boolean           wrap        = true;
+    ArrayList<T> photoList   = null;
+    int          startPos    = 0;
+    ImageLoader  photoLoader = null;
+    boolean      wrap        = true;
 
     /**
      * Start a new activity with the PhotoViewer as the contents
@@ -39,7 +42,7 @@ public class PhotoViewerActivity extends ConfigurationChangeAwareActivity {
      * @param photoList a list of photos to show
      * @param startPos the starting position in the list
      */
-    public static void start(@NonNull Context context, @NonNull ArrayList<String> photoList, int startPos) { // NOSONAR
+    public static <V extends Serializable> void start(@NonNull Context context, @NonNull ArrayList<V> photoList, int startPos) { // NOSONAR
         Intent intent = new Intent(context, PhotoViewerActivity.class);
         intent.putExtra(PhotoViewerFragment.WRAP_KEY, true);
         setExtrasAndStart(context, photoList, startPos, intent);
@@ -53,7 +56,8 @@ public class PhotoViewerActivity extends ConfigurationChangeAwareActivity {
      * @param startPos the starting position in the list
      * @param intent the Intent to use
      */
-    protected static void setExtrasAndStart(@NonNull Context context, @NonNull ArrayList<String> photoList, int startPos, @NonNull Intent intent) {
+    protected static <V extends Serializable> void setExtrasAndStart(@NonNull Context context, @NonNull ArrayList<V> photoList, int startPos,
+            @NonNull Intent intent) {
         intent.putExtra(PhotoViewerFragment.PHOTO_LIST_KEY, photoList);
         intent.putExtra(PhotoViewerFragment.START_POS_KEY, startPos);
         int flags = Intent.FLAG_ACTIVITY_NEW_TASK;
@@ -66,6 +70,7 @@ public class PhotoViewerActivity extends ConfigurationChangeAwareActivity {
         context.startActivity(intent);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         Log.d(DEBUG_TAG, "onCreate");
@@ -77,13 +82,13 @@ public class PhotoViewerActivity extends ConfigurationChangeAwareActivity {
         if (savedInstanceState == null) {
             // No previous state to restore - get the state from the intent
             Log.d(DEBUG_TAG, "Initializing from intent");
-            photoList = getIntent().getStringArrayListExtra(PhotoViewerFragment.PHOTO_LIST_KEY);
+            photoList = Util.getSerializableExtra(getIntent(), PhotoViewerFragment.PHOTO_LIST_KEY, ArrayList.class);
             startPos = getIntent().getIntExtra(PhotoViewerFragment.START_POS_KEY, 0);
             photoLoader = Util.getSerializableExtra(getIntent(), PhotoViewerFragment.PHOTO_LOADER_KEY, ImageLoader.class);
             wrap = Util.getSerializableExtra(getIntent(), PhotoViewerFragment.WRAP_KEY, Boolean.class);
         } else {
             Log.d(DEBUG_TAG, "Initializing from saved state");
-            photoList = savedInstanceState.getStringArrayList(PhotoViewerFragment.PHOTO_LIST_KEY);
+            photoList = Util.getSerializeable(savedInstanceState, PhotoViewerFragment.PHOTO_LIST_KEY, ArrayList.class);
             startPos = savedInstanceState.getInt(PhotoViewerFragment.START_POS_KEY);
             photoLoader = Util.getSerializeable(savedInstanceState, PhotoViewerFragment.PHOTO_LOADER_KEY, ImageLoader.class);
             wrap = savedInstanceState.getBoolean(PhotoViewerFragment.WRAP_KEY);
@@ -96,38 +101,40 @@ public class PhotoViewerActivity extends ConfigurationChangeAwareActivity {
         }
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
-        ArrayList<String> tempList = getIntent().getStringArrayListExtra(PhotoViewerFragment.PHOTO_LIST_KEY);
+        ArrayList<T> tempList = Util.getSerializableExtra(getIntent(), PhotoViewerFragment.PHOTO_LIST_KEY, ArrayList.class);
         int tempPos = intent.getIntExtra(PhotoViewerFragment.START_POS_KEY, 0);
-        String tempPhoto = tempList.get(tempPos);
+        T tempPhoto = tempList.get(tempPos);
         int index = photoList.indexOf(tempPhoto);
         Fragment f = getSupportFragmentManager().findFragmentById(android.R.id.content);
         if (f != null) {
             if (index >= 0) { // existing
-                ((PhotoViewerFragment) f).setCurrentPosition(index);
+                ((PhotoViewerFragment<T>) f).setCurrentPosition(index);
             } else {
                 if (photoList.size() == 1) { // add to existing
                     photoList.add(tempPhoto);
-                    ((PhotoViewerFragment) f).addPhoto(tempPhoto);
+                    ((PhotoViewerFragment<T>) f).addPhoto(tempPhoto);
                 } else { // replace
                     photoList.clear();
                     photoList.addAll(tempList);
                     startPos = tempPos;
-                    ((PhotoViewerFragment) f).replacePhotos(tempList, tempPos);
+                    ((PhotoViewerFragment<T>) f).replacePhotos(tempList, tempPos);
                 }
             }
         }
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         Log.d(DEBUG_TAG, "onSaveInstanceState");
-        outState.putStringArrayList(PhotoViewerFragment.PHOTO_LIST_KEY, photoList);
+        outState.putSerializable(PhotoViewerFragment.PHOTO_LIST_KEY, photoList);
         Fragment f = getSupportFragmentManager().findFragmentById(android.R.id.content);
-        outState.putInt(PhotoViewerFragment.START_POS_KEY, f != null ? ((PhotoViewerFragment) f).getCurrentPosition() : startPos);
+        outState.putInt(PhotoViewerFragment.START_POS_KEY, f != null ? ((PhotoViewerFragment<T>) f).getCurrentPosition() : startPos);
         outState.putSerializable(PhotoViewerFragment.PHOTO_LOADER_KEY, photoLoader);
         outState.putBoolean(PhotoViewerFragment.WRAP_KEY, wrap);
     }

--- a/src/main/java/de/blau/android/util/ImageLoader.java
+++ b/src/main/java/de/blau/android/util/ImageLoader.java
@@ -12,7 +12,7 @@ import androidx.fragment.app.FragmentActivity;
 
 public abstract class ImageLoader implements Serializable {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     protected transient Fragment parentFragment = null;
 
@@ -30,6 +30,17 @@ public abstract class ImageLoader implements Serializable {
      * @param uri the Uri or other reference
      */
     public abstract void load(@NonNull SubsamplingScaleImageView view, @NonNull String uri);
+
+    /**
+     * Load the image
+     * 
+     * @param view the ImageView to load it in to
+     * @param uri the Uri or other reference
+     * @param exifOrientation the EXIT orientation value
+     */
+    public void load(@NonNull SubsamplingScaleImageView view, @NonNull String uri, int exifOrientation) {
+        load(view, uri);
+    }
 
     /**
      * Show the location of the photo on the map

--- a/src/main/java/de/blau/android/util/ImagePagerAdapter.java
+++ b/src/main/java/de/blau/android/util/ImagePagerAdapter.java
@@ -1,5 +1,6 @@
 package de.blau.android.util;
 
+import java.io.Serializable;
 import java.util.List;
 
 import android.content.Context;
@@ -10,12 +11,12 @@ import android.widget.LinearLayout;
 import androidx.annotation.NonNull;
 import androidx.viewpager.widget.PagerAdapter;
 
-public class ImagePagerAdapter extends PagerAdapter {
+public class ImagePagerAdapter<T extends Serializable> extends PagerAdapter {
 
-    protected final Context      mContext;
-    protected LayoutInflater     mLayoutInflater;
-    protected final ImageLoader  loader;
-    protected final List<String> images;
+    protected final Context     mContext;
+    protected LayoutInflater    mLayoutInflater;
+    protected final ImageLoader loader;
+    protected final List<T>     images;
 
     /**
      * Construct a new adapter
@@ -24,7 +25,7 @@ public class ImagePagerAdapter extends PagerAdapter {
      * @param loader the PhotoLoader to use
      * @param images list of images
      */
-    public ImagePagerAdapter(@NonNull Context context, @NonNull ImageLoader loader, @NonNull List<String> images) {
+    public ImagePagerAdapter(@NonNull Context context, @NonNull ImageLoader loader, @NonNull List<T> images) {
         mContext = context;
         this.loader = loader;
         this.images = images;

--- a/src/main/java/de/blau/android/util/SelectByImageFragment.java
+++ b/src/main/java/de/blau/android/util/SelectByImageFragment.java
@@ -1,5 +1,7 @@
 package de.blau.android.util;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,8 +40,8 @@ import de.blau.android.listener.DoNothingListener;
  *
  */
 public class SelectByImageFragment extends SizedDynamicImmersiveDialogFragment implements OnMenuItemClickListener {
-    private static final String DEBUG_TAG = SelectByImageFragment.class.getSimpleName().substring(0,
-            Math.min(23, SelectByImageFragment.class.getSimpleName().length()));
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, SelectByImageFragment.class.getSimpleName().length());
+    private static final String DEBUG_TAG = SelectByImageFragment.class.getSimpleName().substring(0, TAG_LEN);
 
     public static final String TAG = "fragment_combo_image_viewer";
 
@@ -189,7 +191,7 @@ public class SelectByImageFragment extends SizedDynamicImmersiveDialogFragment i
         return layout;
     }
 
-    private class SelectImagePagerAdapter extends ImagePagerAdapter {
+    private class SelectImagePagerAdapter extends ImagePagerAdapter<String> {
 
         /**
          * Construct a new adapter

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -469,6 +469,7 @@
     <string name="layer_gpx">GPX</string>
     <string name="layer_gpx_recording">GPX recording</string>
     <string name="layer_photos">Photos</string>
+    <string name="layer_photos_reindex">Reindex</string>
     <string name="layer_tasks">Tasks</string>
     <string name="layer_data">OSM data</string>
     <string name="layer_data_name">%1$s data</string>


### PR DESCRIPTION
Instead of relying on SubsamplingScaleImageView being able to read the EXIF image orientation from the image, extract and store it while indexing the images. 

Adds a reindex function to the photo layer entry and some fixes to the image info modal.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/2667