### PR TITLE
Remove navigation and sign up tag from osm.org login page

### DIFF
--- a/src/main/java/de/blau/android/Authorize.java
+++ b/src/main/java/de/blau/android/Authorize.java
@@ -111,6 +111,7 @@ public class Authorize extends WebViewActivity {
 
         @Override
         public void onPageFinished(WebView view, String url) {
+            super.onPageFinished(view, url);
             synchronized (progressLock) {
                 synchronized (webViewLock) {
                     if (progressShown && webView != null) {
@@ -119,6 +120,20 @@ public class Authorize extends WebViewActivity {
                     }
                 }
             }
+            
+            // Remove navigation and sign up tab from osm.org 
+            // @formatter:off
+            String script = "(function() {" 
+                    + "var navs = document.getElementsByTagName('nav');" 
+                    + "for (let nav of navs) {" 
+                    + "  nav.innerHTML = '';" 
+                    + "}"
+                    + "var tabs = document.getElementsByClassName('nav-item');" 
+                    + "for (let tab of tabs) {" 
+                    + "  tab.innerHTML = '';" 
+                    + "} })();";
+            // @formatter:on
+            view.evaluateJavascript(script, null);
         }
 
         @Override


### PR DESCRIPTION
This is a hack/plan B to address google blocking us because the sign up tag is visible on openstreetmap.org

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/2672