### PR TITLE
When formatting bounding box coords round down

### DIFF
--- a/src/main/java/de/blau/android/resources/TileLayerDialog.java
+++ b/src/main/java/de/blau/android/resources/TileLayerDialog.java
@@ -4,9 +4,10 @@ import static de.blau.android.contract.Constants.LOG_TAG_LEN;
 
 import java.io.File;
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -697,7 +698,7 @@ public class TileLayerDialog extends ImmersiveDialogFragment {
     @NonNull
     private String formatDouble(double d) {
         try {
-            return String.format(Locale.US, "%.5f", d);
+            return BigDecimal.valueOf(d).setScale(5, RoundingMode.DOWN).toString();
         } catch (Exception e) {
             Log.w(DEBUG_TAG, "Formatting failed " + e.getMessage());
             return "";


### PR DESCRIPTION
In the case that the lat bounds of the bounding box were pre-filled with the max web-mercator value with more than 5 digits of precision, rounding would lead to the value being larger than the max web-mercator value, leading to creation of the bounding box failing.