### PR TITLE
Fix NumberPicker behaviour on Android 8 and earlier

### DIFF
--- a/src/main/java/de/blau/android/propertyeditor/tagform/IntegerValueFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/IntegerValueFragment.java
@@ -118,18 +118,19 @@ public class IntegerValueFragment extends ValueWidgetFragment {
             picker.setValue(v + offset);
             picker.setBackgroundColor(ThemeUtils.getStyleAttribColorValue(activity, R.attr.highlight_background, R.color.black));
             picker.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT, 0));
-
+            
             // see
             // https://stackoverflow.com/questions/17708325/android-numberpicker-with-formatter-doesnt-format-on-first-rendering
             View editView = picker.getChildAt(0);
             if (editView instanceof EditText) {
                 // Remove default input filter
                 ((EditText) editView).setFilters(new InputFilter[0]);
+                ((EditText) editView).setFocusable(false);
             }
         }
 
         /**
-         * Parse a String as an int and add it to a List if sucessful
+         * Parse a String as an int and add it to a List if successful
          * 
          * @param ints target list of ints
          * @param val value to parse and add


### PR DESCRIPTION
On Android 8 and earlier clicking on a number picker will make it do essentially random things. Making the center EditText non-focusable seems to make the behaviour mirror that of later versions.

Long term solution is likely to replace the use of the system number picker with something sane.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/2689