### PR TITLE
Support value type "cardinal_direction" and specific row class for value display

### DIFF
--- a/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
+++ b/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
@@ -322,7 +322,7 @@ public class PropertyEditorTest {
             fail();
         }
         assertNotNull(direction);
-        assertEquals("Type or tap for values", direction.getText());
+        assertEquals(main.getString(R.string.tag_dialog_value_hint), direction.getText());
         direction.clickAndWait(Until.newWindow(), 2000);
         TestUtils.clickText(device, true, main.getString(R.string.save), true, false);
         TestUtils.clickHome(device, true);
@@ -371,12 +371,12 @@ public class PropertyEditorTest {
             fail();
         }
         assertNotNull(direction);
-        assertEquals("Type or tap for values", direction.getText());
+        assertEquals(main.getString(R.string.tag_dialog_value_hint), direction.getText());
         direction.clickAndWait(Until.newWindow(), 2000);
         TestUtils.clickText(device, true, "Forward", false, false);
         TestUtils.clickText(device, true, main.getString(R.string.save), true, false);
         TestUtils.clickHome(device, true);
-        assertEquals("forward", n.getTagWithKey("direction"));
+        assertEquals("forward", n.getTagWithKey("direction").toLowerCase());
     }
 
     @Test
@@ -410,7 +410,7 @@ public class PropertyEditorTest {
             fail();
         }
         assertNotNull(direction);
-        assertEquals("forward", direction.getText());
+        assertEquals("forward", direction.getText().toLowerCase());
         direction.clickAndWait(Until.newWindow(), 2000);
         TestUtils.clickText(device, true, "Forward", false, false);
         TestUtils.clickText(device, true, main.getString(R.string.save), true, false);

--- a/src/main/java/de/blau/android/easyedit/NodeSelectionActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/NodeSelectionActionModeCallback.java
@@ -24,6 +24,7 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AlertDialog.Builder;
 import androidx.appcompat.app.AppCompatDialog;
 import androidx.appcompat.view.ActionMode;
+import de.blau.android.App;
 import de.blau.android.DisambiguationMenu;
 import de.blau.android.R;
 import de.blau.android.dialogs.ElementIssueDialog;
@@ -36,6 +37,7 @@ import de.blau.android.osm.Relation;
 import de.blau.android.osm.Result;
 import de.blau.android.osm.Tags;
 import de.blau.android.osm.Way;
+import de.blau.android.presets.Preset;
 import de.blau.android.util.GeoMath;
 import de.blau.android.util.ScreenMessage;
 import de.blau.android.util.Sound;
@@ -67,6 +69,7 @@ public class NodeSelectionActionModeCallback extends ElementSelectionActionModeC
     private MenuItem         restrictionItem;
     private MenuItem         rotateItem;
     private int              action;
+    private Preset[]         presets;
 
     /**
      * Construct a callback for Node selection
@@ -86,9 +89,9 @@ public class NodeSelectionActionModeCallback extends ElementSelectionActionModeC
         main.invalidateMap();
         mode.setTitle(R.string.actionmode_nodeselect);
         mode.setSubtitle(null);
-
+        presets = App.getCurrentPresets(main);
         menu = replaceMenu(menu, mode, this);
-        SortedMap<String, String> tags = ((Node) element).getTags();
+        SortedMap<String, String> tags = element.getTags();
         if (!tags.containsKey(Tags.KEY_ADDR_HOUSENUMBER) && !tags.containsKey(Tags.KEY_HIGHWAY)) {
             // exclude some stuff that typically doesn't have an address
             menu.add(Menu.NONE, MENUITEM_ADDRESS, Menu.NONE, R.string.tag_menu_address).setIcon(ThemeUtils.getResIdFromAttribute(main, R.attr.menu_address));
@@ -137,7 +140,7 @@ public class NodeSelectionActionModeCallback extends ElementSelectionActionModeC
         }
         updated |= setItemVisibility(highways.size() >= 2, restrictionItem, false);
 
-        updated |= setItemVisibility(Tags.getDirectionKey(element) != null, rotateItem, false);
+        updated |= setItemVisibility(Tags.getDirectionKey(Preset.findBestMatch(presets, element.getTags(), null, null), element) != null, rotateItem, false);
 
         if (updated) {
             arrangeMenu(menu);

--- a/src/main/java/de/blau/android/easyedit/ReplaceGeometryActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/ReplaceGeometryActionModeCallback.java
@@ -7,14 +7,11 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 
-import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
-import android.content.DialogInterface.OnDismissListener;
 import android.util.Log;
 import android.view.Menu;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.appcompat.view.ActionMode;
 import de.blau.android.App;
 import de.blau.android.Logic;
@@ -22,12 +19,10 @@ import de.blau.android.R;
 import de.blau.android.dialogs.ElementIssueDialog;
 import de.blau.android.exception.OsmIllegalOperationException;
 import de.blau.android.exception.StorageException;
-import de.blau.android.osm.GeoPoint;
 import de.blau.android.osm.MergeAction;
 import de.blau.android.osm.Node;
 import de.blau.android.osm.OsmElement;
 import de.blau.android.osm.Result;
-import de.blau.android.osm.StorageDelegator;
 import de.blau.android.osm.Way;
 import de.blau.android.util.SerializableState;
 

--- a/src/main/java/de/blau/android/osm/Tags.java
+++ b/src/main/java/de/blau/android/osm/Tags.java
@@ -11,6 +11,10 @@ import java.util.Set;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import de.blau.android.presets.PresetField;
+import de.blau.android.presets.PresetItem;
+import de.blau.android.presets.PresetTagField;
+import de.blau.android.presets.ValueType;
 
 /**
  * Key and value constants for tags that are used in the code
@@ -281,19 +285,20 @@ public final class Tags {
     public static final String KEY_CAMERA_DIRECTION = "camera:direction";
     public static final String KEY_LIGHT_DIRECTION  = "light:direction";
 
-    public static final List<String> DIRECTION_KEYS = Collections.unmodifiableList(Arrays.asList(KEY_DIRECTION, KEY_CAMERA_DIRECTION, KEY_LIGHT_DIRECTION));
-
     /**
      * Get a direction key if any are present from the OSM element
      * 
+     * @param presetItem matching preset item
      * @param e the OSM element
      * @return the key or null
      */
     @Nullable
-    public static String getDirectionKey(@NonNull OsmElement e) {
-        for (String key : Tags.DIRECTION_KEYS) {
-            if (e.hasTagKey(key)) {
-                return key;
+    public static String getDirectionKey(@Nullable PresetItem presetItem, @NonNull OsmElement e) {
+        if (presetItem != null) {
+            for (PresetField field : presetItem.getFields().values()) {
+                if (field instanceof PresetTagField && ((PresetTagField) field).getValueType() == ValueType.CARDINAL_DIRECTION) {
+                    return ((PresetTagField) field).getKey();
+                }
             }
         }
         return null;

--- a/src/main/java/de/blau/android/presets/ValueType.java
+++ b/src/main/java/de/blau/android/presets/ValueType.java
@@ -5,7 +5,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 public enum ValueType {
-    OPENING_HOURS, OPENING_HOURS_MIXED, DIMENSION_HORIZONTAL, DIMENSION_VERTICAL, INTEGER, WEBSITE, PHONE, WIKIPEDIA, WIKIDATA;
+    OPENING_HOURS, OPENING_HOURS_MIXED, DIMENSION_HORIZONTAL, DIMENSION_VERTICAL, INTEGER, WEBSITE, PHONE, WIKIPEDIA, WIKIDATA, CARDINAL_DIRECTION;
 
     /**
      * Get a ValueType corresponding to the input String
@@ -43,6 +43,9 @@ public enum ValueType {
             break;
         case "wikidata":
             type = WIKIDATA;
+            break;
+        case "cardinal_direction":
+            type = CARDINAL_DIRECTION;
             break;
         default:
             Log.e(ValueType.class.getSimpleName(), "Unknown value type string " + typeString);

--- a/src/main/java/de/blau/android/propertyeditor/tagform/IntegerValueFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/IntegerValueFragment.java
@@ -125,7 +125,7 @@ public class IntegerValueFragment extends ValueWidgetFragment {
             if (editView instanceof EditText) {
                 // Remove default input filter
                 ((EditText) editView).setFilters(new InputFilter[0]);
-                ((EditText) editView).setFocusable(false);
+                editView.setFocusable(false);
             }
         }
 

--- a/src/main/java/de/blau/android/propertyeditor/tagform/TagFormFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/TagFormFragment.java
@@ -1014,6 +1014,10 @@ public class TagFormFragment extends BaseFragment implements FormUpdate {
                 rowLayout.addView(LongTextDialogRow.getRow(this, inflater, rowLayout, preset, (PresetTextField) field, value, maxStringLength));
                 return;
             }
+            if ( ValueType.INTEGER == valueType || ValueType.CARDINAL_DIRECTION == valueType) {
+                rowLayout.addView(ValueWidgetRow.getRow(this, inflater, rowLayout, preset, field, value, values, allTags));
+                return;
+            }
             rowLayout.addView(TextRow.getRow(this, inflater, rowLayout, preset, field, value, values, allTags));
             return;
         }

--- a/src/main/java/de/blau/android/propertyeditor/tagform/TagFormFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/TagFormFragment.java
@@ -993,7 +993,7 @@ public class TagFormFragment extends BaseFragment implements FormUpdate {
         ValueType valueType = field.getValueType();
         if (field instanceof PresetTextField || key.startsWith(Tags.KEY_ADDR_BASE)
                 || (isComboField && ((PresetComboField) field).isEditable() && ValueType.OPENING_HOURS_MIXED != valueType) || Tags.isConditional(key)
-                || ValueType.INTEGER == valueType || Tags.DIRECTION_KEYS.contains(key)) {
+                || ValueType.INTEGER == valueType || ValueType.CARDINAL_DIRECTION == valueType) {
             if (Tags.isConditional(key)) {
                 rowLayout.addView(getConditionalRestrictionDialogRow(rowLayout, preset, hint, key, value, values, allTags));
                 return;

--- a/src/main/java/de/blau/android/propertyeditor/tagform/TextRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/TextRow.java
@@ -178,7 +178,6 @@ public class TextRow extends LinearLayout implements KeyValueRow, TagChanged {
         final TextRow row = (TextRow) inflater.inflate(R.layout.tag_form_text_row, rowLayout, false);
         final String key = field.getKey();
         final String hint = preset != null ? field.getHint() : null;
-        final String defaultValue = field.getDefaultValue();
         row.valueType = preset != null ? preset.getValueType(key) : null;
         final boolean isName = Tags.isLikeAName(key);
         final Context context = rowLayout.getContext();
@@ -216,24 +215,6 @@ public class TextRow extends LinearLayout implements KeyValueRow, TagChanged {
                         caller.getValueAutocompleteAdapter(key, values, preset, null, allTags, true, false, -1), row, valueType, imperial);
                 dialog.setOnDismissListener(d -> finalView.setEnabled(true));
                 dialog.show();
-            });
-        }
-        if (ValueType.INTEGER == valueType) {
-            ourValueView.setFocusable(false);
-            ourValueView.setFocusableInTouchMode(false);
-            ourValueView.setOnClickListener(v -> {
-                final View finalView = v;
-                finalView.setEnabled(false); // debounce
-                IntegerValueFragment.show(caller, hint != null ? hint : key, key, ((TextView) v).getText().toString(), values, preset, allTags);
-            });
-        }
-        if (ValueType.CARDINAL_DIRECTION == valueType) {
-            ourValueView.setFocusable(false);
-            ourValueView.setFocusableInTouchMode(false);
-            ourValueView.setOnClickListener(v -> {
-                final View finalView = v;
-                finalView.setEnabled(false); // debounce
-                DirectionValueFragment.show(caller, hint != null ? hint : key, key, ((TextView) v).getText().toString(), values, preset, allTags);
             });
         }
         ourValueView.setOnFocusChangeListener((v, hasFocus) -> {

--- a/src/main/java/de/blau/android/propertyeditor/tagform/TextRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/TextRow.java
@@ -227,8 +227,7 @@ public class TextRow extends LinearLayout implements KeyValueRow, TagChanged {
                 IntegerValueFragment.show(caller, hint != null ? hint : key, key, ((TextView) v).getText().toString(), values, preset, allTags);
             });
         }
-        if (Tags.DIRECTION_KEYS.contains(key)
-                && (preset == null || !(preset.hasKeyValue(Tags.KEY_HIGHWAY, Tags.VALUE_MINI_ROUNDABOUT) && Tags.KEY_DIRECTION.equals(key)))) {
+        if (ValueType.CARDINAL_DIRECTION == valueType) {
             ourValueView.setFocusable(false);
             ourValueView.setFocusableInTouchMode(false);
             ourValueView.setOnClickListener(v -> {

--- a/src/main/java/de/blau/android/propertyeditor/tagform/ValueWidgetRow.java
+++ b/src/main/java/de/blau/android/propertyeditor/tagform/ValueWidgetRow.java
@@ -1,0 +1,109 @@
+package de.blau.android.propertyeditor.tagform;
+
+import java.util.List;
+import java.util.Map;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.LinearLayout;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import de.blau.android.R;
+import de.blau.android.presets.PresetComboField;
+import de.blau.android.presets.PresetItem;
+import de.blau.android.presets.PresetTagField;
+import de.blau.android.presets.ValueType;
+import de.blau.android.propertyeditor.TagChanged;
+import de.blau.android.util.StringWithDescription;
+
+public class ValueWidgetRow extends DialogRow implements TagChanged {
+
+    private ValueType      valueType;
+    private PresetTagField field;
+
+    /**
+     * Construct a row that will display a Dialog when clicked
+     * 
+     * @param context Android Context
+     */
+    public ValueWidgetRow(@NonNull Context context) {
+        super(context);
+    }
+
+    /**
+     * Construct a row that will display a Dialog when clicked
+     * 
+     * @param context Android Context
+     * @param attrs an AttributeSet
+     */
+    public ValueWidgetRow(@NonNull Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    /**
+     * Add a row that displays a dialog for selecting a single when clicked
+     * 
+     * @param caller the calling TagFormFragment instance
+     * @param inflater the inflater to use
+     * @param rowLayout the Layout holding the roes
+     * @param preset the relevant PresetItem
+     * @param field the current PresetTagField
+     * @param value the current value
+     * @param values all relevant values (preset MRU etc)
+     * @param allTags all current tags
+     * @return a ValueWidgetRow
+     */
+    static ValueWidgetRow getRow(@NonNull final TagFormFragment caller, @NonNull final LayoutInflater inflater, @NonNull final LinearLayout rowLayout,
+            @NonNull final PresetItem preset, @NonNull final PresetTagField field, @Nullable final String value, @Nullable final List<String> values,
+            @NonNull final Map<String, String> allTags) {
+        final ValueWidgetRow row = (ValueWidgetRow) inflater.inflate(R.layout.tag_form_value_widget_row, rowLayout, false);
+        final String key = field.getKey();
+        final String hint = field.getHint();
+        row.keyView.setText(hint);
+        row.keyView.setTag(key);
+        row.setPreset(preset);
+        row.valueType = preset.getValueType(key);
+        row.field = field;
+
+        row.valueView.setHint(R.string.tag_dialog_value_hint);
+        row.setValue(value == null ? "" : value);
+
+        row.valueView.setFocusable(false);
+        row.valueView.setFocusableInTouchMode(false);
+        row.setOnClickListener(v -> {
+            final View finalView = v;
+            finalView.setEnabled(false); // debounce
+            if (ValueType.INTEGER == row.valueType) {
+                IntegerValueFragment.show(caller, hint, key, row.getValue(), values, preset, allTags);
+            }
+            if (ValueType.CARDINAL_DIRECTION == row.valueType) {
+                DirectionValueFragment.show(caller, hint, key, row.getValue(), values, preset, allTags);
+            }
+        });
+        return row;
+    }
+
+    @Override
+    public void changed(String key, String value) {
+        if (key.equals(this.getKey())) {
+            valueView.setEnabled(true);
+            setValue(value);
+        }
+    }
+
+    @Override
+    public void setValue(@NonNull String value) {
+        // it might be simpler to simply use the normal autocomplete adapter here
+        if (field instanceof PresetComboField) {
+            for (StringWithDescription swd : ((PresetComboField) field).getValues()) {
+                if (value.equals(swd.getValue())) {
+                    setValue(swd);
+                    return;
+                }
+            }
+        }
+        super.setValue(value);
+    }
+}

--- a/src/main/res/layout/tag_form_value_widget_row.xml
+++ b/src/main/res/layout/tag_form_value_widget_row.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- inner classes must be specified using <view class="classname" /> due to dollar sign -->
+<view xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    class="de.blau.android.propertyeditor.tagform.ValueWidgetRow"
+    android:orientation="horizontal" >
+
+    <LinearLayout
+        style="?attr/Layout"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:baselineAligned="false"
+        android:orientation="horizontal"
+        android:saveEnabled="false" >
+
+        <TextView
+            android:id="@+id/textKey"
+            style="?attr/StaticText"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:layout_marginBottom="1dp"
+            android:layout_marginRight="1dp"
+            android:layout_marginEnd="1dp"
+            android:layout_weight="3"
+            android:gravity="center_vertical"
+            android:maxLines="3"
+            android:minHeight="34dp"
+            android:paddingLeft="5dp"
+            android:paddingRight="5dp"
+            android:saveEnabled="false" />
+
+        <TextView
+            android:id="@+id/textValue"
+            style="?attr/StaticText"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:layout_marginBottom="1dp"
+            android:layout_marginLeft="0dp"
+            android:layout_marginRight="0dp"
+            android:layout_weight="2"
+            android:gravity="center_vertical"
+            android:drawableEnd="?attr/edit"
+            android:drawableRight="?attr/edit"
+            android:focusable="false"
+            android:focusableInTouchMode="false"
+            android:minHeight="34dp"
+            android:paddingLeft="5dp"
+            android:paddingStart="5dp"
+            android:paddingRight="3dp"
+            android:paddingEnd="3dp"
+            android:saveEnabled="false" 
+            android:singleLine="true"
+            android:ellipsize="none" />
+    </LinearLayout>
+
+</view>


### PR DESCRIPTION
This changes behaviour to only show the compass widget for fields with value_type=cardinal_direction, and use a specific row that can display the display values.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/2626
Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/2655