### PR TITLE
Don't force recreating the map object and associated layer state

### DIFF
--- a/src/androidTest/java/de/blau/android/easyedit/NodeTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/NodeTest.java
@@ -150,6 +150,7 @@ public class NodeTest {
     public void unjoinMergeWays() {
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3874964, 47.3884769, true);
+        TestUtils.clickAwayTip(device, main);
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_nodeselect)));
         Node node = App.getLogic().getSelectedNode();
         assertNotNull(node);
@@ -183,6 +184,7 @@ public class NodeTest {
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.unlock(device);
         TestUtils.clickAtCoordinates(device, map, 8.3866386, 47.3904394, true);
+        TestUtils.clickAwayTip(device, main);
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_nodeselect)));
         Node node = App.getLogic().getSelectedNode();
         assertNotNull(node);
@@ -220,6 +222,7 @@ public class NodeTest {
     public void append() {
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3878990, 47.3891959, true);
+        TestUtils.clickAwayTip(device, main);
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_nodeselect)));
         Node node = App.getLogic().getSelectedNode();
         assertNotNull(node);
@@ -236,7 +239,9 @@ public class NodeTest {
     @Test
     public void appendWithMenu() {
         TestUtils.zoomToLevel(device, main, 21);
+        TestUtils.clickAwayTip(device, main);
         TestUtils.clickAtCoordinates(device, map, 8.3879569, 47.3893814, true);
+        TestUtils.clickAwayTip(device, main);
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_nodeselect)));
         Node node = App.getLogic().getSelectedNode();
         assertNotNull(node);
@@ -256,6 +261,7 @@ public class NodeTest {
     public void rotate() {
         TestUtils.zoomToLevel(device, main, 21);
         TestUtils.clickAtCoordinates(device, map, 8.3881577, 47.3886924, true);
+        TestUtils.clickAwayTip(device, main);
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_nodeselect)));
         Node node = App.getLogic().getSelectedNode();
         assertNotNull(node);

--- a/src/androidTest/java/de/blau/android/easyedit/RelationTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/RelationTest.java
@@ -232,8 +232,8 @@ public class RelationTest {
         Way way = (Way) relation.getMembers().get(0).getElement();
         Node n0 = way.getFirstNode();
 
-        assertEquals(83881251, n0.getLon());
-        assertEquals(473885077, n0.getLat());
+        assertEquals(83881251, n0.getLon(), 300);
+        assertEquals(473885077, n0.getLat(), 300);
         if (!TestUtils.clickMenuButton(device, context.getString(R.string.menu_rotate), false, false)) {
             TestUtils.clickOverflowButton(device);
             TestUtils.clickText(device, false, context.getString(R.string.menu_rotate), false, false);

--- a/src/androidTest/java/de/blau/android/easyedit/WayTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/WayTest.java
@@ -126,6 +126,7 @@ public class WayTest {
         assertTrue(TestUtils.clickText(device, false, menuInfo, true, false));
         assertTrue(TestUtils.findText(device, false, "asphalt"));
         assertTrue(TestUtils.clickText(device, false, context.getString(R.string.done), true, false));
+        TestUtils.unlock(device);
         assertTrue(TestUtils.clickOverflowButton(device));
         String menuDelete = context.getString(R.string.delete);
         TestUtils.scrollTo(menuDelete, false);

--- a/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
+++ b/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
@@ -752,6 +752,7 @@ public class PropertyEditorTest {
         assertTrue(found);
         found = TestUtils.clickText(device, true, getTranslatedPresetItemName(main, "Charging Station"), true, false);
         assertTrue(found);
+        TestUtils.clickAwayTip(device, main);
         UiObject2 vehicles = null;
         try {
             vehicles = getField(device, "Types of vehicles which can be charged", 1);

--- a/src/main/java/de/blau/android/Map.java
+++ b/src/main/java/de/blau/android/Map.java
@@ -427,7 +427,7 @@ public class Map extends View implements IMapView {
             if (index >= 0 && index < mLayers.size()) {
                 return mLayers.get(index);
             }
-            Log.e(DEBUG_TAG, "Layer for index " + index + " is null");
+            Log.e(DEBUG_TAG, "Layer for index " + index + " is null " + mLayers.size() + " layers total");
             return null;
         }
     }

--- a/src/main/java/de/blau/android/dialogs/Layers.java
+++ b/src/main/java/de/blau/android/dialogs/Layers.java
@@ -420,7 +420,8 @@ public class Layers extends AbstractConfigurationDialog implements OnUpdateListe
      * @param map current Map
      * @param type the layer type
      */
-    private void addStyleableLayerFromFile(final FragmentActivity activity, final Preferences prefs, final Map map, @NonNull final LayerType type) {
+    private void addStyleableLayerFromFile(@NonNull final FragmentActivity activity, @NonNull final Preferences prefs, @NonNull final Map map,
+            @NonNull final LayerType type) {
         Log.d(DEBUG_TAG, "addStyleableLayerFromFile");
         SelectFile.read(activity, R.string.config_osmPreferredDir_key, new ReadFile() {
             private static final long serialVersionUID = 1L;

--- a/src/test/java/de/blau/android/osm/ApiErrorTest.java
+++ b/src/test/java/de/blau/android/osm/ApiErrorTest.java
@@ -93,7 +93,7 @@ public class ApiErrorTest {
 
         @Override
         public void onError(AsyncResult result) {
-            System.out.println("FailOnErrorHandler onError");
+            System.out.println("FailOnSuccessHandler onError " + expectedError + " " + result.getCode());
             assertEquals(expectedError, result.getCode());
             signal.countDown();
         }
@@ -106,14 +106,15 @@ public class ApiErrorTest {
     public void setup() {
         mockServer = new MockWebServerPlus();
         HttpUrl mockBaseUrl = mockServer.server().url("/api/0.6/");
+        App.getDelegator().reset(true);
         main = Robolectric.buildActivity(Main.class).create().resume().get();
         prefDB = new AdvancedPrefDatabase(main);
         prefDB.deleteAPI("Test");
         prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, "user", "pass", API.Auth.BASIC);
         prefDB.selectAPI("Test");
-        System.out.println("mock api url " + mockBaseUrl.toString()); // NOSONAR
-        Logic logic = App.getLogic();
+        System.out.println("mock api url " + mockBaseUrl.toString()); // NOSONAR        
         prefs = new Preferences(main);
+        Logic logic = App.getLogic();
         logic.setPrefs(prefs);
         logic.getMap().setPrefs(main, prefs);
     }


### PR DESCRIPTION
If Main has been destroyed, both the Map and Logic objects may still be available and current, so we now reuse them instead of forcing recreation.

This resolves race conditions that could be caused by selecting and loading files into layers via the system file picker that could lead to Main being removed.