### PR TITLE
Add a preference to completely disable auto-pruning

### DIFF
--- a/documentation/docs/help/en/Advanced preferences.md
+++ b/documentation/docs/help/en/Advanced preferences.md
@@ -228,10 +228,18 @@ When auto-downloading, the radius of the area that is attempted to download arou
 
 Maximum speed up to which auto-download is attempted. Default: _10 km/h_.
 
+### Auto-prune
+
+Enable/disable automatically pruning in memory data and tasks. Default: _on_.
+
 ### Auto-prune limit
 
-Limit at, when reached, an automatic prune of the data in memory is attempted. Default: _5000 Nodes_.
+Limit at, when reached, an automatic prune of the data in memory is attempted. Requires _Auto prune_ to be on. Default: _5000 Nodes_.
 
+### Auto-prune Bounding Boxes limit
+
+Number of Bounding Boxes in memory that when reached will trigger a prune. Requires _Auto prune_ to be on. Default: _100 Bounding boxes_.
+    
 ### Zoom limit
 
 Minimum zoom for pan and zoom auto-download to work. In high data density areas this should be set to higher values to avoid loading very large amounts of data when zooming out. 
@@ -247,7 +255,7 @@ Maximum speed up to which auto-download of notes and bugs is attempted. Default:
 
 ### Task auto-prune limit
 
-Limit at, when reached, an automatic prune of the tasks in memory is attempted. Default: _10000 Tasks_.
+Limit at, when reached, an automatic prune of the tasks in memory is attempted. Requires _Auto prune_ to be on. Default: _10000 Tasks_.
 
 ## Location Settings
 

--- a/src/main/assets/help/en/Advanced preferences.html
+++ b/src/main/assets/help/en/Advanced preferences.html
@@ -120,8 +120,12 @@
 <p>When auto-downloading, the radius of the area that is attempted to download around the current position. In pan and zoom auto-download mode, this is the minimum download size. Default: <em>50 meters</em>.</p>
 <h3>Maximum auto-download speed</h3>
 <p>Maximum speed up to which auto-download is attempted. Default: <em>10 km/h</em>.</p>
+<h3>Auto-prune</h3>
+<p>Enable/disable automatically pruning in memory data and tasks. Default: <em>on</em>.</p>
 <h3>Auto-prune limit</h3>
-<p>Limit at, when reached, an automatic prune of the data in memory is attempted. Default: <em>5000 Nodes</em>.</p>
+<p>Limit at, when reached, an automatic prune of the data in memory is attempted. Requires <em>Auto prune</em> to be on. Default: <em>5000 Nodes</em>.</p>
+<h3>Auto-prune Bounding Boxes limit</h3>
+<p>Number of Bounding Boxes in memory that when reached will trigger a prune. Requires <em>Auto prune</em> to be on. Default: <em>100 Bounding boxes</em>.</p>
 <h3>Zoom limit</h3>
 <p>Minimum zoom for pan and zoom auto-download to work. In high data density areas this should be set to higher values to avoid loading very large amounts of data when zooming out. This is used both for data and tasks. Default: <em>17</em>.</p>
 <h3>Task download radius</h3>
@@ -129,7 +133,7 @@
 <h3>Maximum task auto-download speed</h3>
 <p>Maximum speed up to which auto-download of notes and bugs is attempted. Default: <em>30 km/h</em>.</p>
 <h3>Task auto-prune limit</h3>
-<p>Limit at, when reached, an automatic prune of the tasks in memory is attempted. Default: <em>10000 Tasks</em>.</p>
+<p>Limit at, when reached, an automatic prune of the tasks in memory is attempted. Requires <em>Auto prune</em> to be on. Default: <em>10000 Tasks</em>.</p>
 <h2>Location Settings</h2>
 <p>GPS and Network location settings.</p>
 <h3>GPS/GNSS source</h3>

--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -3094,7 +3094,7 @@ public class Logic {
                 Server server = prefs.getServer();
                 mapBox.makeValidForApi(server.getCachedCapabilities().getMaxArea());
                 AsyncResult result = download(context, server, mapBox, postMerge, handler, true, true);
-                if (getDelegator().reachedPruneLimits(prefs.getAutoPruneNodeLimit(), prefs.getAutoPruneBoundingBoxLimit())) {
+                if (prefs.autoPrune() && getDelegator().reachedPruneLimits(prefs.getAutoPruneNodeLimit(), prefs.getAutoPruneBoundingBoxLimit())) {
                     ViewBox pruneBox = new ViewBox(map.getViewBox());
                     pruneBox.scale(1.6);
                     getDelegator().prune(pruneBox);

--- a/src/main/java/de/blau/android/layer/data/MapOverlay.java
+++ b/src/main/java/de/blau/android/layer/data/MapOverlay.java
@@ -127,6 +127,7 @@ public class MapOverlay<O extends OsmElement> extends MapViewLayer
     private final int houseNumberRadius;
     private final int verticalNumberOffset;
     private float     maxDownloadSpeed;
+    private boolean   autoPruneEnabled     = false;
     private int       autoPruneNodeLimit   = DEFAULT_AUTOPRUNE_NODE_LIMIT; // node count for autoprune
     private int       autoDownloadBoxLimit = DEFAULT_DOWNLOADBOX_LIMIT;
     private int       panAndZoomLimit      = PAN_AND_ZOOM_LIMIT;
@@ -405,10 +406,6 @@ public class MapOverlay<O extends OsmElement> extends MapViewLayer
             box.ensureMinumumSize(minDownloadSize); // enforce a minimum size
             List<BoundingBox> bboxes = BoundingBox.newBoxes(bbList, box);
             for (BoundingBox b : bboxes) {
-                if (b.getWidth() <= 1 || b.getHeight() <= 1) {
-                    Log.w(DEBUG_TAG, "getNextCenter very small bb " + b.toString());
-                    continue;
-                }
                 delegator.addBoundingBox(b);
                 final Logic logic = App.getLogic();
                 try {
@@ -432,7 +429,7 @@ public class MapOverlay<O extends OsmElement> extends MapViewLayer
                     logic.removeBoundingBox(b);
                 }
             }
-            if ((System.currentTimeMillis() - lastAutoPrune) > AUTOPRUNE_MIN_INTERVAL
+            if (autoPruneEnabled && (System.currentTimeMillis() - lastAutoPrune) > AUTOPRUNE_MIN_INTERVAL
                     && delegator.reachedPruneLimits(autoPruneNodeLimit, autoDownloadBoxLimit)) {
                 try {
                     dataThreadPoolExecutor.execute(MapOverlay.this::prune);
@@ -1754,6 +1751,7 @@ public class MapOverlay<O extends OsmElement> extends MapViewLayer
         panAndZoomDownLoad = prefs.getPanAndZoomAutoDownload();
         minDownloadSize = prefs.getDownloadRadius() * 2;
         maxDownloadSpeed = prefs.getMaxBugDownloadSpeed() / 3.6f;
+        autoPruneEnabled = prefs.autoPrune();
         autoPruneNodeLimit = prefs.getAutoPruneNodeLimit();
         autoDownloadBoxLimit = prefs.getAutoPruneBoundingBoxLimit();
         panAndZoomLimit = prefs.getPanAndZoomLimit();

--- a/src/main/java/de/blau/android/osm/BoundingBox.java
+++ b/src/main/java/de/blau/android/osm/BoundingBox.java
@@ -735,7 +735,11 @@ public class BoundingBox implements Serializable, JosmXmlSerializable, BoundedOb
             }
             if (changed) {
                 result.clear();
-                result.addAll(temp);
+                for (BoundingBox box : temp) {
+                    if (box.getWidth() > 1 && box.getHeight() > 1) { // don't add mini boxes
+                        result.add(box);
+                    }
+                }
             }
         }
         return result;

--- a/src/main/java/de/blau/android/prefs/AdvancedPrefEditorFragment.java
+++ b/src/main/java/de/blau/android/prefs/AdvancedPrefEditorFragment.java
@@ -14,11 +14,13 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.core.os.LocaleListCompat;
+import androidx.preference.CheckBoxPreference;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.Preference.OnPreferenceChangeListener;
 import de.blau.android.R;
 import de.blau.android.util.LocaleUtils;
+import de.blau.android.util.ScreenMessage;
 import de.blau.android.util.Util;
 
 public class AdvancedPrefEditorFragment extends ExtendedPreferenceFragment {
@@ -95,7 +97,34 @@ public class AdvancedPrefEditorFragment extends ExtendedPreferenceFragment {
         setRestartRequiredMessage(R.string.config_indexMediaStore_key);
         setRestartRequiredMessage(R.string.config_supportPresetLabels_key);
         setRestartRequiredMessage(R.string.config_enableHwAcceleration_key);
+
+        CheckBoxPreference autoPrunePref = getPreferenceScreen().findPreference(getString(R.string.config_autoPrune_key));
+        if (autoPrunePref != null) {
+            OnPreferenceChangeListener listener = (preference, newValue) -> {
+                boolean autoPruneEnabled = (Boolean) newValue;
+                enablePreference(R.string.config_autoPruneBoundingBoxLimit_key, autoPruneEnabled);
+                enablePreference(R.string.config_autoPruneNodeLimit_key, autoPruneEnabled);
+                enablePreference(R.string.config_autoPruneTaskLimit_key, autoPruneEnabled);
+                return true;
+            };
+            listener.onPreferenceChange(autoPrunePref, autoPrunePref.isChecked());
+            autoPrunePref.setOnPreferenceChangeListener(listener);
+        }
+
         setTitle();
+    }
+
+    /**
+     * Enable/disable a preference
+     * 
+     * @param keyResource the resource id for the preference
+     * @param enabled state it should have
+     */
+    private void enablePreference(int keyResource, boolean enabled) {
+        Preference pref = getPreferenceScreen().findPreference(getString(keyResource));
+        if (pref != null) {
+            pref.setEnabled(enabled);
+        }
     }
 
     /**

--- a/src/main/java/de/blau/android/prefs/Preferences.java
+++ b/src/main/java/de/blau/android/prefs/Preferences.java
@@ -70,6 +70,7 @@ public class Preferences {
     private int               mapillaryCacheSize;            // in MB
     private int               downloadRadius;                // in m
     private float             maxDownloadSpeed;              // in km/h
+    private final boolean     autoPrune;
     private final int         autoPruneBoundingBoxLimit;
     private final int         autoPruneNodeLimit;
     private final int         autoPruneTaskLimit;
@@ -193,6 +194,7 @@ public class Preferences {
 
         downloadRadius = getIntPref(R.string.config_extTriggeredDownloadRadius_key, 50);
         maxDownloadSpeed = getIntPref(R.string.config_maxDownloadSpeed_key, 10);
+        autoPrune = prefs.getBoolean(r.getString(R.string.config_autoPrune_key), true);
         autoPruneBoundingBoxLimit = getIntPref(R.string.config_autoPruneBoundingBoxLimit_key, de.blau.android.layer.data.MapOverlay.DEFAULT_DOWNLOADBOX_LIMIT);
         autoPruneNodeLimit = getIntPref(R.string.config_autoPruneNodeLimit_key, de.blau.android.layer.data.MapOverlay.DEFAULT_AUTOPRUNE_NODE_LIMIT);
         autoPruneTaskLimit = getIntPref(R.string.config_autoPruneTaskLimit_key, de.blau.android.layer.tasks.MapOverlay.DEFAULT_AUTOPRUNE_TASK_LIMIT);
@@ -681,6 +683,15 @@ public class Preferences {
     public void setMaxDownloadSpeed(float maxDownloadSpeed) {
         this.maxDownloadSpeed = maxDownloadSpeed;
         prefs.edit().putInt(r.getString(R.string.config_maxDownloadSpeed_key), (int) maxDownloadSpeed).commit();
+    }
+
+    /**
+     * Check if autoPrune is enabled
+     * 
+     * @return true if autoPrune is enabled
+     */
+    public boolean autoPrune() {
+        return autoPrune;
     }
 
     /**

--- a/src/main/java/de/blau/android/services/TrackerService.java
+++ b/src/main/java/de/blau/android/services/TrackerService.java
@@ -1033,7 +1033,7 @@ public class TrackerService extends Service {
                     public void download(BoundingBox box) {
                         taskStorage.addBoundingBox(box); // will be filled once download is complete
                         TransferTasks.downloadBox(TrackerService.this, prefs.getServer(), box, true, TransferTasks.MAX_PER_REQUEST, null);
-                        if (taskStorage.reachedPruneLimits(prefs.getAutoPruneNodeLimit(), prefs.getAutoPruneBoundingBoxLimit())) {
+                        if (prefs.autoPrune() && taskStorage.reachedPruneLimits(prefs.getAutoPruneNodeLimit(), prefs.getAutoPruneBoundingBoxLimit())) {
                             ViewBox pruneBox = new ViewBox(App.getLogic().getViewBox());
                             pruneBox.scale(1.6);
                             taskStorage.prune(pruneBox);

--- a/src/main/res/values/prefkeys.xml
+++ b/src/main/res/values/prefkeys.xml
@@ -110,6 +110,7 @@
     <string name="config_supportPresetLabels_key">supportPresetLabels</string>
     <string name="config_zoomWithKeys_key">zoomWithKeys</string>
     <string name="config_poi_keys_key">poiKeys</string>
+    <string name="config_autoPrune_key">autoPrune</string>
     <!-- Preference keys used in the pref editor(s) int prefs -->
     <string name="config_maxInlineValues_key">maxInlineValuesInt</string>
     <string name="config_autoLockDelay_key">autoLockDelayInt</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1427,6 +1427,8 @@
     <string name="config_maxDownloadSpeed_title">Maximum auto-download speed</string>
     <string name="config_maxDownloadSpeed_summary">Limit (in km/h) above which auto-download is suspended.</string>
     <string name="config_downloadSpeed_current">%1$d km/h</string>
+    <string name="config_autoPrune_title">Auto-prune</string>
+    <string name="config_autoPrune_summary">Enable/disable automatically pruning in memory data and tasks</string>           
     <string name="config_autoPruneNodeLimit_title">Auto-prune limit</string>
     <string name="config_autoPruneNodeLimit_summary">Number of Nodes in memory that when reached will trigger a prune.</string>
     <string name="config_autoPruneNodeLimit_current">%1$d Nodes</string>

--- a/src/main/res/xml-v24/advancedpreferences.xml
+++ b/src/main/res/xml-v24/advancedpreferences.xml
@@ -421,6 +421,11 @@
             app:spt_increment="5"
             app:spt_currentValueText="@string/config_downloadSpeed_current"
             app:spt_setWrapSelectorWheel="false" />
+        <androidx.preference.CheckBoxPreference
+            android:defaultValue="true"
+            android:key="@string/config_autoPrune_key"
+            android:summary="@string/config_autoPrune_summary"
+            android:title="@string/config_autoPrune_title" />      
         <ch.poole.android.numberpickerpreference.NumberPickerPreference
             android:defaultValue="5000"
             android:dialogTitle="@string/config_autoPruneNodeLimit_title"

--- a/src/main/res/xml-v29/advancedpreferences.xml
+++ b/src/main/res/xml-v29/advancedpreferences.xml
@@ -421,6 +421,11 @@
             app:spt_increment="5"
             app:spt_currentValueText="@string/config_downloadSpeed_current"
             app:spt_setWrapSelectorWheel="false" />
+        <androidx.preference.CheckBoxPreference
+            android:defaultValue="true"
+            android:key="@string/config_autoPrune_key"
+            android:summary="@string/config_autoPrune_summary"
+            android:title="@string/config_autoPrune_title" />      
         <ch.poole.android.numberpickerpreference.NumberPickerPreference
             android:defaultValue="5000"
             android:dialogTitle="@string/config_autoPruneNodeLimit_title"

--- a/src/main/res/xml/advancedpreferences.xml
+++ b/src/main/res/xml/advancedpreferences.xml
@@ -416,6 +416,11 @@
             app:spt_increment="5"
             app:spt_currentValueText="@string/config_downloadSpeed_current"
             app:spt_setWrapSelectorWheel="false" />
+        <androidx.preference.CheckBoxPreference
+            android:defaultValue="true"
+            android:key="@string/config_autoPrune_key"
+            android:summary="@string/config_autoPrune_summary"
+            android:title="@string/config_autoPrune_title" />        
         <ch.poole.android.numberpickerpreference.NumberPickerPreference
             android:defaultValue="5000"
             android:dialogTitle="@string/config_autoPruneNodeLimit_title"


### PR DESCRIPTION
Additionally removes a bit of code duplication.

Resolves https://github.com/MarcusWolschon/osmeditor4android/issues/2721