### PR TITLE
Don't call Map.onDestroy any more since we want to keep layers

### DIFF
--- a/src/main/java/de/blau/android/Main.java
+++ b/src/main/java/de/blau/android/Main.java
@@ -1443,7 +1443,6 @@ public class Main extends FullScreenAppCompatActivity
     @Override
     protected void onDestroy() {
         Log.d(DEBUG_TAG, "onDestroy");
-        map.onDestroy();
         if (getTracker() != null) {
             getTracker().setListener(null);
             // the services onDestroy is not guaranteed to be called, so we do it here


### PR DESCRIPTION
Calling Map.onDestroy will close down all ThreadPoolExecutors which leads to the data layer not downloading data and not loading icons. This isn't necessary in a situation when we only recreate the Map object when really necessary, see a2fd7a14cca100b81f5bddd49c5f519494c80122