### PR TITLE
Store currently selected elements in undo checkpoint

### DIFF
--- a/src/androidTest/java/de/blau/android/easyedit/NodeTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/NodeTest.java
@@ -213,6 +213,39 @@ public class NodeTest {
         assertEquals(600181872L, node.getOsmId());
         assertEquals(4, delegator.getCurrentStorage().getWays(node).size());
     }
+    
+    /**
+     * Select, unjoin, then undo, node should be selected again
+     */
+    // @SdkSuppress(minSdkVersion = 26)
+    @Test
+    public void unjoinNodesUndo() {
+        TestUtils.zoomToLevel(device, main, 21);
+        TestUtils.unlock(device);
+        TestUtils.clickAtCoordinates(device, map, 8.3866386, 47.3904394, true);
+        TestUtils.clickAwayTip(device, main);
+        assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_nodeselect)));
+        Node node = App.getLogic().getSelectedNode();
+        assertNotNull(node);
+        assertEquals(600181872L, node.getOsmId());
+        final StorageDelegator delegator = App.getDelegator();
+        assertEquals(4, delegator.getCurrentStorage().getWays(node).size());
+
+        int apiNodeCount = delegator.getApiNodeCount();
+        assertTrue(TestUtils.clickMenuButton(device, context.getString(R.string.menu_unjoin), false, true));
+        assertEquals(apiNodeCount + 3, delegator.getApiNodeCount());
+
+        assertTrue(TestUtils.clickMenuButton(device, context.getString(R.string.undo), false, false));
+        TestUtils.clickAwayTip(device, context);
+        
+        assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_nodeselect), 5000));
+        assertEquals(apiNodeCount, delegator.getApiNodeCount());
+
+        node = App.getLogic().getSelectedNode();
+        assertNotNull(node);
+        assertEquals(600181872L, node.getOsmId());
+        assertEquals(4, delegator.getCurrentStorage().getWays(node).size());
+    }
 
     /**
      * Select node that is member of a way, append to it

--- a/src/main/java/de/blau/android/easyedit/PathCreationActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/PathCreationActionModeCallback.java
@@ -192,6 +192,7 @@ public class PathCreationActionModeCallback extends BuilderActionModeCallback {
         } else {
             mode.setSubtitle(R.string.actionmode_createpath);
         }
+        logic.createCheckpoint(main, R.string.undo_action_append);
         snap = logic.getPrefs().isWaySnapEnabled();
         logic.setSelectedWay(null);
         logic.setSelectedNode(appendTargetNode);
@@ -373,13 +374,13 @@ public class PathCreationActionModeCallback extends BuilderActionModeCallback {
         final boolean firstNode = addedNodes.isEmpty();
         Node clicked = logic.getClickedNode(x, y);
         if (appendTargetNode != null) {
-            logic.performAppendAppend(main, x, y, firstNode, snap);
+            logic.performAppendAppend(main, x, y, false, snap);
             appendTargetNode = logic.getSelectedNode();
             if (firstNode) {
                 checkpointName = R.string.undo_action_append;
             }
         } else {
-            logic.performAdd(main, x, y, firstNode, snap);
+            logic.performAdd(main, x, y, false, snap);
             if (firstNode) {
                 checkpointName = R.string.undo_action_add;
             }

--- a/src/main/java/de/blau/android/easyedit/ReplaceGeometryActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/ReplaceGeometryActionModeCallback.java
@@ -132,7 +132,7 @@ public class ReplaceGeometryActionModeCallback extends NonSimpleActionModeCallba
                 Node toReplace = findYoungestUntaggedNode((Way) element);
                 logic.setTags(main, Node.NAME, target.getOsmId(), null, false);
                 logic.performSetPosition(main, (Node) target, toReplace.getLon(), toReplace.getLat(), false);
-                MergeAction merge = new MergeAction(delegator, target, toReplace, false);
+                MergeAction merge = new MergeAction(delegator, target, toReplace, false, logic.getSelectedIds());
                 List<Result> mergeResult = merge.mergeNodes();
                 java.util.Map<String, String> mergedTags = MergeAction.mergeTags(element, targetTags);
                 Result r = mergeResult.get(0);

--- a/src/main/java/de/blau/android/easyedit/WaySelectPartActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/WaySelectPartActionModeCallback.java
@@ -81,9 +81,11 @@ public class WaySelectPartActionModeCallback extends NonSimpleActionModeCallback
                 try {
                     List<Result> result = logic.performSplit(main, way, node, fromEnd);
                     checkSplitResult(way, result);
+                    manager.finish();
+                    logic.setSelectedWay((Way) result.get(0).getElement());
+                    manager.editElements();
                 } catch (OsmIllegalOperationException | StorageException ex) {
                     // toast has already been displayed
-                } finally {
                     manager.finish();
                 }
             });
@@ -96,7 +98,7 @@ public class WaySelectPartActionModeCallback extends NonSimpleActionModeCallback
         state.putLong(WAY_ID_KEY, way.getOsmId());
         state.putLong(NODE_ID_KEY, node.getOsmId());
     }
-    
+
     @Override
     public void onDestroyActionMode(ActionMode mode) {
         logic.setClickableElements(null);

--- a/src/main/java/de/blau/android/easyedit/WaySelectionActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/WaySelectionActionModeCallback.java
@@ -231,9 +231,11 @@ public class WaySelectionActionModeCallback extends ElementSelectionActionModeCa
                 Way way = (Way) element;
                 switch (item.getItemId()) {
                 case MENUITEM_SPLIT:
+                    deselect = false;
                     main.startSupportActionMode(new WaySplittingActionModeCallback(manager, way, false));
                     break;
                 case MENUITEM_MERGE:
+                    deselect = false;
                     main.startSupportActionMode(new WayMergingActionModeCallback(manager, way, cachedMergeableWays));
                     break;
                 case MENUITEM_REVERSE:
@@ -247,9 +249,11 @@ public class WaySelectionActionModeCallback extends ElementSelectionActionModeCa
                     findConnectedWays(way);
                     break;
                 case MENUITEM_APPEND:
+                    deselect = false;
                     main.startSupportActionMode(new WayAppendingActionModeCallback(manager, way, cachedAppendableNodes));
                     break;
                 case MENUITEM_RESTRICTION:
+                    deselect = false;
                     main.startSupportActionMode(new FromElementActionModeCallback(manager, way, cachedViaElements));
                     break;
                 case MENUITEM_ROUTE:
@@ -282,6 +286,7 @@ public class WaySelectionActionModeCallback extends ElementSelectionActionModeCa
                     main.performTagEdit(element, null, true, false);
                     break;
                 case MENUITEM_REMOVE_NODE:
+                    deselect = false;
                     main.startSupportActionMode(new RemoveNodeFromWayActionModeCallback(manager, way));
                     break;
                 case MENUITEM_UNJOIN:
@@ -292,6 +297,7 @@ public class WaySelectionActionModeCallback extends ElementSelectionActionModeCa
                     Util.sharePosition(main, Geometry.centroidLonLat(way), main.getMap().getZoomLevel());
                     break;
                 case MENUITEM_EXTRACT_SEGMENT:
+                    deselect = false;
                     main.startSupportActionMode(new WaySegmentActionModeCallback(manager, way));
                     break;
                 case MENUITEM_SELECT_WAY_NODES:

--- a/src/main/java/de/blau/android/easyedit/WaySplittingActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/WaySplittingActionModeCallback.java
@@ -88,8 +88,7 @@ public class WaySplittingActionModeCallback extends NonSimpleActionModeCallback 
     }
 
     @Override
-    public boolean handleElementClick(OsmElement element) { // due to clickableElements, only valid nodes can be
-                                                            // clicked
+    public boolean handleElementClick(OsmElement element) { // due to clickableElements, only valid nodes can be clicked
         super.handleElementClick(element);
         // protect against race conditions
         if (!(element instanceof Node)) {
@@ -102,9 +101,11 @@ public class WaySplittingActionModeCallback extends NonSimpleActionModeCallback 
                 try {
                     List<Result> result = logic.performSplit(main, way, (Node) element, true);
                     checkSplitResult(way, result);
+                    manager.finish();
+                    logic.setSelectedWay((Way) result.get(0).getElement());
+                    manager.editElements();
                 } catch (OsmIllegalOperationException | StorageException ex) {
                     // toast has already been displayed
-                } finally {
                     manager.finish();
                 }
             });

--- a/src/main/java/de/blau/android/osm/MergeAction.java
+++ b/src/main/java/de/blau/android/osm/MergeAction.java
@@ -19,6 +19,8 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import de.blau.android.R;
+import de.blau.android.Selection;
+import de.blau.android.Selection.Ids;
 import de.blau.android.exception.OsmIllegalOperationException;
 import de.blau.android.util.ACRAHelper;
 import de.blau.android.util.Coordinates;
@@ -40,6 +42,8 @@ public class MergeAction {
     private final OsmElement       mergeFrom;
     private final List<Result>     overallResult;
 
+    private final Selection.Ids selection;
+
     /**
      * Initialize a new MergeAction
      * 
@@ -48,9 +52,10 @@ public class MergeAction {
      * @param delegator the StorageDelegator to use
      * @param mergeInto the OsmElement that we are going to merge into
      * @param mergeFrom the OsmElement that is going to be removed
+     * @param selection the current selection in the UI
      */
-    public MergeAction(final @NonNull StorageDelegator delegator, @NonNull OsmElement mergeInto, @NonNull OsmElement mergeFrom) {
-        this(delegator, mergeInto, mergeFrom, true);
+    public MergeAction(final @NonNull StorageDelegator delegator, @NonNull OsmElement mergeInto, @NonNull OsmElement mergeFrom, Ids selection) {
+        this(delegator, mergeInto, mergeFrom, true, selection);
     }
 
     /**
@@ -62,8 +67,10 @@ public class MergeAction {
      * @param mergeInto the OsmElement that we are going to merge into
      * @param mergeFrom the OsmElement that is going to be removed
      * @param swappable if true the elements can be swapped to maintain history
+     * @param selection the current selection in the UI
      */
-    public MergeAction(final @NonNull StorageDelegator delegator, @NonNull OsmElement mergeInto, @NonNull OsmElement mergeFrom, boolean swappable) {
+    public MergeAction(final @NonNull StorageDelegator delegator, @NonNull OsmElement mergeInto, @NonNull OsmElement mergeFrom, boolean swappable,
+            Ids selection) {
         this.delegator = delegator;
         // first determine if one of the elements already has a valid id, if it is not and other node has valid id swap
         // else check version numbers, then choose the older element. The point of this is to preserve as much history
@@ -79,6 +86,7 @@ public class MergeAction {
         }
         this.mergeInto = mergeInto;
         this.mergeFrom = mergeFrom;
+        this.selection = selection;
         overallResult = roleConflict(mergeInto, mergeFrom);
     }
 
@@ -540,7 +548,7 @@ public class MergeAction {
                 delegator.setTags(result, tags);
                 try {
                     delegator.lock();
-                    delegator.getUndo().createCheckpoint(map.getContext().getString(R.string.undo_action_move_tags));
+                    delegator.getUndo().createCheckpoint(map.getContext().getString(R.string.undo_action_move_tags), selection);
                     delegator.recordImagery(map);
                 } finally {
                     delegator.unlock();

--- a/src/test/java/de/blau/android/osm/StorageDelegatorRoboelectricTest.java
+++ b/src/test/java/de/blau/android/osm/StorageDelegatorRoboelectricTest.java
@@ -39,7 +39,7 @@ public class StorageDelegatorRoboelectricTest {
         StorageDelegator d = RelationUtilTest.loadTestData(getClass());
         Way w9 = RelationUtilTest.getWay(d, -9L);
         Way w8 = RelationUtilTest.getWay(d, -8L);
-        MergeAction action = new MergeAction(d, w9, w8);
+        MergeAction action = new MergeAction(d, w9, w8, null);
         List<Result> results = action.mergeSimplePolygons(getMap(d));
         assertEquals(1, results.size());
         Result r = results.get(0);
@@ -69,7 +69,7 @@ public class StorageDelegatorRoboelectricTest {
         StorageDelegator d = RelationUtilTest.loadTestData(getClass());
         Way w9 = RelationUtilTest.getWay(d, -9L);
         Way w8 = RelationUtilTest.getWay(d, -8L);
-        MergeAction action = new MergeAction(d, w8, w9);
+        MergeAction action = new MergeAction(d, w8, w9, null);
         List<Result> results = action.mergeSimplePolygons(getMap(d));
         assertEquals(1, results.size());
         Result r = results.get(0);
@@ -92,7 +92,7 @@ public class StorageDelegatorRoboelectricTest {
         Way w9 = RelationUtilTest.getWay(d, -9L);
         Way w8 = RelationUtilTest.getWay(d, -8L);
         d.reverseWay(w8);
-        MergeAction action = new MergeAction(d, w8, w9);
+        MergeAction action = new MergeAction(d, w8, w9, null);
         List<Result> results = action.mergeSimplePolygons(getMap(d));
         assertEquals(1, results.size());
         Result r = results.get(0);
@@ -115,7 +115,7 @@ public class StorageDelegatorRoboelectricTest {
         Way w9 = RelationUtilTest.getWay(d, -9L);
         Way w8 = RelationUtilTest.getWay(d, -8L);
         d.reverseWay(w9);
-        MergeAction action = new MergeAction(d, w8, w9);
+        MergeAction action = new MergeAction(d, w8, w9, null);
         List<Result> results = action.mergeSimplePolygons(getMap(d));
         assertEquals(1, results.size());
         Result r = results.get(0);
@@ -137,7 +137,7 @@ public class StorageDelegatorRoboelectricTest {
         StorageDelegator d = RelationUtilTest.loadTestData(getClass());
         Way w1 = RelationUtilTest.getWay(d, -1L);
         Way w3 = RelationUtilTest.getWay(d, -3L);
-        MergeAction action = new MergeAction(d, w1, w3);
+        MergeAction action = new MergeAction(d, w1, w3, null);
         List<Result> results = action.mergeSimplePolygons(getMap(d));
         assertEquals(1, results.size());
         Result r = results.get(0);
@@ -161,7 +161,7 @@ public class StorageDelegatorRoboelectricTest {
         StorageDelegator d = RelationUtilTest.loadTestData(getClass());
         Way w7 = RelationUtilTest.getWay(d, -7L);
         Way w6 = RelationUtilTest.getWay(d, -6L);
-        MergeAction action = new MergeAction(d, w6, w7);
+        MergeAction action = new MergeAction(d, w6, w7, null);
         List<Result> results = action.mergeSimplePolygons(getMap(d));
         assertEquals(1, results.size());
         Result r = results.get(0);

--- a/src/test/java/de/blau/android/osm/StorageDelegatorTest.java
+++ b/src/test/java/de/blau/android/osm/StorageDelegatorTest.java
@@ -50,7 +50,7 @@ public class StorageDelegatorTest {
         Node n0 = w.getNodes().get(0);
 
         try {
-            d.getUndo().createCheckpoint("rotate test");
+            d.getUndo().createCheckpoint("rotate test", null);
             ViewBox v = new ViewBox(0D, 51.476D, 0.003D, 51.478D);
             Coordinates[] coords = Coordinates.nodeListToCoordinateArray(1000, 2000, v, new ArrayList<>(w.getNodes()));
             Coordinates center = Geometry.centroidXY(coords, true);
@@ -144,7 +144,7 @@ public class StorageDelegatorTest {
         int parentCount = w.getParentRelations().size();
         SortedMap<String, String> tags = new TreeMap<>(w.getTags());
         tags.put("test", "pruneAll");
-        d.getUndo().createCheckpoint("pruneAll");
+        d.getUndo().createCheckpoint("pruneAll", null);
         d.setTags(w, tags);
         assertEquals(1, d.getApiElementCount());
         Node n = (Node) d.getOsmElement(Node.NAME, 761534749L);
@@ -179,7 +179,7 @@ public class StorageDelegatorTest {
         int parentCount = w.getParentRelations().size();
         SortedMap<String, String> tags = new TreeMap<>(w.getTags());
         tags.put("test", "prunBox");
-        d.getUndo().createCheckpoint("pruneBox");
+        d.getUndo().createCheckpoint("pruneBox", null);
         d.setTags(w, tags);
         assertEquals(1, d.getApiElementCount());
 
@@ -252,7 +252,7 @@ public class StorageDelegatorTest {
         assertNotNull(w);
         SortedMap<String, String> tags = new TreeMap<>(w.getTags());
         tags.put("test", "merge");
-        d.getUndo().createCheckpoint("merge");
+        d.getUndo().createCheckpoint("merge", null);
         d.setTags(w, tags);
         assertEquals(1, d.getApiElementCount());
         Node n = (Node) d.getOsmElement(Node.NAME, 761534749L);
@@ -288,7 +288,7 @@ public class StorageDelegatorTest {
         assertNotNull(w);
         SortedMap<String, String> tags = new TreeMap<>(w.getTags());
         tags.put("test", "merge");
-        d.getUndo().createCheckpoint("merge");
+        d.getUndo().createCheckpoint("merge", null);
         d.setTags(w, tags);
         assertEquals(1, d.getApiElementCount());
         Node n = (Node) d.getOsmElement(Node.NAME, 761534749L);
@@ -332,7 +332,7 @@ public class StorageDelegatorTest {
         Way newWay = (Way) splitResult.get(0).getElement();
 
         // all things the same the 1st way remains after merger
-        MergeAction action = new MergeAction(d, w, newWay);
+        MergeAction action = new MergeAction(d, w, newWay, null);
         List<Result> result = action.mergeWays();
         assertFalse(result.isEmpty());
         assertFalse(result.get(0).hasIssue());
@@ -342,7 +342,7 @@ public class StorageDelegatorTest {
         assertNotNull(splitResult);
         assertFalse(splitResult.isEmpty());
         newWay = (Way) splitResult.get(0).getElement();
-        action = new MergeAction(d, newWay, w, false);
+        action = new MergeAction(d, newWay, w, false, null);
         result = action.mergeWays();
         assertFalse(result.isEmpty());
         assertFalse(result.get(0).hasIssue());
@@ -354,7 +354,7 @@ public class StorageDelegatorTest {
         assertFalse(splitResult.isEmpty());
         w = (Way) splitResult.get(0).getElement();
         d.reverseWay(w);
-        action = new MergeAction(d, w, newWay, false);
+        action = new MergeAction(d, w, newWay, false, null);
         result = action.mergeWays();
         assertFalse(result.isEmpty());
         assertFalse(result.get(0).hasIssue());
@@ -367,7 +367,7 @@ public class StorageDelegatorTest {
         assertFalse(splitResult.isEmpty());
         newWay = (Way) splitResult.get(0).getElement();
         d.reverseWay(w);
-        action = new MergeAction(d, w, newWay, false);
+        action = new MergeAction(d, w, newWay, false, null);
         result = action.mergeWays();
         assertFalse(result.isEmpty());
         assertFalse(result.get(0).hasIssue());
@@ -383,7 +383,7 @@ public class StorageDelegatorTest {
         tags.clear();
         tags.put(Tags.KEY_HIGHWAY, "service");
         newWay.setTags(tags);
-        action = new MergeAction(d, w, newWay, false);
+        action = new MergeAction(d, w, newWay, false, null);
         result = action.mergeWays();
         assertEquals(4, w.getNodes().size());
         assertFalse(result.isEmpty());
@@ -402,7 +402,7 @@ public class StorageDelegatorTest {
         newWay.setTags(tags);
         tags.put(Tags.KEY_STEP_COUNT, "4");
         w.setTags(tags);
-        action = new MergeAction(d, w, newWay, false);
+        action = new MergeAction(d, w, newWay, false, null);
         result = action.mergeWays();
         assertEquals(4, w.getNodes().size());
         assertFalse(result.isEmpty());
@@ -421,7 +421,7 @@ public class StorageDelegatorTest {
         tags.clear();
         tags.put(Tags.KEY_STEP_COUNT, "3");
         newWay.setTags(tags);
-        action = new MergeAction(d, w, newWay, false);
+        action = new MergeAction(d, w, newWay, false, null);
         result = action.mergeWays();
         assertEquals(4, w.getNodes().size());
         assertFalse(result.isEmpty());
@@ -441,7 +441,7 @@ public class StorageDelegatorTest {
         tags.clear();
         tags.put(Tags.KEY_STEP_COUNT, "ABC");
         newWay.setTags(tags);
-        action = new MergeAction(d, w, newWay, false);
+        action = new MergeAction(d, w, newWay, false, null);
         result = action.mergeWays();
         assertEquals(4, w.getNodes().size());
         assertFalse(result.isEmpty());
@@ -461,7 +461,7 @@ public class StorageDelegatorTest {
         newWay.setTags(tags);
         tags.put(Tags.KEY_DURATION, "5");
         w.setTags(tags);
-        action = new MergeAction(d, w, newWay, false);
+        action = new MergeAction(d, w, newWay, false, null);
         result = action.mergeWays();
         assertEquals(4, w.getNodes().size());
         assertFalse(result.isEmpty());
@@ -479,7 +479,7 @@ public class StorageDelegatorTest {
         assertNotNull(newWay.getParentRelations());
         Relation r = newWay.getParentRelations().get(0);
         r.getMember(newWay).setRole("test2");
-        action = new MergeAction(d, w, newWay, false);
+        action = new MergeAction(d, w, newWay, false, null);
         result = action.mergeWays();
         assertEquals(4, w.getNodes().size());
         assertFalse(result.isEmpty());
@@ -492,7 +492,7 @@ public class StorageDelegatorTest {
         assertFalse(splitResult.isEmpty());
         newWay = (Way) splitResult.get(0).getElement();
         newWay.setOsmId(1234L);
-        action = new MergeAction(d, w, newWay);
+        action = new MergeAction(d, w, newWay, null);
         result = action.mergeWays();
         assertFalse(result.isEmpty());
         assertFalse(result.get(0).hasIssue());
@@ -506,7 +506,7 @@ public class StorageDelegatorTest {
         assertFalse(splitResult.isEmpty());
         w = (Way) splitResult.get(0).getElement();
         d.unjoinWays(n);
-        action = new MergeAction(d, w, newWay, false);
+        action = new MergeAction(d, w, newWay, false, null);
         try {
             action.mergeWays();
             fail("Should have thrown an OsmIllegalOperationException");
@@ -526,7 +526,7 @@ public class StorageDelegatorTest {
         d.insertElementSafe(n1);
         Node n2 = factory.createNodeWithNewId(toE7(51.476), toE7(0.006));
         d.insertElementSafe(n2);
-        MergeAction action = new MergeAction(d, n1, n2);
+        MergeAction action = new MergeAction(d, n1, n2, null);
         List<Result> result = action.mergeNodes();
         assertFalse(result.isEmpty());
         assertFalse(result.get(0).hasIssue());
@@ -545,7 +545,7 @@ public class StorageDelegatorTest {
         d.insertElementSafe(n1);
         Node n2 = factory.createNodeWithNewId(toE7(51.476), toE7(0.006));
         d.insertElementSafe(n2);
-        MergeAction action = new MergeAction(d, n2, n1);
+        MergeAction action = new MergeAction(d, n2, n1, null);
         List<Result> result = action.mergeNodes();
         assertFalse(result.isEmpty());
         assertFalse(result.get(0).hasIssue());
@@ -565,7 +565,7 @@ public class StorageDelegatorTest {
         Node n2 = factory.createNodeWithNewId(toE7(51.476), toE7(0.006));
         d.insertElementSafe(n2);
         n2.setOsmId(1234L);
-        MergeAction action = new MergeAction(d, n1, n2);
+        MergeAction action = new MergeAction(d, n1, n2, null);
         List<Result> result = action.mergeNodes();
         assertFalse(result.isEmpty());
         assertFalse(result.get(0).hasIssue());
@@ -582,7 +582,7 @@ public class StorageDelegatorTest {
         OsmElementFactory factory = d.getFactory();
         Node n1 = factory.createNodeWithNewId(toE7(51.476), toE7(0.006));
         d.insertElementSafe(n1);
-        MergeAction action = new MergeAction(d, n1, n1);
+        MergeAction action = new MergeAction(d, n1, n1, null);
         List<Result> result = action.mergeNodes();
         assertFalse(result.isEmpty());
         assertTrue(result.get(0).hasIssue());
@@ -607,7 +607,7 @@ public class StorageDelegatorTest {
         Node n1 = w.getLastNode();
         Node n2 = newWay.getFirstNode();
         assertNotEquals(n1, n2);
-        MergeAction action = new MergeAction(d, n1, n2, false);
+        MergeAction action = new MergeAction(d, n1, n2, false, null);
         List<Result> result = action.mergeNodes();
         assertFalse(result.isEmpty());
         assertFalse(result.get(0).hasIssue());
@@ -637,7 +637,7 @@ public class StorageDelegatorTest {
         RelationMember member2 = new RelationMember("test2", n2);
         r.addMember(member2);
         n2.addParentRelation(r);
-        MergeAction action = new MergeAction(d, n1, n2);
+        MergeAction action = new MergeAction(d, n1, n2, null);
         List<Result> result = action.mergeNodes();
         assertEquals(2, result.size());
         assertEquals(1, result.get(1).getIssues().size());
@@ -662,7 +662,7 @@ public class StorageDelegatorTest {
         SortedMap<String, String> tags2 = new TreeMap<>();
         tags2.put(Tags.KEY_HIGHWAY, "b");
         n2.setTags(tags2);
-        MergeAction action = new MergeAction(d, n1, n2);
+        MergeAction action = new MergeAction(d, n1, n2, null);
         List<Result> result = action.mergeNodes();
         assertFalse(result.isEmpty());
         assertEquals(1, result.get(0).getIssues().size());
@@ -687,7 +687,7 @@ public class StorageDelegatorTest {
         SortedMap<String, String> tags2 = new TreeMap<>();
         tags2.put("test2", "d;e;f");
         n2.setTags(tags2);
-        MergeAction action = new MergeAction(d, n1, n2);
+        MergeAction action = new MergeAction(d, n1, n2, null);
         List<Result> result = action.mergeNodes();
         assertNotNull(d.getOsmElement(Node.NAME, n1.getOsmId()));
         assertEquals("a;b;c", n1.getTagWithKey("test1"));
@@ -716,7 +716,7 @@ public class StorageDelegatorTest {
         tags2.put(Tags.KEY_HIGHWAY,
                 "baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         n2.setTags(tags2);
-        MergeAction action = new MergeAction(d, n1, n2);
+        MergeAction action = new MergeAction(d, n1, n2, null);
         try {
             List<Result> result = action.mergeNodes();
             fail("this should have failed");
@@ -743,7 +743,7 @@ public class StorageDelegatorTest {
         SortedMap<String, String> tags2 = new TreeMap<>();
         tags2.put(Tags.KEY_HIGHWAY, "d;e;f");
         n2.setTags(tags2);
-        MergeAction action = new MergeAction(d, n1, n2);
+        MergeAction action = new MergeAction(d, n1, n2, null);
         List<Result> result = action.mergeNodes();
         assertNotNull(d.getOsmElement(Node.NAME, n1.getOsmId()));
         assertEquals("a;b;c;d;e;f", n1.getTagWithKey(Tags.KEY_HIGHWAY));
@@ -770,7 +770,7 @@ public class StorageDelegatorTest {
         SortedMap<String, String> tags2 = new TreeMap<>();
         tags2.put("test" + Tags.KEY_CONDITIONAL_SUFFIX, "(d;e;f)");
         n2.setTags(tags2);
-        MergeAction action = new MergeAction(d, n1, n2);
+        MergeAction action = new MergeAction(d, n1, n2, null);
         List<Result> result = action.mergeNodes();
         assertNotNull(d.getOsmElement(Node.NAME, n1.getOsmId()));
         assertEquals("(a;b;c);(d;e;f)", n1.getTagWithKey("test" + Tags.KEY_CONDITIONAL_SUFFIX));
@@ -1075,7 +1075,7 @@ public class StorageDelegatorTest {
         assertEquals("00:04:53", newWay.getTagWithKey(Tags.KEY_DURATION));
 
         // merge
-        MergeAction action = new MergeAction(d, newWay, w);
+        MergeAction action = new MergeAction(d, newWay, w, null);
         List<Result> results = action.mergeWays();
         assertNotNull(results);
         assertEquals(1, results.size());

--- a/src/test/java/de/blau/android/osm/UndoStorageTest.java
+++ b/src/test/java/de/blau/android/osm/UndoStorageTest.java
@@ -23,7 +23,7 @@ import de.blau.android.osm.UndoStorage.UndoWay;
 import de.blau.android.util.Util;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk=33)
+@Config(sdk = 33)
 @LargeTest
 public class UndoStorageTest {
 
@@ -89,7 +89,7 @@ public class UndoStorageTest {
         assertFalse(undo.canUndo());
         assertFalse(undo.canRedo());
         Way w = addWayToStorage(d, false); // w is already a member here
-        undo.createCheckpoint("add test relation");
+        undo.createCheckpoint("add test relation", null);
         Relation r = d.createAndInsertRelation(Util.wrapInList(w));
         assertEquals(1, d.getCurrentStorage().getWayCount());
         assertEquals(1, d.getApiStorage().getWayCount());

--- a/src/testCommon/java/de/blau/android/osm/DelegatorUtil.java
+++ b/src/testCommon/java/de/blau/android/osm/DelegatorUtil.java
@@ -12,7 +12,7 @@ public class DelegatorUtil {
      * @return the way
      */
     public static Way addWayToStorage(@NonNull StorageDelegator d, boolean close) {
-        d.getUndo().createCheckpoint("add test way");
+        d.getUndo().createCheckpoint("add test way", null);
         OsmElementFactory factory = d.getFactory();
         Way w = factory.createWayWithNewId();
         Node n0 = factory.createNodeWithNewId(toE7(51.478), toE7(0));


### PR DESCRIPTION
With the exception of multi checkpoint operations this allows restoring the original selection state on undo. In particular for merging and splitting objects.

Resolves https://github.com/MarcusWolschon/osmeditor4android/issues/2645