### PR TITLE
Improve behaviour and caching for large sequences

### DIFF
--- a/src/main/java/de/blau/android/dialogs/Progress.java
+++ b/src/main/java/de/blau/android/dialogs/Progress.java
@@ -41,6 +41,7 @@ public class Progress extends ImmersiveDialogFragment {
     public static final int PROGRESS_LOADING_PRESET            = 14;
     public static final int PROGRESS_IMPORTING_FILE            = 15;
     public static final int PROGRESS_DOWNLOAD_TASKS            = 16;
+    public static final int PROGRESS_DOWNLOAD_SEQUENCE         = 17;
 
     private int    dialogType;
     private String messageArg;
@@ -133,6 +134,7 @@ public class Progress extends ImmersiveDialogFragment {
         dismissDialog(activity, PROGRESS_LOADING_PRESET);
         dismissDialog(activity, PROGRESS_IMPORTING_FILE);
         dismissDialog(activity, PROGRESS_DOWNLOAD_TASKS);
+        dismissDialog(activity, PROGRESS_DOWNLOAD_SEQUENCE);
     }
 
     /**
@@ -176,6 +178,8 @@ public class Progress extends ImmersiveDialogFragment {
             return "dialog_progress_importing_file";
         case PROGRESS_DOWNLOAD_TASKS:
             return "dialog_progress_download_tasks";
+        case PROGRESS_DOWNLOAD_SEQUENCE:
+            return "dialog_progress_download_sequence";
         default:
             Log.w(DEBUG_TAG, "Unknown dialog type " + dialogType);
         }

--- a/src/main/java/de/blau/android/dialogs/ProgressDialog.java
+++ b/src/main/java/de/blau/android/dialogs/ProgressDialog.java
@@ -112,6 +112,10 @@ public final class ProgressDialog {
             titleId = R.string.progress_title;
             messageId = R.string.progress_download_tasks_message;
             break;
+        case Progress.PROGRESS_DOWNLOAD_SEQUENCE:
+            titleId = R.string.progress_title;
+            messageId = R.string.progress_download_sequence_message;
+            break;
         default:
             return null;
         }

--- a/src/main/java/de/blau/android/util/collections/MRUHashMap.java
+++ b/src/main/java/de/blau/android/util/collections/MRUHashMap.java
@@ -1,0 +1,140 @@
+package de.blau.android.util.collections;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Fixed sized HashMap with MRU semantics
+ * 
+ * Note that we do not extend Map
+ * 
+ * @param <K> Key
+ * @param <V> Value
+ */
+public class MRUHashMap<K extends Serializable, V extends Serializable> implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final MRUList<K> list;
+    private final Map<K, V>  map;
+
+    /**
+     * Constract a new instance
+     * 
+     * @param size the maximum number of entries
+     */
+    public MRUHashMap(int size) {
+        list = new MRUList<>(size);
+        map = new HashMap<>();
+    }
+
+    /**
+     * Get the current size of the collection
+     * 
+     * @return the size
+     */
+    public int size() {
+        return list.size();
+    }
+
+    /**
+     * Check if the collection is empty
+     * 
+     * @return tru eif empty
+     */
+    public boolean isEmpty() {
+        return list.isEmpty();
+    }
+
+    /**
+     * Get the object for key
+     * 
+     * @param key the key
+     * @return the stored object or null
+     */
+    @SuppressWarnings("unchecked")
+    public V get(Object key) {
+        V result = map.get(key);
+        if (result != null) {
+            list.push((K) key);
+        }
+        return result;
+    }
+
+    /**
+     * Add the key and value to the map
+     * 
+     * Note that this does not have the Map.put signature
+     * 
+     * @param key the key
+     * @param value the value
+     * @return the value removed from the map or null
+     */
+    public V put(K key, V value) {
+        K removedKey = list.push(key);
+        V removedValue = null;
+        if (removedKey != null) {
+            removedValue = map.remove(removedKey);
+        }
+        map.put(key, value);
+        return removedValue;
+    }
+
+    /**
+     * Remove the entry for a key
+     * 
+     * @param key the key
+     * @return the removed object or null
+     */
+    public V remove(Object key) {
+        V removed = map.remove(key);
+        if (removed != null) {
+            list.remove(key);
+        }
+        return removed;
+    }
+
+    /**
+     * Empty the collection
+     */
+    public void clear() {
+        list.clear();
+        map.clear();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((list == null) ? 0 : list.hashCode());
+        result = prime * result + ((map == null) ? 0 : map.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof MRUHashMap<?, ?>)) {
+            return false;
+        }
+        MRUHashMap<?, ?> other = (MRUHashMap<?, ?>) obj;
+        if (list == null) {
+            if (other.list != null) {
+                return false;
+            }
+        } else if (!list.equals(other.list)) {
+            return false;
+        }
+        if (map == null) {
+            if (other.map != null) {
+                return false;
+            }
+        } else if (!map.equals(other.map)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/de/blau/android/util/collections/MRUList.java
+++ b/src/main/java/de/blau/android/util/collections/MRUList.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.Objects;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * A list that can be used in a stack like fashion for implementing MRU (Most Recently Used) semantics
@@ -42,16 +43,20 @@ public class MRUList<T> extends ArrayList<T> {
      * Add o to top of stack, if o is already present move it there
      * 
      * @param o Object to push
+     * @return the Object removed from the list or null if there was none
      */
-    public void push(T o) {
+    @Nullable
+    public T push(T o) {
         int index = indexOf(o);
         if (index >= 0) {
             remove(index);
         }
+        T removed = null;
         if (size() >= capacity) {
-            remove(size() - 1);
+            removed = remove(size() - 1);
         }
         add(0, o);
+        return removed;
     }
 
     /**

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -151,6 +151,7 @@
     <string name="progress_message">Loading data into memory…</string>
     <string name="progress_download_message">Downloading data from server…</string>
     <string name="progress_download_tasks_message">Downloading tasks from servers…</string>
+    <string name="progress_download_sequence_message">Downloading sequence from server…</string>
     <string name="progress_general_title">Please wait</string>
     <string name="progress_deleting_message">Deleting…</string>
     <string name="progress_searching_message">Searching…</string>

--- a/src/test/java/de/blau/android/util/collections/CollectionTest.java
+++ b/src/test/java/de/blau/android/util/collections/CollectionTest.java
@@ -3,6 +3,7 @@ package de.blau.android.util.collections;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -18,11 +19,6 @@ import de.blau.android.osm.Node;
 import de.blau.android.osm.OsmElement;
 import de.blau.android.osm.OsmElementFactory;
 import de.blau.android.util.GeoMath;
-import de.blau.android.util.collections.LongHashSet;
-import de.blau.android.util.collections.LongOsmElementMap;
-import de.blau.android.util.collections.MRUList;
-import de.blau.android.util.collections.MultiHashMap;
-import de.blau.android.util.collections.UnsignedSparseBitSet;
 import de.blau.android.util.rtree.RTree;
 
 public class CollectionTest {
@@ -203,10 +199,43 @@ public class CollectionTest {
         assertEquals(2, mru.size());
         assertEquals("bottom", mru.last());
 
+        assertFalse(mru.equals(new MRUList<String>(mru))); // the limit is different
+        assertFalse(mru.equals(new MRUList<String>(11)));
+
         mru.pushAll(Arrays.asList("1", "2"));
         assertEquals(4, mru.size());
         assertEquals("2", mru.last());
         mru.push("top");
         assertEquals(4, mru.size());
+        assertTrue(mru.remove("top"));
+        mru.clear();
+        assertEquals(0, mru.size());
+        assertTrue(mru.isEmpty());
+    }
+
+    @Test
+    public void mruHashMap() {
+        MRUHashMap<String, String> mruMap = new MRUHashMap<>(10);
+        for (int i = 0; i < 9; i++) {
+            assertNull(mruMap.put("key" + i, "value" + i));
+        }
+
+        MRUHashMap<String, String> mruMap2 = new MRUHashMap<>(10);
+        for (int i = 0; i < 9; i++) {
+            assertNull(mruMap2.put("key" + i, "value" + i));
+        }
+        assertTrue(mruMap.equals(mruMap2));
+        assertFalse(mruMap.equals(new MRUHashMap<String, String>(11)));
+
+        assertEquals(9, mruMap.size());
+        assertEquals("value8", mruMap.get("key8"));
+        assertNull(mruMap.put("key9", "value9"));
+        assertEquals(10, mruMap.size());
+        assertEquals("value0", mruMap.put("key10", "value10"));
+        assertEquals(10, mruMap.size());
+        assertEquals("value8", mruMap.remove("key8"));
+        mruMap.clear();
+        assertEquals(0, mruMap.size());
+        assertTrue(mruMap.isEmpty());
     }
 }


### PR DESCRIPTION
Panoramax has sequences in the order of magnitude of 10'000 entries these take a substantial while to download, and we can't pass the whole list to the viewer as that will exceed Androids max transaction buffer size. We fix this by only passing roughly 200 ids to the viewer.

Further we limit the size of the sequence cache both for Panoramax and Mapillary.