### PR TITLE
Automatically add an extension to files when saving if it is missing

### DIFF
--- a/src/androidTest/java/de/blau/android/gpx/GpxTest.java
+++ b/src/androidTest/java/de/blau/android/gpx/GpxTest.java
@@ -43,6 +43,7 @@ import de.blau.android.MockTileServer;
 import de.blau.android.R;
 import de.blau.android.SignalHandler;
 import de.blau.android.TestUtils;
+import de.blau.android.contract.FileExtensions;
 import de.blau.android.layer.LayerDialogTest;
 import de.blau.android.layer.LayerType;
 import de.blau.android.layer.MapViewLayer;
@@ -180,12 +181,14 @@ public class GpxTest {
         UiObject2 menuButton = TestUtils.getLayerButton(device, main.getString(R.string.layer_gpx_recording), LayerDialogTest.MENU_BUTTON);
         menuButton.click();
         assertTrue(TestUtils.clickText(device, false, main.getString(R.string.menu_gps_export), false, false));
-        String filename = "" + System.currentTimeMillis() + ".gpx";
+        String filename = "" + System.currentTimeMillis();
         TestUtils.selectFile(device, main, null, filename, true, true);
 
         assertTrue(TestUtils.clickButton(device, device.getCurrentPackageName() + ":id/add", true));
         TestUtils.scrollTo(main.getString(R.string.layer_add_gpx), false);
         assertTrue(TestUtils.clickText(device, false, main.getString(R.string.layer_add_gpx), true, false));
+        // should have extension now
+        filename = filename  + "." + FileExtensions.GPX;
         TestUtils.selectFile(device, main, null, filename, true);
 
         assertTrue(TestUtils.clickText(device, false, main.getString(R.string.okay), true, false));

--- a/src/main/java/de/blau/android/contract/FileExtensions.java
+++ b/src/main/java/de/blau/android/contract/FileExtensions.java
@@ -8,6 +8,8 @@ public final class FileExtensions {
     public static final String PO      = "po";
     public static final String JPG     = "jpg";
     public static final String OSC     = "osc";
+    public static final String OSM     = "osm";
+    public static final String OSN     = "osn"; // osm notes
     public static final String MD      = "md";
     public static final String MVT     = "mvt";
     public static final String PBF     = "pbf";

--- a/src/main/java/de/blau/android/contract/MimeTypes.java
+++ b/src/main/java/de/blau/android/contract/MimeTypes.java
@@ -2,6 +2,17 @@ package de.blau.android.contract;
 
 public final class MimeTypes {
 
+    // types and subtypes
+    public static final String IMAGE_TYPE                = "image";
+    public static final String PNG_SUBTYPE               = "png";
+    public static final String BMP_SUBTYPE               = "bmp";
+    public static final String APPLICATION_TYPE          = "application";
+    public static final String JSON_SUBTYPE              = "json";
+    public static final String WMS_EXCEPTION_XML_SUBTYPE = "vnd.ogc.se_xml";
+    public static final String TEXT_TYPE                 = "text";
+    public static final String MVT_SUBTYPE               = "vnd.mapbox-vector-tile";
+    public static final String X_PROTOBUF_SUBTYPE        = "x-protobuf";            // not registered
+
     public static final String ALL_IMAGE_FORMATS = "image/*";
     public static final String JPEG              = "image/jpeg";
     public static final String PNG               = "image/png";
@@ -14,18 +25,14 @@ public final class MimeTypes {
     public static final String TEXTXML   = "text/xml";
     public static final String TEXTCSV   = "text/comma-separated-values";
 
-    public static final String ZIP = "application/zip";
+    public static final String OSMXML = "application/vnd.openstreetmap.data+xml";                   // registered
+    public static final String OSMPBF = "application/vnd.openstreetmap.data+" + X_PROTOBUF_SUBTYPE; // not registered
+    public static final String OSCXML = "application/vnd.openstreetmap.osc+xml";                    // not registered
+    public static final String OSNXML = "application/vnd.openstreetmap.osn+xml";                    // not registered
 
-    // types and subtypes
-    public static final String IMAGE_TYPE                = "image";
-    public static final String PNG_SUBTYPE               = "png";
-    public static final String BMP_SUBTYPE               = "bmp";
-    public static final String APPLICATION_TYPE          = "application";
-    public static final String JSON_SUBTYPE              = "json";
-    public static final String WMS_EXCEPTION_XML_SUBTYPE = "vnd.ogc.se_xml";
-    public static final String TEXT_TYPE                 = "text";
-    public static final String MVT_SUBTYPE               = "vnd.mapbox-vector-tile";
-    public static final String X_PROTOBUF_SUBTYPE        = "x-protobuf";
+    public static final String TODOJSON = "application/vnd.vespucci.todo+" + JSON_SUBTYPE;// not registered
+
+    public static final String ZIP = "application/zip";
 
     /**
      * Private constructor

--- a/src/main/java/de/blau/android/dialogs/ConsoleDialog.java
+++ b/src/main/java/de/blau/android/dialogs/ConsoleDialog.java
@@ -254,7 +254,7 @@ public class ConsoleDialog extends DialogFragment {
                 activity.startActivity(shareIntent);
                 break;
             case R.id.console_menu_save:
-                SelectFile.save(activity, R.string.config_scriptsPreferredDir_key, new SaveFile() {
+                SelectFile.save(activity, null, R.string.config_scriptsPreferredDir_key, new SaveFile() {
                     private static final long serialVersionUID = 1L;
 
                     @Override

--- a/src/main/java/de/blau/android/dialogs/Layers.java
+++ b/src/main/java/de/blau/android/dialogs/Layers.java
@@ -1179,7 +1179,7 @@ public class Layers extends AbstractConfigurationDialog implements OnUpdateListe
                 });
                 item = menu.add(R.string.menu_gps_export);
                 item.setOnMenuItemClickListener(unused -> {
-                    SelectFile.save(activity, R.string.config_osmPreferredDir_key, new SaveFile() {
+                    SelectFile.save(activity, MimeTypes.GPX, R.string.config_osmPreferredDir_key, new SaveFile() {
                         private static final long serialVersionUID = 1L;
 
                         @Override
@@ -1189,6 +1189,7 @@ public class Layers extends AbstractConfigurationDialog implements OnUpdateListe
                                 final Track track = ((de.blau.android.layer.gpx.MapOverlay) layer).getTrack();
                                 if (track != null) {
                                     SavingHelper.asyncExport(currentActivity, track, fileUri);
+                                    SaveFile.addExtensionIfNeeded(currentActivity, fileUri, FileExtensions.GPX);
                                     SelectFile.savePref(App.getLogic().getPrefs(), R.string.config_osmPreferredDir_key, fileUri);
                                 }
                             }

--- a/src/main/java/de/blau/android/util/ContentResolverUtil.java
+++ b/src/main/java/de/blau/android/util/ContentResolverUtil.java
@@ -1,6 +1,9 @@
 package de.blau.android.util;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +26,8 @@ import de.blau.android.contract.Schemes;
 
 public final class ContentResolverUtil {
 
-    private static final String DEBUG_TAG = ContentResolverUtil.class.getSimpleName().substring(0, Math.min(23, ContentResolverUtil.class.getSimpleName().length()));
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, ContentResolverUtil.class.getSimpleName().length());
+    private static final String DEBUG_TAG = ContentResolverUtil.class.getSimpleName().substring(0, TAG_LEN);
 
     private static final String PRIMARY                   = "primary";
     private static final String MY_DOWNLOADS              = "content://downloads/my_downloads";
@@ -152,6 +156,24 @@ public final class ContentResolverUtil {
         } else if (Schemes.CONTENT.equals(scheme)) {
             Log.i(DEBUG_TAG, "content scheme");
             return getDataColumn(context, uri, null, null);
+        }
+        return null;
+    }
+
+    /**
+     * Rename a file
+     * 
+     * @param context an Android Context
+     * @param uri the URI
+     * @param newName the new name
+     * @param the new uri or null
+     */
+    @Nullable
+    public static Uri rename(@NonNull Context context, @NonNull Uri uri, @NonNull String newName) {
+        try {
+            return DocumentsContract.renameDocument(context.getContentResolver(), uri, newName);
+        } catch (FileNotFoundException e) {
+            Log.e(DEBUG_TAG, e.getMessage());
         }
         return null;
     }

--- a/src/main/java/de/blau/android/util/SaveFile.java
+++ b/src/main/java/de/blau/android/util/SaveFile.java
@@ -1,8 +1,12 @@
 package de.blau.android.util;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import java.io.Serializable;
 
+import android.content.Context;
 import android.net.Uri;
+import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.FragmentActivity;
 
@@ -11,6 +15,39 @@ public abstract class SaveFile implements Serializable {
      * 
      */
     private static final long serialVersionUID = 1L;
+
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, SaveFile.class.getSimpleName().length());
+    private static final String DEBUG_TAG = SaveFile.class.getSimpleName().substring(0, TAG_LEN);
+
+    /**
+     * Add an extension to a file name if necessary
+     * 
+     * This will only work if the file has already been written
+     * 
+     * @param context an Android Context
+     * @param fileUri the original Uri
+     * @param extension the extension to add
+     * @return a potentially new Uri
+     */
+    @NonNull
+    public static Uri addExtensionIfNeeded(@NonNull Context context, @NonNull Uri fileUri, @NonNull String extension) {
+        String displayName = ContentResolverUtil.getDisplaynameColumn(context, fileUri);
+        if (displayName.indexOf(".") < 0) {
+            String newName = displayName + "." + extension;
+            Log.i(DEBUG_TAG, "Renaming to " + newName);
+            try {
+                Uri newUri = ContentResolverUtil.rename(context, fileUri, newName);
+                if (newUri != null) {
+                    return newUri;
+                }
+            } catch (Exception ex) {
+                // we can't trust Android
+                Log.e(DEBUG_TAG, "Rename to " + newName + " failed with " + ex.getMessage());
+            }
+
+        }
+        return fileUri;
+    }
 
     /**
      * Save a file


### PR DESCRIPTION
THe Android system file picker does not allow to provide a default extension to add to a file when creating a new one.

We get around this, at the price of this being a bad UX, by renaming the file as soon as we have written it. We only do this if there is no extension at all present.

Further we attempt to save with proper mime types, however currently it seems as if these are ignored by the system.

Note: currently we do nothing when saving scripts from the console modal.

Resolves: https://github.com/MarcusWolschon/osmeditor4android/issues/2589