### PR TITLE
Improve relation ordering in the disambiguation menu

### DIFF
--- a/src/main/java/de/blau/android/osm/NwrComparator.java
+++ b/src/main/java/de/blau/android/osm/NwrComparator.java
@@ -10,7 +10,7 @@ import java.util.Comparator;
  * @author simon
  *
  */
-final class NwrComparator implements Comparator<OsmElement> {
+public final class NwrComparator implements Comparator<OsmElement> {
     
     @Override
     public int compare(OsmElement o1, OsmElement o2) {


### PR DESCRIPTION
Originally the parent relations were added depth first, this kept "related" relations together but often was more confusing. We now add deeper relation memberships later and sort them by "size" (number of members).