### PR TITLE
Limit pending tile requests

### DIFF
--- a/src/main/java/de/blau/android/services/util/MapTileDownloader.java
+++ b/src/main/java/de/blau/android/services/util/MapTileDownloader.java
@@ -1,6 +1,8 @@
 // Created by plusminus on 21:31:36 - 25.09.2008
 package de.blau.android.services.util;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
@@ -85,7 +87,8 @@ public class MapTileDownloader extends MapAsyncTileProvider {
         }
     }
 
-    private static final String DEBUG_TAG = MapTileDownloader.class.getSimpleName().substring(0, Math.min(23, MapTileDownloader.class.getSimpleName().length()));
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, MapTileDownloader.class.getSimpleName().length());
+    private static final String DEBUG_TAG = MapTileDownloader.class.getSimpleName().substring(0, TAG_LEN);
 
     public static final long TIMEOUT = 5000;
 
@@ -152,10 +155,10 @@ public class MapTileDownloader extends MapAsyncTileProvider {
                         mCallback.mapTileFailed(sourceId, mTile.zoomLevel, mTile.x, mTile.y, IOERR, ioe.getMessage());
                     }
                 }
-            } catch (NullPointerException | IllegalArgumentException | IOException | UnsupportedOperationException e) {
-                Log.e(DEBUG_TAG, "Error for MapTile, disabling source: " + sourceId + " exception: " + e);
+            } catch (NullPointerException | IllegalArgumentException | IOException | UnsupportedOperationException | OutOfMemoryError t) {
+                Log.e(DEBUG_TAG, "Error for MapTile, disabling source: " + sourceId + " cause: " + t);
                 // disable source temporarily to avoid hitting source time and time again
-                MapTileFilesystemProvider.displayError(mCtx, disabled, sourceId, R.string.toast_tile_source_issue, e);
+                MapTileFilesystemProvider.displayError(mCtx, disabled, sourceId, R.string.toast_tile_source_issue, t);
             } finally {
                 /*
                  * What to do when downloading tile caused an error? Also remove it from the mPending? Not doing so

--- a/src/main/java/de/blau/android/services/util/MapTileFilesystemProvider.java
+++ b/src/main/java/de/blau/android/services/util/MapTileFilesystemProvider.java
@@ -1,5 +1,7 @@
 package de.blau.android.services.util;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
@@ -44,8 +46,8 @@ import de.blau.android.util.ScreenMessage;
  */
 public class MapTileFilesystemProvider extends MapAsyncTileProvider implements MapTileSaver {
 
-    static final String DEBUG_TAG = MapTileFilesystemProvider.class.getSimpleName().substring(0,
-            Math.min(23, MapTileFilesystemProvider.class.getSimpleName().length()));
+    private static final int TAG_LEN   = Math.min(LOG_TAG_LEN, MapTileFilesystemProvider.class.getSimpleName().length());
+    static final String      DEBUG_TAG = MapTileFilesystemProvider.class.getSimpleName().substring(0, TAG_LEN);
 
     private final Context                 mCtx;
     private final MapTileProviderDataBase tileCache;
@@ -311,9 +313,9 @@ public class MapTileFilesystemProvider extends MapAsyncTileProvider implements M
      * @param displayed a set to track if we have already messaged
      * @param sourceId the source id
      * @param msg a string resource with the message
-     * @param e the Exception we caught
+     * @param e the Throwable we caught
      */
-    static void displayError(Context ctx, Set<String> displayed, final String sourceId, int msg, Exception e) {
+    static void displayError(Context ctx, Set<String> displayed, final String sourceId, int msg, Throwable e) {
         if (!displayed.contains(sourceId)) {
             // something is seriously wrong with the database or source file, show a toast once
             final String localizedMessage = e.getLocalizedMessage();


### PR DESCRIPTION
This limits the number of pending tile requests per source to 1000 and improves handling of OOM situations. Neither should actually happen but, now an then, do seem to. The later is likely due to configuration errors or broken input data.