### PR TITLE
Improve tile diagnostics and allow accept-encoding header override

### DIFF
--- a/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
+++ b/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
@@ -1860,7 +1860,7 @@ public class PropertyEditorTest {
         instrumentation.sendCharacterSync(KeyEvent.KEYCODE_M);
         instrumentation.sendCharacterSync(KeyEvent.KEYCODE_C);
         instrumentation.sendCharacterSync(KeyEvent.KEYCODE_D);
-        assertTrue(TestUtils.findText(device, false, "MCM", 5000));
+        assertTrue(TestUtils.findText(device, false, "MCM", 10000));
         assertTrue(TestUtils.findText(device, false, "McDonald's", 1000));
         instrumentation.sendCharacterSync(KeyEvent.KEYCODE_O);
         instrumentation.sendCharacterSync(KeyEvent.KEYCODE_N);

--- a/src/main/java/de/blau/android/dialogs/TileSourceDiagnostics.java
+++ b/src/main/java/de/blau/android/dialogs/TileSourceDiagnostics.java
@@ -1,5 +1,7 @@
 package de.blau.android.dialogs;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import java.util.Random;
 
 import android.graphics.Bitmap;
@@ -39,8 +41,8 @@ import de.blau.android.util.ThemeUtils;
  */
 public class TileSourceDiagnostics extends ImmersiveDialogFragment {
 
-    private static final String DEBUG_TAG = TileSourceDiagnostics.class.getSimpleName().substring(0,
-            Math.min(23, TileSourceDiagnostics.class.getSimpleName().length()));
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, TileSourceDiagnostics.class.getSimpleName().length());
+    private static final String DEBUG_TAG = TileSourceDiagnostics.class.getSimpleName().substring(0, TAG_LEN);
 
     private static final String TAG = "fragment_tile_source_diag";
 

--- a/src/main/java/de/blau/android/layer/tiles/ImageryLayerInfo.java
+++ b/src/main/java/de/blau/android/layer/tiles/ImageryLayerInfo.java
@@ -1,5 +1,7 @@
 package de.blau.android.layer.tiles;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import java.util.Collection;
 
 import android.os.Bundle;
@@ -8,6 +10,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ScrollView;
 import android.widget.TableLayout;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 import de.blau.android.App;
@@ -22,7 +25,9 @@ import de.blau.android.util.DateFormatter;
 import de.blau.android.util.Util;
 
 public class ImageryLayerInfo extends LayerInfo {
-    private static final String DEBUG_TAG = ImageryLayerInfo.class.getSimpleName().substring(0, Math.min(23, ImageryLayerInfo.class.getSimpleName().length()));
+
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, MapTilesLayer.class.getSimpleName().length());
+    private static final String DEBUG_TAG = ImageryLayerInfo.class.getSimpleName().substring(0, TAG_LEN);
 
     public static final String LAYER_KEY       = "layer";
     public static final String ERROR_COUNT_KEY = "tileErrorCount";
@@ -52,60 +57,75 @@ public class ImageryLayerInfo extends LayerInfo {
         if (layer == null) {
             Log.e(DEBUG_TAG, "layer null");
             tableLayout.addView(TableLayoutUtils.createFullRowTitle(activity, activity.getString(R.string.layer_info_layer_not_available), tp));
-        } else if (!layer.isMetadataLoaded()) {
+            return sv;
+        }
+        if (!layer.isMetadataLoaded()) {
             Log.e(DEBUG_TAG, "meta data not loaded");
             tableLayout.addView(TableLayoutUtils.createFullRowTitle(activity, activity.getString(R.string.layer_info_no_meta_data), tp));
-        } else {
-            tableLayout.addView(TableLayoutUtils.createFullRowTitle(activity, layer.getName(), tp));
-            tableLayout.addView(TableLayoutUtils.divider(activity));
-            String description = layer.getDescription();
-            if (description != null) {
-                tableLayout.addView(TableLayoutUtils.createFullRow(activity, description, tp));
-                tableLayout.addView(TableLayoutUtils.divider(activity));
-            }
-            tableLayout.addView(TableLayoutUtils.createRow(activity, R.string.type, null, layer.getType(), tp));
-            if (TileLayerSource.TYPE_WMS.equals(layer.getType())) {
-                tableLayout.addView(TableLayoutUtils.createRow(activity, R.string.projection, null, layer.getProj(), tp));
-            }
-            tableLayout.addView(TableLayoutUtils.createRow(activity, R.string.layer_info_min_zoom, null, Integer.toString(layer.getMinZoomLevel()), tp));
-            tableLayout.addView(TableLayoutUtils.createRow(activity, R.string.layer_info_max_zoom, null, Integer.toString(layer.getMaxZoomLevel()), tp));
-            long startDate = layer.getStartDate();
-            if (startDate > 0) {
-                tableLayout.addView(TableLayoutUtils.createRow(activity, R.string.layer_info_start_date, null,
-                        DateFormatter.getUtcFormat(DATE_FORMAT).format(startDate), tp));
-            }
-            long endDate = layer.getEndDate();
-            if (endDate >= 0 && endDate < Long.MAX_VALUE) {
-                tableLayout.addView(
-                        TableLayoutUtils.createRow(activity, R.string.layer_info_end_date, null, DateFormatter.getUtcFormat(DATE_FORMAT).format(endDate), tp));
-            }
-            tableLayout.addView(TableLayoutUtils.createRow(activity, R.string.errors, null, Long.toString(tileErrorCount), tp));
-            String tou = layer.getTouUri();
-            if (tou != null) {
-                tableLayout.addView(TableLayoutUtils.createRow(activity, R.string.layer_info_terms, null, tou, true, tp));
-            }
-            String privacyPolicy = layer.getPrivacyPolicyUrl();
-            if (privacyPolicy != null) {
-                tableLayout.addView(TableLayoutUtils.createRow(activity, R.string.layer_info_privacy_policy, null, privacyPolicy, true, tp));
-            }
-            Logic logic = App.getLogic();
-            if (logic != null) {
-                Map map = logic.getMap();
-                if (map != null) {
-                    Collection<Provider> providers = layer.getProviders(map.getZoomLevel(), map.getViewBox());
-                    String legend = activity.getString(R.string.attribution);
-                    for (Provider provider : providers) {
-                        String attributionUrl = provider.getAttributionUrl();
-                        boolean hasAttributionUrl = attributionUrl != null;
-                        tableLayout.addView(TableLayoutUtils.createRow(activity, legend, null,
-                                hasAttributionUrl ? Util.fromHtml("<A href=\"" + attributionUrl + "\">" + provider.getAttribution() + "</A>")
-                                        : provider.getAttribution(),
-                                hasAttributionUrl, tp, R.attr.colorAccent, R.color.material_teal));
-                        legend = "";
-                    }
-                }
-            }
+            return sv;
         }
+        tableLayout.addView(TableLayoutUtils.createFullRowTitle(activity, layer.getName(), tp));
+        tableLayout.addView(TableLayoutUtils.divider(activity));
+        String description = layer.getDescription();
+        if (description != null) {
+            tableLayout.addView(TableLayoutUtils.createFullRow(activity, description, tp));
+            tableLayout.addView(TableLayoutUtils.divider(activity));
+        }
+        tableLayout.addView(TableLayoutUtils.createRow(activity, R.string.type, null, layer.getType(), tp));
+        if (TileLayerSource.TYPE_WMS.equals(layer.getType())) {
+            tableLayout.addView(TableLayoutUtils.createRow(activity, R.string.projection, null, layer.getProj(), tp));
+        }
+        tableLayout.addView(TableLayoutUtils.createRow(activity, R.string.layer_info_min_zoom, null, Integer.toString(layer.getMinZoomLevel()), tp));
+        tableLayout.addView(TableLayoutUtils.createRow(activity, R.string.layer_info_max_zoom, null, Integer.toString(layer.getMaxZoomLevel()), tp));
+        long startDate = layer.getStartDate();
+        if (startDate > 0) {
+            tableLayout.addView(
+                    TableLayoutUtils.createRow(activity, R.string.layer_info_start_date, null, DateFormatter.getUtcFormat(DATE_FORMAT).format(startDate), tp));
+        }
+        long endDate = layer.getEndDate();
+        if (endDate >= 0 && endDate < Long.MAX_VALUE) {
+            tableLayout.addView(
+                    TableLayoutUtils.createRow(activity, R.string.layer_info_end_date, null, DateFormatter.getUtcFormat(DATE_FORMAT).format(endDate), tp));
+        }
+        tableLayout.addView(TableLayoutUtils.createRow(activity, R.string.errors, null, Long.toString(tileErrorCount), tp));
+        String tou = layer.getTouUri();
+        if (tou != null) {
+            tableLayout.addView(TableLayoutUtils.createRow(activity, R.string.layer_info_terms, null, tou, true, tp));
+        }
+        String privacyPolicy = layer.getPrivacyPolicyUrl();
+        if (privacyPolicy != null) {
+            tableLayout.addView(TableLayoutUtils.createRow(activity, R.string.layer_info_privacy_policy, null, privacyPolicy, true, tp));
+        }
+        addAttribution(activity, tableLayout, tp);
+        tableLayout.addView(TableLayoutUtils.createRow(activity, R.string.url, null, layer.getOriginalTileUrl(), false, tp));
         return sv;
+    }
+
+    /**
+     * Add a row containing attribution for the current view box
+     * 
+     * @param activity the current activity
+     * @param tableLayout the TableLayout we are adding to
+     * @param tp the layout params
+     */
+    public void addAttribution(@NonNull FragmentActivity activity, @NonNull TableLayout tableLayout, @NonNull TableLayout.LayoutParams tp) {
+        Logic logic = App.getLogic();
+        if (logic == null) {
+            return;
+        }
+        Map map = logic.getMap();
+        if (map == null) {
+            return;
+        }
+        Collection<Provider> providers = layer.getProviders(map.getZoomLevel(), map.getViewBox());
+        String legend = activity.getString(R.string.attribution);
+        for (Provider provider : providers) {
+            String attributionUrl = provider.getAttributionUrl();
+            boolean hasAttributionUrl = attributionUrl != null;
+            tableLayout.addView(TableLayoutUtils.createRow(activity, legend, null,
+                    hasAttributionUrl ? Util.fromHtml("<A href=\"" + attributionUrl + "\">" + provider.getAttribution() + "</A>") : provider.getAttribution(),
+                    hasAttributionUrl, tp, R.attr.colorAccent, R.color.material_teal));
+            legend = "";
+        }
     }
 }

--- a/src/main/java/de/blau/android/resources/TileLayerSource.java
+++ b/src/main/java/de/blau/android/resources/TileLayerSource.java
@@ -2465,7 +2465,7 @@ public class TileLayerSource implements Serializable {
         return EPSG_3857_COMPATIBLE.contains(proj) || isLatLon(proj);
     }
 
-    private static final Pattern APIKEY_PATTERN = Pattern.compile(".*\\{" + APIKEY_PLACEHOLDER + "\\}.*", Pattern.CASE_INSENSITIVE);
+    public static final Pattern APIKEY_PATTERN = Pattern.compile(".*\\{" + APIKEY_PLACEHOLDER + "\\}.*", Pattern.CASE_INSENSITIVE);
 
     /**
      * Replace any apikey placeholder if possible

--- a/src/main/java/de/blau/android/services/util/MapTileTester.java
+++ b/src/main/java/de/blau/android/services/util/MapTileTester.java
@@ -1,5 +1,7 @@
 package de.blau.android.services.util;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -16,7 +18,9 @@ import de.blau.android.resources.TileLayerSource.TileType;
 import de.blau.android.util.ExecutorTask;
 
 public class MapTileTester {
-    private static final String DEBUG_TAG = MapTileTester.class.getSimpleName().substring(0, Math.min(23, MapTileTester.class.getSimpleName().length()));
+
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, MapTileTester.class.getSimpleName().length());
+    private static final String DEBUG_TAG = MapTileTester.class.getSimpleName().substring(0, TAG_LEN);
 
     private final Runnable      testTileLoader;
     private final StringBuilder output    = new StringBuilder();
@@ -50,7 +54,10 @@ public class MapTileTester {
                 eol();
                 TileLayerSource renderer = TileLayerSource.get(ctx, rendererID, false);
                 if (renderer != null) {
-                    String url = MapTileDownloader.buildURL(renderer, new MapTile(rendererID, zoomLevel, tileX, tileY));
+                    // if we've replaced an api key place holder show the original url
+                    final String originalTileUrl = renderer.getOriginalTileUrl();
+                    String url = TileLayerSource.APIKEY_PATTERN.matcher(originalTileUrl).matches() ? originalTileUrl
+                            : MapTileDownloader.buildURL(renderer, new MapTile(rendererID, zoomLevel, tileX, tileY));
                     output.append(ctx.getString(R.string.tile_input_error, message, url));
                 }
                 eol();


### PR DESCRIPTION
This slightly improves the contents of both the layer info and testing modal for tile layers, and rearranges where we add the accept-encoding header so that it can be overridden by a custom header. For example to completely disable compression as necessary to work around https://github.com/MarcusWolschon/osmeditor4android/issues/2846