### PR TITLE
Preset error handling improvments

### DIFF
--- a/src/main/java/de/blau/android/prefs/PrefEditor.java
+++ b/src/main/java/de/blau/android/prefs/PrefEditor.java
@@ -1,11 +1,14 @@
 package de.blau.android.prefs;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
 import de.blau.android.R;
 
 /**
@@ -15,7 +18,8 @@ import de.blau.android.R;
  */
 public class PrefEditor extends PrefEditorActivity {
 
-    private static final String DEBUG_TAG = PrefEditor.class.getSimpleName().substring(0, Math.min(23, PrefEditor.class.getSimpleName().length()));
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, PrefEditor.class.getSimpleName().length());
+    private static final String DEBUG_TAG = PrefEditor.class.getSimpleName().substring(0, TAG_LEN);
 
     /**
      * Start the PrefEditor activity
@@ -36,6 +40,17 @@ public class PrefEditor extends PrefEditorActivity {
     public static void start(@NonNull Activity activity, int requestCode) {
         Intent intent = new Intent(activity, PrefEditor.class);
         activity.startActivityForResult(intent, requestCode);
+    }
+
+    /**
+     * Start the PrefEditor activity and wait for a result
+     * 
+     * @param fragment the calling fragment
+     * @param requestCode an int value to identify the request
+     */
+    public static void start(@NonNull Fragment fragment, int requestCode) {
+        Intent intent = new Intent(fragment.getContext(), PrefEditor.class);
+        fragment.startActivityForResult(intent, requestCode);
     }
 
     @Override

--- a/src/main/java/de/blau/android/presets/AutoPreset.java
+++ b/src/main/java/de/blau/android/presets/AutoPreset.java
@@ -143,7 +143,7 @@ public class AutoPreset {
                                 item.setAppliesToRelation();
                             }
                             Log.d(DEBUG_TAG, "adding " + resultKey + " " + sr.getValue());
-                            item.addTag(resultKey, PresetKeyType.TEXT, sr.getValue(), null, null);
+                            item.addFixedTag(resultKey, sr.getValue(), null, null);
 
                             List<String> combinationsFromTaginfo = TaginfoServer.tagCombinations(context, server, resultKey, sr.getValue(), getAppliesTo(item),
                                     10);

--- a/src/main/java/de/blau/android/presets/PresetIconManager.java
+++ b/src/main/java/de/blau/android/presets/PresetIconManager.java
@@ -96,9 +96,9 @@ public class PresetIconManager implements Serializable {
                 Context extCtx = context.createPackageContext(assetPackage, 0);
                 return extCtx.getAssets();
             } catch (NameNotFoundException e) {
-                Log.e(DEBUG_TAG, "Asset package not found" + assetPackage);
+                Log.e(DEBUG_TAG, "Asset package not found " + assetPackage);
             } catch (Exception e) {
-                Log.e(DEBUG_TAG, "Exception while loading  asset package " + assetPackage, e);
+                Log.e(DEBUG_TAG, "Exception while loading asset package " + assetPackage, e);
             }
         }
         return null;

--- a/src/main/java/de/blau/android/presets/PresetItem.java
+++ b/src/main/java/de/blau/android/presets/PresetItem.java
@@ -307,20 +307,13 @@ public class PresetItem extends PresetElement {
      * Adds a fixed tag to the item
      * 
      * @param key key name of the tag
-     * @param type PresetType
      * @param value value of the tag
      * @param text description of the tag return the allocated PresetField
      * @param textContext a translation context
      * @return the allocated PresetField
      */
     @NonNull
-    public PresetTagField addTag(final String key, final PresetKeyType type, @Nullable String value, @Nullable String text, @Nullable String textContext) {
-        if (key == null) {
-            throw new NullPointerException("null key not supported");
-        }
-        if (value == null) {
-            value = "";
-        }
+    public PresetTagField addFixedTag(@NonNull final String key, @NonNull String value, @Nullable String text, @Nullable String textContext) {
         if (text != null) {
             text = preset.translate(text, textContext);
         }

--- a/src/main/java/de/blau/android/propertyeditor/PropertyEditorFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/PropertyEditorFragment.java
@@ -459,7 +459,7 @@ public class PropertyEditorFragment<M extends Map<String, String> & Serializable
             return true;
         }
         if (item.getItemId() == R.id.menu_config) {
-            PrefEditor.start(getActivity(), PREFERENCES_CODE);
+            PrefEditor.start(this, PREFERENCES_CODE);
             return true;
         }
         return super.onOptionsItemSelected(item);
@@ -478,6 +478,8 @@ public class PropertyEditorFragment<M extends Map<String, String> & Serializable
             // Preferences may have been changed
             prefs = new Preferences(getContext());
             App.getLogic().setPrefs(prefs);
+            updatePresets();
+            updateRecentPresets();
         }
     }
 

--- a/src/main/java/de/blau/android/propertyeditor/RecentPresetsFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/RecentPresetsFragment.java
@@ -206,6 +206,7 @@ public class RecentPresetsFragment extends BaseFragment {
      */
     private void recreateRecentPresetView(@NonNull LinearLayout presetLayout) {
         Log.d(DEBUG_TAG, "recreateRecentPresetView");
+        presets = App.getCurrentPresets(getActivity());
         presetLayout.removeAllViews();
         View v = getRecentPresetsView(presetLayout, element, presets);
         if (v != null) {

--- a/src/main/java/de/blau/android/util/SearchIndexUtils.java
+++ b/src/main/java/de/blau/android/util/SearchIndexUtils.java
@@ -1,5 +1,7 @@
 package de.blau.android.util;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,12 +29,13 @@ import de.blau.android.presets.PresetElement;
 import de.blau.android.presets.PresetField;
 import de.blau.android.presets.PresetFixedField;
 import de.blau.android.presets.PresetItem;
-import de.blau.android.presets.PresetKeyType;
 import de.blau.android.presets.PresetTagField;
 import de.blau.android.util.collections.MultiHashMap;
 
 public final class SearchIndexUtils {
-    private static final String DEBUG_TAG = SearchIndexUtils.class.getSimpleName().substring(0, Math.min(23, SearchIndexUtils.class.getSimpleName().length()));
+
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, SearchIndexUtils.class.getSimpleName().length());
+    private static final String DEBUG_TAG = SearchIndexUtils.class.getSimpleName().substring(0, TAG_LEN);
 
     private static final Pattern DEACCENT_PATTERN = Pattern.compile("\\p{InCombiningDiacriticalMarks}+");
 
@@ -227,7 +230,7 @@ public final class SearchIndexUtils {
                             PresetItem namePi = new PresetItem(preset, null, nat.getName(), pi == null ? null : pi.getIconpath(), null);
 
                             for (Entry<String, String> entry : tags.entrySet()) {
-                                namePi.addTag(entry.getKey(), PresetKeyType.TEXT, entry.getValue(), null, null);
+                                namePi.addFixedTag(entry.getKey(), entry.getValue(), null, null);
                             }
                             if (pi != null) {
                                 Map<String, PresetField> fields = pi.getFields();

--- a/src/test/java/de/blau/android/presets/PresetParserTest.java
+++ b/src/test/java/de/blau/android/presets/PresetParserTest.java
@@ -1,0 +1,62 @@
+package de.blau.android.presets;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.xml.sax.SAXException;
+
+import androidx.test.filters.LargeTest;
+
+/**
+ * Some preset parsing error tests
+ * 
+ * @author simon
+ *
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 33)
+@LargeTest
+public class PresetParserTest {
+
+
+    /**
+     * Test that missing keys throw an exception
+     */
+    @Test
+    public void missingKey() {
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        try (InputStream input = loader.getResourceAsStream("test-preset-missing-key.xml")) {
+            Preset preset = Preset.dummyInstance();
+            PresetParser.parseXML(preset, input, true);
+        } catch (SAXException sex) {
+            assertTrue(sex.getMessage().contains("key must be present"));
+        } catch (ParserConfigurationException | IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    /**
+     * Test that missing values throw an exception
+     */
+    @Test
+    public void missingValue() {
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        try (InputStream input = loader.getResourceAsStream("test-preset-missing-value.xml")) {
+            Preset preset = Preset.dummyInstance();
+            PresetParser.parseXML(preset, input, true);
+        } catch (SAXException sex) {
+            assertTrue(sex.getMessage().contains("value must be present in key field"));
+        } catch (ParserConfigurationException | IOException e) {
+            fail(e.getMessage());
+        }
+    }
+}

--- a/src/testCommon/resources/test-preset-missing-key.xml
+++ b/src/testCommon/resources/test-preset-missing-key.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<presets version="0.0.0" xmlns="http://josm.openstreetmap.de/tagging-preset-1.0"
+        shortdescription="Testing preset"
+        object_keys="imaginary2">
+    <group name="Test Group">
+        <item name="Test Item" type="node,way,closedway,multipolygon">
+            <key value="tag" />
+        </item> <!-- -->
+    </group>
+</presets>

--- a/src/testCommon/resources/test-preset-missing-value.xml
+++ b/src/testCommon/resources/test-preset-missing-value.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<presets version="0.0.0" xmlns="http://josm.openstreetmap.de/tagging-preset-1.0"
+        shortdescription="Testing preset"
+        object_keys="imaginary2">
+    <group name="Test Group">
+        <item name="Test Item" type="node,way,closedway,multipolygon">
+            <key key="key" />
+        </item> <!-- -->
+    </group>
+</presets>


### PR DESCRIPTION
Small re-factoring of preset parser

- catch more errors in parser instead of when creating items
- improve error messages

Further this fixes an issue that caused the preset MRU fragment not to update when the preferences were changed from within the property editor.