### PR TITLE
Impove error display for cloudflare caused download errors

### DIFF
--- a/documentation/docs/tutorials/faq.md
+++ b/documentation/docs/tutorials/faq.md
@@ -218,11 +218,7 @@ Vespucci preferentially attempts to store aerial imagery data on an external SD 
 
 ### Can't download data from OpenStreetMap servers 
 
-If it is not a connectivity issue you may be running in to the following problem: current Vespucci versions use HTTPS (encrypted connections) to connect to the OpenStreetMap servers, if you are running on an older Android version this may be failing due to problems the old devices have with more recent certificates. 
-
-Workaround: create a new non-HTTPS API entry (enter "http://api.openstreetmap.org/api/0.6/" as API URL) and select that. 0.9.8 and later versions already have such an entry, you only need to activate it. 
-
-Note that the same issue may apply to certain background and overlay layers.
+If you are getting an _Unknown error_ when you try to download data from OpenStreetMap and the displayed message seems to be gibberish (that is HTML and CSS code), you are likely being blocked by Cloudflare anti-misuse measures. There is currently no way to circumvent these in the app and you are essentially stuck. If the issue persists over multiple days please open an issue.
 
 ### "301 Moved Permanently" error when trying to download
 

--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -3253,7 +3253,7 @@ public class Logic {
                 result = new AsyncResult(ErrorCodes.DOWNLOAD_LIMIT_EXCEEDED);
                 break;
             default:
-                result = new AsyncResult(ErrorCodes.UNKNOWN_ERROR, e.getMessage());
+                result = new AsyncResult(ErrorCodes.UNKNOWN_ERROR, ctx.getString(R.string.unknown_http_code_message, e.getHttpErrorCode(), e.getMessage()));
             }
         } catch (StorageException sex) {
             result = new AsyncResult(ErrorCodes.OUT_OF_MEMORY);

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -77,6 +77,7 @@
     <string name="not_found_message">The API couldn\'t find an existing element or changeset with the specified id.&lt;br&gt;&lt;br&gt;</string>
     <string name="unknown_error_title">Unknown error</string>
     <string name="unknown_error_message">The error code returned from the API or the message could not be processed.&lt;br&gt;&lt;br&gt;</string>
+    <string name="unknown_http_code_message">HTTP error code: %1$d&lt;br&gt;Error message:&lt;br&gt;&lt;br&gt;%1$s</string>
     <string name="no_data_title">No data</string>
     <string name="no_data_message">The configured data source has no coverage here.</string>
     <string name="required_feature_missing_title">Missing or disabled component</string> 


### PR DESCRIPTION
This slightly improves how we display "unknown errors" on downloads, which are essentially always caused by Cloudflare and adds a couple of words on the matter to the FAQ. 