### PR TITLE
Improve messaging if/when opening changeset times out

### DIFF
--- a/src/main/java/de/blau/android/dialogs/UploadRetry.java
+++ b/src/main/java/de/blau/android/dialogs/UploadRetry.java
@@ -186,18 +186,20 @@ public class UploadRetry extends ImmersiveDialogFragment {
             builder.setView(layout);
             AlertDialog dialog = builder.create();
 
-            if (changesetId != -1) {
-                determineStatus(App.getPreferences(getActivity()), App.getLogic(), changesetId, dialog);
-            } else {
-                String message = getString(R.string.upload_retry_message_no_open_changeset);
-                retryMessage.setText(message);
-                ACRAHelper.nocrashReport(null, message);
+            final Logic logic = App.getLogic();
+            if (changesetId == -1) {
+                retryMessage.setText(getString(R.string.upload_retry_message_no_open_changeset));
+                final UploadListener.UploadArguments arguments = new UploadListener.UploadArguments(comment, source, false, false, extraTags, elements);
+                dialog.setOnShowListener((DialogInterface d) -> {
+                    dialog.getButton(DialogInterface.BUTTON_POSITIVE).setVisibility(View.GONE);
+                    setupButton(dialog.getButton(DialogInterface.BUTTON_NEGATIVE), R.string.retry, (View v) -> logic.upload(getActivity(), arguments, null));
+                });
+                return dialog;
             }
+            determineStatus(App.getPreferences(getActivity()), logic, changesetId, dialog);
             dialog.setOnShowListener((DialogInterface d) -> {
-                final Button positive = dialog.getButton(DialogInterface.BUTTON_POSITIVE);
-                positive.setVisibility(View.GONE);
-                final Button negative = dialog.getButton(DialogInterface.BUTTON_NEGATIVE);
-                negative.setVisibility(View.GONE);
+                dialog.getButton(DialogInterface.BUTTON_POSITIVE).setVisibility(View.GONE);
+                dialog.getButton(DialogInterface.BUTTON_NEGATIVE).setVisibility(View.GONE);
             });
             return dialog;
         } catch (Exception e) {
@@ -295,21 +297,20 @@ public class UploadRetry extends ImmersiveDialogFragment {
                     Log.e(DEBUG_TAG, "Unexpected result vale " + result);
                 }
             }
-
-            /**
-             * Make a button visible, set text and listener
-             * 
-             * @param button the button
-             * @param text the text displayed on the button
-             * @param listener the listener that is called when the button is clicked
-             */
-            private void setupButton(@NonNull final Button button, final int textRes, @Nullable final View.OnClickListener listener) {
-                button.setVisibility(View.VISIBLE);
-                button.setText(textRes);
-                button.setOnClickListener(listener);
-            }
-
         }.execute(changesetId);
+    }
+
+    /**
+     * Make a button visible, set text and listener
+     * 
+     * @param button the button
+     * @param text the text displayed on the button
+     * @param listener the listener that is called when the button is clicked
+     */
+    private void setupButton(@NonNull final Button button, final int textRes, @Nullable final View.OnClickListener listener) {
+        button.setVisibility(View.VISIBLE);
+        button.setText(textRes);
+        button.setOnClickListener(listener);
     }
 
     /**

--- a/src/main/java/de/blau/android/osm/Server.java
+++ b/src/main/java/de/blau/android/osm/Server.java
@@ -807,7 +807,8 @@ public class Server {
         checkResponseCode(response);
 
         try (InputStream in = response.body().byteStream()) {
-            String line = readLine(in);
+            BufferedReader reader = new BufferedReader(new InputStreamReader(in), 9);
+            String line = reader.readLine();
             if (line != null) {
                 changesetId = Long.parseLong(line);
             } else {
@@ -1102,25 +1103,6 @@ public class Server {
             }
         }
         return res.toString();
-    }
-
-    /**
-     * Read a single line from an InputStream
-     * 
-     * @param in the InputStream
-     * @return a String containing the line without the EOL or null
-     */
-    @Nullable
-    private static String readLine(@NonNull final InputStream in) {
-        BufferedReader reader = new BufferedReader(new InputStreamReader(in), 9);
-        String res = null;
-        try {
-            res = reader.readLine();
-        } catch (IOException e) {
-            Log.e(DEBUG_TAG, "Problem reading", e);
-        }
-
-        return res;
     }
 
     /**

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -51,7 +51,7 @@
     <string name="undelete_on_server">Undelete\non server</string>
     <!-- Upload retry -->
     <string name="upload_retry_title">Upload failed</string>
-    <string name="upload_retry_message_no_open_changeset">No open changeset. This shouldn\'t happen.</string>
+    <string name="upload_retry_message_no_open_changeset">Opening changeset failed.\n\nIt is safe to retry.</string>
     <string name="upload_retry_message_unexpected_error">Unexpected error trying to determine status of changeset %1$d.</string>
     <string name="upload_retry_message_no_changeset_status">Unable to determine status of changeset %1$d.\n\nWe suggest saving your changes as an OCS file and determining what to do when you have better reception.</string>
     <string name="upload_retry_message_nothing_uploaded">No changes have been uploaded in changeset %1$d.\n\nIt is safe to retry.</string>


### PR DESCRIPTION
Previously this would show a bit of a nonsensical error message and not offer to retry.