### PR TITLE
Use MediaStore.createTrashRequest to delete/move to trash images

### DIFF
--- a/documentation/docs/help/en/Advanced preferences.md
+++ b/documentation/docs/help/en/Advanced preferences.md
@@ -30,7 +30,11 @@ Select the camera app to use. If your, installed, camera app is not listed, plea
 
 ### Use the MediaStore
 
-Additionally use Androids MediaStore for accessing photos. This will add all photographs in JPEG format found via the MediaStore that contain coordinates in their EXIF data to the phto layer. Default: _off_.
+Additionally use Androids MediaStore for accessing photos. This will add all photographs in JPEG format found via the MediaStore that contain coordinates in their EXIF data to the photo layer. Default: _off_.
+
+### Add images to the MediaStore
+
+Add images recorded via the camera button (see above) to Androids MediaStore. This potentially makes managing the images from an external app easier. Default: _off_.
 
 ### Follow location button layout
 

--- a/src/main/assets/help/en/Advanced preferences.html
+++ b/src/main/assets/help/en/Advanced preferences.html
@@ -21,7 +21,9 @@
 <h3>Camera app</h3>
 <p>Select the camera app to use. If your, installed, camera app is not listed, please report this and we will add it to the list. Unluckily google does not allow to automatically determine installed camera apps outside of pre-installed ones. Default: <em>System default</em>.</p>
 <h3>Use the MediaStore</h3>
-<p>Additionally use Androids MediaStore for accessing photos. This will add all photographs in JPEG format found via the MediaStore that contain coordinates in their EXIF data to the phto layer. Default: <em>off</em>.</p>
+<p>Additionally use Androids MediaStore for accessing photos. This will add all photographs in JPEG format found via the MediaStore that contain coordinates in their EXIF data to the photo layer. Default: <em>off</em>.</p>
+<h3>Add images to the MediaStore</h3>
+<p>Add images recorded via the camera button (see above) to Androids MediaStore. This potentially makes managing the images from an external app easier. Default: <em>off</em>.</p>
 <h3>Follow location button layout</h3>
 <p>Change the side of the display the &quot;Follow location&quot; button is positioned on or remove it completely. Default: <em>lefthand side</em>.</p>
 <h3>Always dim non-downloaded areas</h3>

--- a/src/main/java/de/blau/android/dialogs/ImageInfo.java
+++ b/src/main/java/de/blau/android/dialogs/ImageInfo.java
@@ -1,5 +1,7 @@
 package de.blau.android.dialogs;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
@@ -33,26 +35,29 @@ import de.blau.android.util.InfoDialogFragment;
  */
 public class ImageInfo extends InfoDialogFragment {
 
-    private static final String DEBUG_TAG = ImageInfo.class.getSimpleName().substring(0, Math.min(23, ImageInfo.class.getSimpleName().length()));
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, ImageInfo.class.getSimpleName().length());
+    private static final String DEBUG_TAG = ImageInfo.class.getSimpleName().substring(0, TAG_LEN);
 
-    private static final String URI_KEY = "uri";
-
-    private static final String TAG = "fragment_image_info";
+    private static final String URI_KEY      = "uri";
+    private static final String SHOW_URI_KEY = "showUri";
+    private static final String TAG          = "fragment_image_info";
 
     private Uri              uri        = null;
     private SimpleDateFormat dateFormat = DateFormatter.getUtcFormat("yyyy-MM-dd HH:mm:ssZZ");
+    private boolean          showUri;
 
     /**
      * Show an info dialog for an image
      * 
      * @param activity the calling Activity
      * @param uriString the uri of the image as a string
+     * @param showUri if true display the uri besides the file path
      */
-    public static void showDialog(@NonNull FragmentActivity activity, @NonNull String uriString) {
+    public static void showDialog(@NonNull FragmentActivity activity, @NonNull String uriString, boolean showUri) {
         dismissDialog(activity);
         try {
             FragmentManager fm = activity.getSupportFragmentManager();
-            ImageInfo elementInfoFragment = newInstance(uriString);
+            ImageInfo elementInfoFragment = newInstance(uriString, showUri);
             elementInfoFragment.show(fm, TAG);
         } catch (IllegalStateException isex) {
             Log.e(DEBUG_TAG, "showDialog", isex);
@@ -71,16 +76,17 @@ public class ImageInfo extends InfoDialogFragment {
     /**
      * Create a new instance of the ImageInfo dialog
      * 
-     * @param feature Feature to display the info on
-     * 
+     * @param uriString the uri of the image as a string
+     * @param showUri if true display the uri besides the file path
      * @return an instance of ImageInfo
      */
     @NonNull
-    private static ImageInfo newInstance(@NonNull String uriString) {
+    private static ImageInfo newInstance(@NonNull String uriString, boolean showUri) {
         ImageInfo f = new ImageInfo();
 
         Bundle args = new Bundle();
         args.putString(URI_KEY, uriString);
+        args.putBoolean(SHOW_URI_KEY, showUri);
 
         f.setArguments(args);
         f.setShowsDialog(true);
@@ -96,6 +102,7 @@ public class ImageInfo extends InfoDialogFragment {
         } catch (Exception e) {
             Log.e(DEBUG_TAG, "Unable to parse uri " + uriString);
         }
+        showUri = getArguments().getBoolean(SHOW_URI_KEY, true);
         Builder builder = new AlertDialog.Builder(getActivity());
         DoNothingListener doNothingListener = new DoNothingListener();
         builder.setPositiveButton(R.string.done, doNothingListener);
@@ -110,33 +117,40 @@ public class ImageInfo extends InfoDialogFragment {
         TableLayout tl = (TableLayout) sv.findViewById(R.id.element_info_vertical_layout);
         TableLayout.LayoutParams tp = getTableLayoutParams();
 
-        if (uri != null) {
-            tl.setColumnShrinkable(1, true);
-            try {
-                FragmentActivity activity = getActivity();
-                Photo image = new Photo(getContext(), uri, null);
-                String path = ContentResolverUtil.getPath(getContext(), uri);
-                tl.addView(TableLayoutUtils.createRow(activity, path == null ? uri.toString() : path, null, tp));
-                long size = ContentResolverUtil.getSizeColumn(getContext(), uri);
-                if (size > -1) {
-                    tl.addView(TableLayoutUtils.createRow(activity, R.string.file_size, getString(R.string.file_size_kB, size / 1024), tp));
-                }
-                String creator = image.getCreator();
-                if (creator != null) {
-                    tl.addView(TableLayoutUtils.createRow(activity, R.string.created_by, creator, tp));
-                }
-                Long captureDate = image.getCaptureDate();
-                if (captureDate != null) {
-                    tl.addView(TableLayoutUtils.createRow(activity, R.string.capture_date, dateFormat.format(new Date(captureDate)), tp));
-                }
-                tl.addView(TableLayoutUtils.createRow(activity, R.string.location_lon_label, prettyPrintCoord(image.getLon() / 1E7D), tp));
-                tl.addView(TableLayoutUtils.createRow(activity, R.string.location_lat_label, prettyPrintCoord(image.getLat() / 1E7D), tp));
-                if (image.hasDirection()) {
-                    tl.addView(TableLayoutUtils.createRow(activity, R.string.direction, String.format(Locale.US, "%3d°", image.getDirection()), tp));
-                }
-            } catch (Exception ex) {
-                Log.e(DEBUG_TAG, "Exception displaying image meta data " + ex.getMessage());
+        if (uri == null) {
+            return sv;
+        }
+        tl.setColumnShrinkable(1, true);
+        try {
+            FragmentActivity activity = getActivity();
+            Photo image = new Photo(getContext(), uri, null);
+            String path = ContentResolverUtil.getPath(getContext(), uri);
+            Log.i(DEBUG_TAG, "path " + path + " uri " + uri.toString());
+            if (path != null) {
+                tl.addView(TableLayoutUtils.createRow(activity, R.string.File, path, tp));
             }
+            if (showUri || path == null) {
+                tl.addView(TableLayoutUtils.createRow(activity, R.string.URI, uri.toString(), tp));
+            }
+            long size = ContentResolverUtil.getSizeColumn(getContext(), uri);
+            if (size > -1) {
+                tl.addView(TableLayoutUtils.createRow(activity, R.string.file_size, getString(R.string.file_size_kB, size / 1024), tp));
+            }
+            String creator = image.getCreator();
+            if (creator != null) {
+                tl.addView(TableLayoutUtils.createRow(activity, R.string.created_by, creator, tp));
+            }
+            Long captureDate = image.getCaptureDate();
+            if (captureDate != null) {
+                tl.addView(TableLayoutUtils.createRow(activity, R.string.capture_date, dateFormat.format(new Date(captureDate)), tp));
+            }
+            tl.addView(TableLayoutUtils.createRow(activity, R.string.location_lon_label, prettyPrintCoord(image.getLon() / 1E7D), tp));
+            tl.addView(TableLayoutUtils.createRow(activity, R.string.location_lat_label, prettyPrintCoord(image.getLat() / 1E7D), tp));
+            if (image.hasDirection()) {
+                tl.addView(TableLayoutUtils.createRow(activity, R.string.direction, String.format(Locale.US, "%3d°", image.getDirection()), tp));
+            }
+        } catch (Exception ex) {
+            Log.e(DEBUG_TAG, "Exception displaying image meta data " + ex.getMessage());
         }
         return sv;
     }

--- a/src/main/java/de/blau/android/dialogs/TableLayoutUtils.java
+++ b/src/main/java/de/blau/android/dialogs/TableLayoutUtils.java
@@ -205,7 +205,6 @@ public final class TableLayoutUtils {
         TextView cell = new TextView(context);
         cell.setSingleLine();
         cell.setMinEms(FIRST_CELL_WIDTH);
-        cell.setMaxEms(MAX_FIRST_CELL_WIDTH);
 
         SpannableString span = new SpannableString(cell1);
         SpannableString span2 = null;
@@ -225,6 +224,7 @@ public final class TableLayoutUtils {
             ThemeUtils.setSpanColor(context, span, highlightColorAttr, highlightColorFallback);
             ThemeUtils.setSpanColor(context, span2, highlightColorAttr, highlightColorFallback);
             ThemeUtils.setSpanColor(context, span3, highlightColorAttr, highlightColorFallback);
+            cell.setMaxEms(MAX_FIRST_CELL_WIDTH);
         }
         cell.setText(span);
         cell.setEllipsize(TruncateAt.MARQUEE);

--- a/src/main/java/de/blau/android/layer/streetlevel/NetworkImageLoader.java
+++ b/src/main/java/de/blau/android/layer/streetlevel/NetworkImageLoader.java
@@ -206,6 +206,6 @@ public abstract class NetworkImageLoader extends ImageLoader {
     @Override
     public void info(@NonNull FragmentActivity activity, @NonNull String uri) {
         Uri f = FileProvider.getUriForFile(activity, activity.getString(R.string.content_provider), new File(cacheDir, uri + JPG));
-        ImageInfo.showDialog(activity, f.toString());
+        ImageInfo.showDialog(activity, f.toString(), false);
     }
 }

--- a/src/main/java/de/blau/android/photos/Photo.java
+++ b/src/main/java/de/blau/android/photos/Photo.java
@@ -262,13 +262,13 @@ public class Photo implements BoundedObject, GeoPoint, Serializable {
     @Nullable
     public Uri getRefUri(@NonNull Context context) {
         try {
-            Log.d(DEBUG_TAG, "getRef ref is " + ref);
+            Log.d(DEBUG_TAG, "getRefUri ref is " + ref);
             if (ref.startsWith("content:")) {
                 return Uri.parse(ref);
             }
             return FileProvider.getUriForFile(context, context.getString(R.string.content_provider), new File(ref));
         } catch (Exception ex) {
-            Log.d(DEBUG_TAG, "getRef Problem with Uri for ref " + ref + " " + ex);
+            Log.d(DEBUG_TAG, "getRefUri Problem with Uri for ref " + ref + " " + ex);
             return null;
         }
     }

--- a/src/main/java/de/blau/android/photos/PhotoViewerFragment.java
+++ b/src/main/java/de/blau/android/photos/PhotoViewerFragment.java
@@ -239,7 +239,7 @@ public class PhotoViewerFragment<T extends Serializable> extends SizedDynamicImm
 
         @Override
         public void info(@NonNull FragmentActivity activity, @NonNull String uri) {
-            ImageInfo.showDialog(activity, uri);
+            ImageInfo.showDialog(activity, uri, true);
         }
 
         @Override

--- a/src/main/java/de/blau/android/photos/PhotoViewerFragment.java
+++ b/src/main/java/de/blau/android/photos/PhotoViewerFragment.java
@@ -301,7 +301,7 @@ public class PhotoViewerFragment<T extends Serializable> extends SizedDynamicImm
                     photoUri = ContentUris.withAppendedId(MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL), mediaId);
                 }
                 Log.d(DEBUG_TAG, "deleting " + photoUri);
-                IntentSenderRequest.Builder builder = new IntentSenderRequest.Builder(MediaStore.createDeleteRequest(resolver, Arrays.asList(photoUri)));
+                IntentSenderRequest.Builder builder = new IntentSenderRequest.Builder(MediaStore.createTrashRequest(resolver, Arrays.asList(photoUri), true));
                 ((PhotoViewerActivity) getActivity()).getDeleteRequestLauncher().launch(builder.build());
 
             } catch (java.lang.SecurityException sex) {

--- a/src/main/java/de/blau/android/prefs/Preferences.java
+++ b/src/main/java/de/blau/android/prefs/Preferences.java
@@ -103,6 +103,7 @@ public class Preferences {
     private final String      cameraApp;
     private final boolean     useInternalPhotoViewer;
     private final boolean     scanMediaStore;
+    private final boolean     addToMediaStore;
     private final boolean     generateAlerts;
     private final boolean     groupAlertsOnly;
     private int               maxAlertDistance;
@@ -259,6 +260,7 @@ public class Preferences {
         cameraApp = prefs.getString(r.getString(R.string.config_selectCameraApp_key), "");
         useInternalPhotoViewer = prefs.getBoolean(r.getString(R.string.config_useInternalPhotoViewer_key), true);
         scanMediaStore = prefs.getBoolean(r.getString(R.string.config_indexMediaStore_key), false);
+        addToMediaStore = prefs.getBoolean(r.getString(R.string.config_addToMediaStore_key), false);
 
         generateAlerts = prefs.getBoolean(r.getString(R.string.config_generateAlerts_key), true);
         maxAlertDistance = getIntPref(R.string.config_maxAlertDistance_key, 100);
@@ -1000,12 +1002,21 @@ public class Preferences {
     }
 
     /**
-     * Check if we should scane the media store for photos
+     * Check if we should scan the media store for photos
      * 
      * @return true if we should scan the MediaStore
      */
     public boolean scanMediaStore() {
         return scanMediaStore;
+    }
+
+    /**
+     * Check if we should add imaged to the media store for photos
+     * 
+     * @return true if we should add images the MediaStore
+     */
+    public boolean addToMediaStore() {
+        return addToMediaStore;
     }
 
     /**

--- a/src/main/java/de/blau/android/util/ContentResolverUtil.java
+++ b/src/main/java/de/blau/android/util/ContentResolverUtil.java
@@ -9,12 +9,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Environment;
+import android.provider.BaseColumns;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 import android.util.Log;
@@ -284,5 +286,32 @@ public final class ContentResolverUtil {
             }
         }
         return false;
+    }
+
+    /**
+     * Convert a file path to a content uri with media id
+     * 
+     * @param cr a ContentResolver
+     * @param path the path
+     * @return the media id, 0 if not found
+     */
+    public static long imageFilePathToMediaID(@NonNull ContentResolver cr, @NonNull String path) {
+        long id = 0;
+
+        Uri uri = MediaStore.Files.getContentUri(MediaStore.VOLUME_EXTERNAL);
+        String selection = MediaStore.MediaColumns.DATA;
+        String[] selectionArgs = { path };
+        String[] projection = { BaseColumns._ID };
+
+        Cursor cursor = cr.query(uri, projection, selection + "=?", selectionArgs, null);
+
+        if (cursor != null) {
+            while (cursor.moveToNext()) {
+                int idIndex = cursor.getColumnIndex(BaseColumns._ID);
+                id = Long.parseLong(cursor.getString(idIndex));
+            }
+        }
+
+        return id;
     }
 }

--- a/src/main/java/de/blau/android/util/ContentResolverUtil.java
+++ b/src/main/java/de/blau/android/util/ContentResolverUtil.java
@@ -89,6 +89,9 @@ public final class ContentResolverUtil {
                 Log.e(DEBUG_TAG, "getPath " + e.getMessage());
                 return null;
             }
+        } else if (Schemes.CONTENT.equals(scheme)) {
+            Log.i(DEBUG_TAG, "content scheme");
+            return getDataColumn(context, uri, null, null);
         } else if (Schemes.FILE.equals(scheme)) {
             return uri.getPath();
         }
@@ -175,7 +178,7 @@ public final class ContentResolverUtil {
         try {
             return DocumentsContract.renameDocument(context.getContentResolver(), uri, newName);
         } catch (FileNotFoundException e) {
-            Log.e(DEBUG_TAG, e.getMessage());
+            Log.e(DEBUG_TAG, "rename " + e.getMessage());
         }
         return null;
     }
@@ -243,7 +246,7 @@ public final class ContentResolverUtil {
                 return cursor.getString(column_index);
             }
         } catch (Exception ex) {
-            Log.e(DEBUG_TAG, ex.getMessage());
+            Log.e(DEBUG_TAG, "getColumn " + ex.getMessage());
         }
         return null;
     }

--- a/src/main/res/layout/element_info_view.xml
+++ b/src/main/res/layout/element_info_view.xml
@@ -21,21 +21,18 @@
                 android:id="@+id/element_info_vertical_layout"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
                 tools:background="@android:color/holo_orange_light">
             </TableLayout>
             <TableLayout
                 android:id="@+id/element_info_vertical_layout_2"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
                 tools:background="@android:color/holo_orange_light">
             </TableLayout>
             <TableLayout
                 android:id="@+id/element_info_vertical_layout_3"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
                 tools:background="@android:color/holo_orange_light">
             </TableLayout>
         </LinearLayout>

--- a/src/main/res/values/prefkeys.xml
+++ b/src/main/res/values/prefkeys.xml
@@ -104,6 +104,7 @@
     <string name="config_appLocale_key">appLocale</string>
     <string name="config_nameCap_key">nameCap</string>
     <string name="config_indexMediaStore_key">indexMediaStore</string>
+    <string name="config_addToMediaStore_key">addToMediaStore</string>
     <string name="config_wayNodeDragging_key">wayNodeDragging</string>
     <string name="config_splitWindowForPropertyEditor_key">splitWindowForPropertyEditor</string>
     <string name="config_newTaskForPropertyEditor_key">newTaskForPropertyEditor</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1622,6 +1622,8 @@
     <string name="regular_expression">Regular expression</string>
     <string name="state">State</string>
     <string name="Continue">Continue</string>
+    <string name="File">File</string>
+    <string name="URI">URI</string>
     <!--   -->
     <string name="empty_list">No entries</string>
     <string name="geocoder_type">Geocoder type</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1340,6 +1340,8 @@
     <string name="config_useInternalPhotoViewer_summary">Use the builtin photo view, if not checked an external viewer will be used.</string>    
     <string name="config_indexMediaStore_summary">Additionally use the MediaStore for accessing photos</string>
     <string name="config_indexMediaStore_title">Use the MediaStore</string>
+    <string name="config_addToMediaStore_summary">Add images recorded with the camera button to the MediaStore</string>
+    <string name="config_addToMediaStore_title">Add images to the MediaStore</string>
     <string name="config_followGPSbutton_title">Follow location button layout</string>
     <string name="config_followGPSbutton_summary">Where the "Follow location" button will be positioned.</string>
     <string name="config_alwaysDrawBoundingBoxes_title">Always dim non-downloaded areas</string>

--- a/src/main/res/xml-v24/advancedpreferences.xml
+++ b/src/main/res/xml-v24/advancedpreferences.xml
@@ -49,6 +49,11 @@
             android:key="@string/config_indexMediaStore_key"
             android:summary="@string/config_indexMediaStore_summary"
             android:title="@string/config_indexMediaStore_title" />
+        <androidx.preference.CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/config_addToMediaStore_key"
+            android:summary="@string/config_addToMediaStore_summary"
+            android:title="@string/config_addToMediaStore_title" />
         <androidx.preference.ListPreference
             android:defaultValue="@string/follow_GPS_left"
             android:entries="@array/followGPSbutton_entries"

--- a/src/main/res/xml-v29/advancedpreferences.xml
+++ b/src/main/res/xml-v29/advancedpreferences.xml
@@ -49,6 +49,11 @@
             android:key="@string/config_indexMediaStore_key"
             android:summary="@string/config_indexMediaStore_summary"
             android:title="@string/config_indexMediaStore_title" />
+        <androidx.preference.CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/config_addToMediaStore_key"
+            android:summary="@string/config_addToMediaStore_summary"
+            android:title="@string/config_addToMediaStore_title" />
         <androidx.preference.ListPreference
             android:defaultValue="@string/follow_GPS_left"
             android:entries="@array/followGPSbutton_entries"

--- a/src/main/res/xml/advancedpreferences.xml
+++ b/src/main/res/xml/advancedpreferences.xml
@@ -49,6 +49,11 @@
             android:key="@string/config_indexMediaStore_key"
             android:summary="@string/config_indexMediaStore_summary"
             android:title="@string/config_indexMediaStore_title" />
+        <androidx.preference.CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/config_addToMediaStore_key"
+            android:summary="@string/config_addToMediaStore_summary"
+            android:title="@string/config_addToMediaStore_title" />
         <androidx.preference.ListPreference
             android:defaultValue="@string/follow_GPS_left"
             android:entries="@array/followGPSbutton_entries"


### PR DESCRIPTION
On Android 11 and later we can ask the MediaStore to delete images this works if if we are not owner of the image.

The down side of this is that depending on if the image is being indexed via the media store or directly in the Vespucci Pictures directory, the confirmation modal will be different.

Doesn't resolve  https://github.com/MarcusWolschon/osmeditor4android/issues/1913