### PR TITLE
Avoid index out of bound if selected nodes isn't null

### DIFF
--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -1630,7 +1630,7 @@ public class Logic {
             }
         }
         List<Node> selectedNodes = selection.getNodes();
-        if (selectedNodes != null) {
+        if (Util.notEmpty(selectedNodes)) {
             if (selection.count() == 1) {
                 updateDirection(activity, (float) Math.toDegrees(angle), direction, selectedNodes.get(0));
                 return;


### PR DESCRIPTION
We were relying on selected.nodes being null when no nodes are selected.