### PR TITLE
Handle server errors during conflict resolution better

### DIFF
--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -3850,7 +3850,19 @@ public class Logic {
     public synchronized void replaceElement(@Nullable Activity activity, @NonNull OsmElement e, @Nullable PostAsyncActionHandler postLoad) {
         createCheckpoint(activity, R.string.undo_action_fix_conflict);
         getDelegator().removeFromUpload(e, OsmElement.STATE_UNCHANGED); // this will allow merging to replace it
-        downloadElement(activity, e.getName(), e.getOsmId(), false, true, postLoad);
+        downloadElement(activity, e.getName(), e.getOsmId(), false, true, new PostAsyncActionHandler() {
+
+            @Override
+            public void onSuccess() {
+                postLoad.onSuccess();
+            }
+
+            @Override
+            public void onError(AsyncResult result) {
+                postLoad.onError(result);
+                rollback();
+            }
+        });
     }
 
     /**

--- a/src/main/java/de/blau/android/dialogs/ReviewAndUpload.java
+++ b/src/main/java/de/blau/android/dialogs/ReviewAndUpload.java
@@ -122,11 +122,12 @@ public class ReviewAndUpload extends AbstractReviewDialog {
     @Override
     public AppCompatDialog onCreateDialog(Bundle savedInstanceState) {
         Log.d(DEBUG_TAG, "onCreateDialog");
+
         if (savedInstanceState != null) {
             Log.d(DEBUG_TAG, "restoring from saved state");
-            elements = de.blau.android.dialogs.Util.getElementsFromBundle(savedInstanceState);
+            de.blau.android.dialogs.Util.getElements(getContext(), savedInstanceState);
         } else {
-            elements = de.blau.android.dialogs.Util.getElementsFromBundle(getArguments());
+            elements = de.blau.android.dialogs.Util.getElements(getContext(), getArguments());
         }
 
         FragmentActivity activity = getActivity();

--- a/src/main/java/de/blau/android/dialogs/UploadConflict.java
+++ b/src/main/java/de/blau/android/dialogs/UploadConflict.java
@@ -164,10 +164,10 @@ public class UploadConflict extends ImmersiveDialogFragment {
         if (savedInstanceState != null) {
             Log.d(DEBUG_TAG, "restoring from saved state");
             conflict = de.blau.android.util.Util.getSerializeable(savedInstanceState, CONFLICT_KEY, Conflict.class);
-            elements = de.blau.android.dialogs.Util.getElementsFromBundle(savedInstanceState);
+            elements = de.blau.android.dialogs.Util.getElements(getContext(), savedInstanceState);
         } else {
             conflict = de.blau.android.util.Util.getSerializeable(getArguments(), CONFLICT_KEY, Conflict.class);
-            elements = de.blau.android.dialogs.Util.getElementsFromBundle(getArguments());
+            elements = de.blau.android.dialogs.Util.getElements(getContext(), getArguments());
         }
     }
 

--- a/src/main/java/de/blau/android/dialogs/UploadRetry.java
+++ b/src/main/java/de/blau/android/dialogs/UploadRetry.java
@@ -162,7 +162,7 @@ public class UploadRetry extends ImmersiveDialogFragment {
         comment = bundle.getString(COMMENT_KEY);
         source = bundle.getString(SOURCE_KEY);
         extraTags = de.blau.android.util.Util.getSerializeable(bundle, EXTRA_TAGS_KEY, HashMap.class);
-        elements = de.blau.android.dialogs.Util.getElementsFromBundle(bundle);
+        elements = de.blau.android.dialogs.Util.getElements(getContext(), bundle);
     }
 
     @NonNull

--- a/src/main/java/de/blau/android/dialogs/Util.java
+++ b/src/main/java/de/blau/android/dialogs/Util.java
@@ -5,6 +5,7 @@ import static de.blau.android.contract.Constants.LOG_TAG_LEN;
 import java.util.ArrayList;
 import java.util.List;
 
+import android.content.Context;
 import android.os.Bundle;
 import android.util.Log;
 import androidx.annotation.NonNull;
@@ -14,8 +15,11 @@ import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 import de.blau.android.App;
+import de.blau.android.R;
 import de.blau.android.osm.OsmElement;
 import de.blau.android.osm.StorageDelegator;
+import de.blau.android.util.ACRAHelper;
+import de.blau.android.util.ScreenMessage;
 
 public final class Util {
 
@@ -95,7 +99,7 @@ public final class Util {
      * @return return a List of elements or null
      */
     @Nullable
-    static List<OsmElement> getElementsFromBundle(@NonNull Bundle bundle) {
+    private static List<OsmElement> getElementsFromBundle(@NonNull Bundle bundle) {
         List<OsmElement> result = new ArrayList<>();
         List<Long> ids = de.blau.android.util.Util.getSerializeableArrayList(bundle, ELEMENT_IDS_KEY, Long.class);
         List<String> types = bundle.getStringArrayList(ELEMENT_TYPES_KEY);
@@ -116,5 +120,22 @@ public final class Util {
             return result;
         }
         return null;
+    }
+
+    /**
+     * Get elements from references in a bundle
+     * 
+     * @param context an Android context
+     * @param bundle the Bundle
+     */
+    static List<OsmElement> getElements(@NonNull Context context, @NonNull Bundle bundle) {
+        try {
+            return de.blau.android.dialogs.Util.getElementsFromBundle(bundle);
+        } catch (IllegalStateException ise) {
+            ScreenMessage.toastTopError(context, R.string.toast_inconsistent_state);
+            Log.e(DEBUG_TAG, "Inconsistent state because " + ise.getMessage());
+            ACRAHelper.nocrashReport(ise, ise.getMessage());
+            return new ArrayList<>();
+        }
     }
 }

--- a/src/main/java/de/blau/android/osm/StorageDelegator.java
+++ b/src/main/java/de/blau/android/osm/StorageDelegator.java
@@ -3092,7 +3092,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
     public int getApiElementCount() {
         return apiStorage.getElementCount();
     }
-    
+
     /**
      * Get the total number of elements in current storage
      * 
@@ -4204,6 +4204,9 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
     public void removeFromUpload(@NonNull OsmElement element, byte state) {
         undo.save(element);
         apiStorage.removeElement(element);
+        if (OsmElement.STATE_DELETED == element.getState() && state != OsmElement.STATE_DELETED) {
+            currentStorage.insertElementSafe(element);
+        }
         element.setState(state);
     }
 


### PR DESCRIPTION
Rollback changes if we are unable to download server version and when replacing modified element with unmodified version check deleted status.

Improve error handling if OSM elements cannot be restored from state.