### PR TITLE
Explicitly filter elements for clicking

### DIFF
--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -991,8 +991,21 @@ public class Logic {
      * @return a List of Ways
      */
     @NonNull
-    List<Way> getClickableWays() {
-        return filter != null ? filter.getVisibleWays() : getWays(map.getViewBox());
+    private List<Way> getClickableWays() {
+        List<Way> ways = getWays(map.getViewBox());
+        if (filter == null) {
+            return ways;
+        }
+        List<Way> filteredWays = new ArrayList<>();
+        for (Way w : ways) {
+            if (filter.include(w, false)) {
+                filteredWays.add(w);
+            }
+        }
+        if (getSelectedWays() != null) {
+            filteredWays.addAll(getSelectedWays());
+        }
+        return filteredWays;
     }
 
     /**
@@ -1152,18 +1165,21 @@ public class Logic {
      * @return a List of Nodes
      */
     @NonNull
-    List<Node> getClickableNodes() {
-        List<Node> nodes;
-        if (filter != null) {
-            nodes = filter.getVisibleNodes();
-            if (getSelectedNodes() != null) { // selected Nodes are always visible if a filter is
-                // applied
-                nodes.addAll(getSelectedNodes());
-            }
-        } else {
-            nodes = getDelegator().getCurrentStorage().getNodes(map.getViewBox());
+    private List<Node> getClickableNodes() {
+        List<Node> nodes = getNodes(map.getViewBox());
+        if (filter == null) {
+            return nodes;
         }
-        return nodes;
+        List<Node> filteredNodes = new ArrayList<>();
+        for (Node n : nodes) {
+            if (filter.include(n, false)) {
+                filteredNodes.add(n);
+            }
+        }
+        if (getSelectedNodes() != null) {
+            filteredNodes.addAll(getSelectedNodes());
+        }
+        return filteredNodes;
     }
 
     /**

--- a/src/main/java/de/blau/android/filter/Filter.java
+++ b/src/main/java/de/blau/android/filter/Filter.java
@@ -2,11 +2,9 @@ package de.blau.android.filter;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import android.content.Context;
 import android.view.ViewGroup;
@@ -163,38 +161,6 @@ public abstract class Filter implements Serializable {
         cachedNodes.clear();
         cachedWays.clear();
         cachedRelations.clear();
-    }
-
-    /**
-     * Get all nodes that are currently visible from the cache
-     * 
-     * @return List of visible Nodes
-     */
-    @NonNull
-    public List<Node> getVisibleNodes() {
-        List<Node> result = new ArrayList<>();
-        for (Entry<Node, Include> e : cachedNodes.entrySet()) {
-            if (e.getValue() != Include.DONT) {
-                result.add(e.getKey());
-            }
-        }
-        return result;
-    }
-
-    /**
-     * Get all ways that are currently visible from the cache
-     * 
-     * @return List of visible Ways
-     */
-    @NonNull
-    public List<Way> getVisibleWays() {
-        List<Way> result = new ArrayList<>();
-        for (Entry<Way, Include> e : cachedWays.entrySet()) {
-            if (e.getValue() != Include.DONT) {
-                result.add(e.getKey());
-            }
-        }
-        return result;
     }
 
     /**


### PR DESCRIPTION
Previously we relied on the cache of filtered elements being filled prior to determining which objects can be clicked. This seems to fail consistently since we switched to using SurfaceView in V20.

This switches to explicitly filtering objects, which resolves the issue.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/2861