### PR TITLE
Use explicit lock instead of synchronize, lock when getting boxes

### DIFF
--- a/src/main/java/de/blau/android/osm/StorageDelegator.java
+++ b/src/main/java/de/blau/android/osm/StorageDelegator.java
@@ -90,7 +90,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
     /**
      * when reading state lockout writing/reading
      */
-    private transient ReentrantLock readingLock = new ReentrantLock();
+    private transient ReentrantLock lock = new ReentrantLock();
 
     /**
      * Indicates whether changes have been made since the last save to disk. Since a newly created storage is not saved,
@@ -3153,7 +3153,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
             Log.i(DEBUG_TAG, "storage delegator not dirty, skipping save");
             return;
         }
-        if (readingLock.tryLock()) {
+        if (lock.tryLock()) {
             if (savingHelper.save(ctx, FILENAME, this, true)) {
                 dirty = false;
             } else {
@@ -3172,7 +3172,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
                 SavingHelper.export(ctx, this); // ctx == null is checked in method
                 Log.d(DEBUG_TAG, "save of state file failed, written emergency change file");
             }
-            readingLock.unlock();
+            lock.unlock();
         } else {
             Log.i(DEBUG_TAG, "storage delegator state being read, skipping save");
         }
@@ -4303,22 +4303,22 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
      * Try to set the reading lock
      */
     public boolean tryLock() {
-        return readingLock.tryLock();
+        return lock.tryLock();
     }
 
     /**
      * Set the reading lock
      */
     public void lock() {
-        readingLock.lock();
+        lock.lock();
     }
 
     /**
      * Free the reading lock checking if it is currently held
      */
     public void unlock() {
-        if (readingLock.isHeldByCurrentThread()) {
-            readingLock.unlock();
+        if (lock.isHeldByCurrentThread()) {
+            lock.unlock();
         }
     }
 }

--- a/src/main/java/de/blau/android/tasks/TransferTasks.java
+++ b/src/main/java/de/blau/android/tasks/TransferTasks.java
@@ -838,30 +838,28 @@ public final class TransferTasks {
         final Preferences prefs = App.getLogic().getPrefs();
         boolean generateAlerts = prefs.generateAlerts();
         long now = System.currentTimeMillis();
-        synchronized (storage) { // NOSONAR this will be the same object
-            for (Task b : tasks) {
-                if (b.isNew()) { // need to renumber assuming that there are no duplicates
-                    ((Note) b).setId(storage.getNextId());
-                }
-                Task existing = storage.get(b);
-                if (existing == null) {
-                    // add open bugs or closed bugs younger than 7 days
-                    if (!b.isClosed() || (now - b.getLastUpdate().getTime()) < MAX_CLOSED_AGE) {
-                        storage.add(b);
-                        if (!b.isClosed() && generateAlerts) {
-                            IssueAlert.alert(context, prefs, b);
-                        }
+        for (Task b : tasks) {
+            if (b.isNew()) { // need to renumber assuming that there are no duplicates
+                ((Note) b).setId(storage.getNextId());
+            }
+            Task existing = storage.get(b);
+            if (existing == null) {
+                // add open bugs or closed bugs younger than 7 days
+                if (!b.isClosed() || (now - b.getLastUpdate().getTime()) < MAX_CLOSED_AGE) {
+                    storage.add(b);
+                    if (!b.isClosed() && generateAlerts) {
+                        IssueAlert.alert(context, prefs, b);
                     }
-                } else {
-                    if (b.getLastUpdate().getTime() > existing.getLastUpdate().getTime()) {
-                        // downloaded task is newer
-                        if (existing.hasBeenChanged()) { // conflict, show message and abort
-                            ScreenMessage.toastTopError(context, context.getString(R.string.toast_task_conflict, existing.getDescription(context)));
-                            break;
-                        } else {
-                            storage.delete(existing);
-                            storage.add(b);
-                        }
+                }
+            } else {
+                if (b.getLastUpdate().getTime() > existing.getLastUpdate().getTime()) {
+                    // downloaded task is newer
+                    if (existing.hasBeenChanged()) { // conflict, show message and abort
+                        ScreenMessage.toastTopError(context, context.getString(R.string.toast_task_conflict, existing.getDescription(context)));
+                        break;
+                    } else {
+                        storage.delete(existing);
+                        storage.add(b);
                     }
                 }
             }


### PR DESCRIPTION
This brings the locking logic for tasks in line with that for OSM data and addresses crashes caused by not locking when getting the bounding box list.