### PR TITLE
Add explicit support for empty way error from API

### DIFF
--- a/src/androidTest/java/de/blau/android/osm/TransferMenuTest.java
+++ b/src/androidTest/java/de/blau/android/osm/TransferMenuTest.java
@@ -3,6 +3,7 @@ package de.blau.android.osm;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -16,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -56,6 +58,7 @@ import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.QueueDispatcher;
 import okhttp3.mockwebserver.RecordedRequest;
+import okio.Buffer;
 
 @RunWith(AndroidJUnit4.class)
 @LargeTest
@@ -95,8 +98,9 @@ public class TransferMenuTest {
         prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
         prefDB.selectAPI("Test");
         prefDB.deleteLayer(LayerType.TASKS, null);
-        prefs = new Preferences(context);     
+        prefs = new Preferences(context);
         prefs.setPanAndZoomAutoDownload(false);
+        prefs.enableAcra(false);
         LayerUtils.removeImageryLayers(context);
         main.getMap().setPrefs(main, prefs);
         System.out.println("mock api url " + mockBaseUrl.toString()); // NOSONAR
@@ -222,6 +226,47 @@ public class TransferMenuTest {
         }
         assertTrue(TestUtils.findText(device, false, main.getString(R.string.upload_limit_title)));
         assertTrue(TestUtils.clickText(device, false, main.getString(android.R.string.ok), true));
+    }
+
+    /**
+     * Upload to changes (mock-)server get a 412 response
+     */
+    @Test
+    public void degenWayUploadError() {
+
+        StorageDelegator delegator = App.getDelegator();
+        App.getLogic().createCheckpoint(main, R.string.undo_action_add);
+        Way way = delegator.getFactory().createWayWithNewId();
+        delegator.insertElementSafe(way);
+        main.invalidateOptionsMenu();
+        TestUtils.sleep();
+
+        mockServer.enqueue(CAPABILITIES1_FIXTURE);
+        mockServer.enqueue("changeset1");
+        MockResponse response = new MockResponse();
+        response.setHeader("Content-type", MimeTypes.TEXTXML);
+        response.setResponseCode(412);
+        response.setBody("Precondition failed: Way " + way.getOsmId() + " must have at least one node");
+        mockServer.enqueue(response);
+
+        TestUtils.clickMenuButton(device, main.getString(R.string.menu_transfer), false, true);
+        TestUtils.clickText(device, false, main.getString(R.string.menu_transfer_upload), true, false); // menu item
+
+        UiSelector uiSelector = new UiSelector().className("android.widget.Button").instance(1); // dialog upload button
+        UiObject button = device.findObject(uiSelector);
+        try {
+            button.click();
+        } catch (UiObjectNotFoundException e1) {
+            fail(e1.getMessage());
+        }
+        UploadConflictTest.fillCommentAndSource(instrumentation, device);
+        try {
+            button.clickAndWaitForNewWindow();
+        } catch (UiObjectNotFoundException e1) {
+            fail(e1.getMessage());
+        }
+        assertTrue(TestUtils.findText(device, false, main.getString(R.string.upload_way_needs_one_node_title)));
+        assertNull(delegator.getOsmElement(Way.NAME, way.getOsmId())); // node is deleted
     }
 
     final QueueDispatcher dispatcher = new QueueDispatcher() {
@@ -404,7 +449,7 @@ public class TransferMenuTest {
 
         mockServer.setDispatcher(new QueueDispatcher() {
             boolean seen;
-            
+
             @Override
             public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
 
@@ -417,7 +462,7 @@ public class TransferMenuTest {
         });
 
         dispatcher.enqueueResponse(TestUtils.createBinaryReponse(MimeTypes.TEXTXML, "fixtures/capabilities1.xml"));
-        
+
         TestUtils.clickMenuButton(device, main.getString(R.string.menu_transfer), false, true);
         TestUtils.clickText(device, false, main.getString(R.string.menu_transfer_upload), true, false); // menu item
 
@@ -437,9 +482,9 @@ public class TransferMenuTest {
             fail(e1.getMessage());
         }
         assertTrue(TestUtils.findText(device, false, main.getString(R.string.upload_retry_title), 50000));
-        assertTrue(TestUtils.findText(device, false, main.getString(R.string.upload_retry_message_no_open_changeset), 1000, true));        
+        assertTrue(TestUtils.findText(device, false, main.getString(R.string.upload_retry_message_no_open_changeset), 1000, true));
     }
-    
+
     /**
      * Clear data
      */

--- a/src/main/java/de/blau/android/ErrorCodes.java
+++ b/src/main/java/de/blau/android/ErrorCodes.java
@@ -44,4 +44,5 @@ public final class ErrorCodes {
     public static final int ALREADY_DELETED               = 60;
     public static final int UPLOAD_BOUNDING_BOX_TOO_LARGE = 61;
     public static final int TOO_MANY_WAY_NODES            = 62;
+    public static final int UPLOAD_WAY_NEEDS_ONE_NODE     = 63;
 }

--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -4610,6 +4610,17 @@ public class Logic {
                                     server.resetChangeset();
                                 }
                                 ErrorAlert.showDialog(activity, ErrorCodes.UPLOAD_BOUNDING_BOX_TOO_LARGE, result.getMessage());
+                            } else if (conflict instanceof ApiResponse.NoNodesWayError) {
+                                ErrorAlert.showDialog(activity, ErrorCodes.UPLOAD_WAY_NEEDS_ONE_NODE, result.getMessage());
+                                ACRAHelper.nocrashReport(null, result.getMessage());
+                                long degenId = conflict.getElementId();
+                                Way degenWay = (Way) delegator.getOsmElement(Way.NAME, degenId);
+                                Log.e(DEBUG_TAG, "Upload of way " + degenId + " with no nodes");
+                                if (degenWay != null) {
+                                    Log.e(DEBUG_TAG, "Deleting way " + degenWay.toString());
+                                    createCheckpoint(activity, R.string.undo_action_deleteway); // separate checkpoint
+                                    delegator.removeWay(degenWay);
+                                }
                             } else if (conflict instanceof ApiResponse.ChangesetLocked) {
                                 ErrorAlert.showDialog(activity, ErrorCodes.UPLOAD_PROBLEM, result.getMessage());
                             } else {

--- a/src/main/java/de/blau/android/dialogs/ErrorAlert.java
+++ b/src/main/java/de/blau/android/dialogs/ErrorAlert.java
@@ -158,6 +158,8 @@ public class ErrorAlert extends ImmersiveDialogFragment {
             return "alert_bounding_box_too_large";
         case ErrorCodes.TOO_MANY_WAY_NODES:
             return "alert_too_many_way_nodes";
+        case ErrorCodes.UPLOAD_WAY_NEEDS_ONE_NODE:
+            return "alert_way_needs_one_node";
         default:
             // nothing
         }
@@ -228,6 +230,8 @@ public class ErrorAlert extends ImmersiveDialogFragment {
             return createNewInstance(R.string.upload_bounding_box_too_large_title, R.string.upload_bounding_box_too_large_message, msg);
         case ErrorCodes.TOO_MANY_WAY_NODES:
             return createNewInstance(R.string.attempt_to_add_too_many_way_nodes_title, R.string.attempt_to_add_too_many_way_nodes_message, msg);
+        case ErrorCodes.UPLOAD_WAY_NEEDS_ONE_NODE:
+            return createNewInstance(R.string.upload_way_needs_one_node_title, R.string.upload_way_needs_one_node_message, msg);
         default:
             // ignore
         }

--- a/src/main/java/de/blau/android/prefs/Preferences.java
+++ b/src/main/java/de/blau/android/prefs/Preferences.java
@@ -184,9 +184,7 @@ public class Preferences {
         }
         // we *are* using acra.enable
         if (!prefs.contains(ACRA_ENABLE)) {
-            SharedPreferences.Editor editor = prefs.edit();
-            editor.putBoolean(ACRA_ENABLE, true);
-            editor.commit();
+            enableAcra(true);
         }
 
         maxStrokeWidth = getIntPref(R.string.config_maxStrokeWidth_key, 16);
@@ -356,6 +354,18 @@ public class Preferences {
         poiKeys = prefs.getStringSet(r.getString(R.string.config_poi_keys_key), new HashSet<>(Arrays.asList(r.getStringArray(R.array.poi_keys_defaults))));
 
         replaceTolerance = getFloatFromStringPref(R.string.config_replaceTolerance_key, 1.0f);
+    }
+
+    /**
+     * Enable/disable acra
+     * 
+     * @param b if true anable acra
+     * 
+     */
+    public void enableAcra(boolean b) {
+        SharedPreferences.Editor editor = prefs.edit();
+        editor.putBoolean(ACRA_ENABLE, b);
+        editor.commit();
     }
 
     /**

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -116,6 +116,8 @@
     <string name="upload_bounding_box_too_large_message">The area covering the changes you are trying to upload is too large.
         &lt;br&gt;&lt;br&gt;Please split your changes in to multiple smaller changesets. 
         You can do this by selecting a subset of changed elements and uploading them separately.</string>
+    <string name="upload_way_needs_one_node_title">Way needs at least one node</string>
+    <string name="upload_way_needs_one_node_message">A way you tried to upload has no nodes. This should not happen and the way has now been deleted so that you can retry. Please open an issue with the feedback form and independently submit the crash dump.</string>
     <string name="attempt_to_add_too_many_way_nodes_title">Attempt to add too many way nodes</string>
     <string name="attempt_to_add_too_many_way_nodes_message">The operation would create a way that contains more than the maximum number of way nodes. Either add less nodes or split the way at a suitable position.</string>
     <string name="too_many_way_nodes_details">Trying to add %1$d nodes that would lead to a total count of %2$d nodes which is larger than the limit of %3$d</string>

--- a/src/test/java/de/blau/android/osm/ApiResponseTest.java
+++ b/src/test/java/de/blau/android/osm/ApiResponseTest.java
@@ -14,7 +14,7 @@ import org.robolectric.annotation.Config;
 import androidx.test.filters.LargeTest;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk=33)
+@Config(sdk = 33)
 @LargeTest
 public class ApiResponseTest {
 
@@ -38,6 +38,8 @@ public class ApiResponseTest {
     private static final String ERROR_MESSAGE_PRECONDITION_REQUIRED_WAY_NODE      = "Precondition failed: Way 12345 requires the nodes with id in 56789 which either do not exist, or are not visible.";
     private static final String ERROR_MESSAGE_PRECONDITION_REQUIRED_WAY_NODES     = "Precondition failed: Way 12345 requires the nodes with id in 56789,54321 which either do not exist, or are not visible.";
 
+    private static final String ERROR_MESSAGE_PRECONDITION_REQUIRED_ONE_WAY_NODE = "Precondition failed: Way -522 must have at least one node";
+
     private static final String ERROR_MESSAGE_PRECONDITION_REQUIRED_RELATION_MEMBERS_NODE_NEG  = "Precondition failed: Relation -2 requires the nodes with id in 56789 which either do not exist, or are not visible.";
     private static final String ERROR_MESSAGE_PRECONDITION_REQUIRED_RELATION_MEMBERS_NODES_NEG = "Precondition failed: Relation -2 requires the nodes with id in 56789,54321 which either do not exist, or are not visible.";
     private static final String ERROR_MESSAGE_PRECONDITION_REQUIRED_RELATION_MEMBERS_NODE      = "Precondition failed: Relation 12345 requires the nodes with id in 56789 which either do not exist, or are not visible.";
@@ -47,13 +49,13 @@ public class ApiResponseTest {
     private static final String ERROR_MESSAGE_PRECONDITION_REQUIRED_RELATION_MEMBERS_RELATION  = "Precondition failed: Relation 12345 requires the relations with id in 56789 which either do not exist, or are not visible.";
     private static final String ERROR_MESSAGE_PRECONDITION_REQUIRED_RELATION_MEMBERS_RELATIONS = "Precondition failed: Relation 12345 requires the relations with id in 56789,54321 which either do not exist, or are not visible.";
 
-    private static final String ERROR_MESSAGE_PRECONDITION_RELATION_RELATION = "Precondition failed: The relation 12345 is used in relation 6789.";
+    private static final String ERROR_MESSAGE_PRECONDITION_RELATION_RELATION        = "Precondition failed: The relation 12345 is used in relation 6789.";
     private static final String ERROR_MESSAGE_PRECONDITION_RELATION_RELATION_CGIMAP = "Precondition failed: The relation 12345 is used in relations 6789.";
 
     private static final String ERROR_MESSAGE_CLOSED_CHANGESET = "The changeset 123456 was closed at 2022-01-12T06:06:08.";
-    
+
     private static final String ERROR_MESSAGE_BOUNDING_BOX_TOO_LARGE = "Changeset bounding box size limit exceeded.";
-    
+
     private static final String ERROR_MESSAGE_CHANGESET_LOCKED = "Changeset 123456 is currently locked by another process.";
 
     /**
@@ -180,6 +182,17 @@ public class ApiResponseTest {
     /**
      */
     @Test
+    public void oneWayNodeRequired() {
+        ApiResponse.Conflict conflict = ApiResponse.parseConflictResponse(HttpURLConnection.HTTP_PRECON_FAILED,
+                ERROR_MESSAGE_PRECONDITION_REQUIRED_ONE_WAY_NODE);
+        assertTrue(conflict instanceof ApiResponse.NoNodesWayError);
+        assertEquals(Way.NAME, conflict.getElementType());
+        assertEquals(-522L, conflict.getElementId());
+    }
+    
+    /**
+     */
+    @Test
     public void relationMemberRequired() {
         ApiResponse.Conflict conflict = ApiResponse.parseConflictResponse(HttpURLConnection.HTTP_PRECON_FAILED,
                 ERROR_MESSAGE_PRECONDITION_REQUIRED_RELATION_MEMBERS_NODE_NEG);
@@ -255,14 +268,15 @@ public class ApiResponseTest {
      */
     @Test
     public void relationRelationMemberStillUsedCgiMap() {
-        ApiResponse.Conflict conflict = ApiResponse.parseConflictResponse(HttpURLConnection.HTTP_PRECON_FAILED, ERROR_MESSAGE_PRECONDITION_RELATION_RELATION_CGIMAP);
+        ApiResponse.Conflict conflict = ApiResponse.parseConflictResponse(HttpURLConnection.HTTP_PRECON_FAILED,
+                ERROR_MESSAGE_PRECONDITION_RELATION_RELATION_CGIMAP);
         assertTrue(conflict instanceof ApiResponse.StillUsedConflict);
         assertEquals(Relation.NAME, conflict.getElementType());
         assertEquals(12345L, conflict.getElementId());
         assertEquals(Relation.NAME, ((ApiResponse.StillUsedConflict) conflict).getUsedByElementType());
         assertArrayEquals(new long[] { 6789 }, ((ApiResponse.StillUsedConflict) conflict).getUsedByElementIds());
     }
-    
+
     /**
      */
     @Test
@@ -271,7 +285,7 @@ public class ApiResponseTest {
         assertTrue(conflict instanceof ApiResponse.ClosedChangesetConflict);
         assertEquals(123456L, conflict.getElementId());
     }
-    
+
     /**
      */
     @Test
@@ -280,7 +294,7 @@ public class ApiResponseTest {
         assertTrue(conflict instanceof ApiResponse.ChangesetLocked);
         assertEquals(123456L, conflict.getElementId());
     }
-    
+
     /**
      */
     @Test


### PR DESCRIPTION
We previously didn't handle the error response for ways without nodes from the API. This should never happen, but now and then does.

This deletes the offending way and improves both messaging and diagnostics.