### PR TITLE
Avoid ANRs in more places

### DIFF
--- a/src/main/java/de/blau/android/layer/tasks/MapOverlay.java
+++ b/src/main/java/de/blau/android/layer/tasks/MapOverlay.java
@@ -170,11 +170,14 @@ public class MapOverlay extends NonSerializeableLayer
                 }
             });
             // check interval first as tasks.count traverses the whole R-Tree
-            if (autoPruneEnabled && (System.currentTimeMillis() - lastAutoPrune) > AUTOPRUNE_MIN_INTERVAL
-                    && tasks.reachedPruneLimits(autoPruneTaskLimit, autoDownloadBoxLimit)) {
+            if (autoPruneEnabled && (System.currentTimeMillis() - lastAutoPrune) > AUTOPRUNE_MIN_INTERVAL) {
                 try {
-                    pruneThreadPool.execute(MapOverlay.this::prune);
-                    lastAutoPrune = System.currentTimeMillis();
+                    pruneThreadPool.execute(() -> {
+                        if (tasks.reachedPruneLimits(autoPruneTaskLimit, autoDownloadBoxLimit)) {
+                            MapOverlay.this.prune();
+                            lastAutoPrune = System.currentTimeMillis();
+                        }
+                    });
                 } catch (RejectedExecutionException rjee) {
                     Log.e(DEBUG_TAG, "Prune execution rejected " + rjee.getMessage());
                 }


### PR DESCRIPTION
This should avoid ANRs caused by locking for downloads in trackerservice and in the data and task overlay when checking if the contents should be pruned.