### PR TITLE
Offer to create a copy of the oauth config if no matching one can be found

### DIFF
--- a/src/androidTest/java/de/blau/android/AuthorizationTest.java
+++ b/src/androidTest/java/de/blau/android/AuthorizationTest.java
@@ -1,0 +1,126 @@
+package de.blau.android;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.orhanobut.mockwebserverplus.MockWebServerPlus;
+
+import android.app.Instrumentation;
+import android.app.Instrumentation.ActivityMonitor;
+import android.content.Context;
+import android.util.Log;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.uiautomator.UiDevice;
+import de.blau.android.prefs.API;
+import de.blau.android.prefs.API.AuthParams;
+import de.blau.android.prefs.AdvancedPrefDatabase;
+import de.blau.android.prefs.Preferences;
+import de.blau.android.resources.KeyDatabaseHelper;
+import de.blau.android.resources.KeyDatabaseHelper.EntryType;
+import okhttp3.HttpUrl;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class AuthorizationTest {
+
+    private static final String DEBUG_TAG = AuthorizationTest.class.getSimpleName();
+
+    MockWebServerPlus    mockApiServer      = null;
+    MockWebServerPlus    mockServer      = null;
+    Context              context         = null;
+    AdvancedPrefDatabase prefDB          = null;
+    Instrumentation      instrumentation = null;
+    UiDevice             device          = null;
+    Main                 main            = null;
+
+    @Rule
+    public ActivityTestRule<Main> mActivityRule = new ActivityTestRule<>(Main.class);
+
+    /**
+     * Pre-test setup
+     */
+    @Before
+    public void setup() {
+        instrumentation = InstrumentationRegistry.getInstrumentation();
+        device = UiDevice.getInstance(instrumentation);
+        context = instrumentation.getTargetContext();
+        main = mActivityRule.getActivity();
+        KeyDatabaseHelper.readKeysFromAssets(main);
+        mockServer = new MockWebServerPlus();
+        HttpUrl mockUrl = mockServer.server().url("/");
+        try (KeyDatabaseHelper keyDatabase = new KeyDatabaseHelper(main)) {
+            KeyDatabaseHelper.replaceOrDeleteKey(keyDatabase.getWritableDatabase(), "OpenStreetMap sandbox", EntryType.API_OAUTH2_KEY, "1111111111", false, true, "empty", mockUrl.toString());
+        }
+        mockApiServer = new MockWebServerPlus();
+        HttpUrl mockApiBaseUrl = mockApiServer.server().url("/api/0.6/");
+        Log.d(DEBUG_TAG, "Mock url " + mockApiBaseUrl);
+
+        prefDB = new AdvancedPrefDatabase(context);
+        prefDB.deleteAPI("Test");
+        prefDB.addAPI("Test", "Test", mockApiBaseUrl.toString(), null, null, new AuthParams(API.Auth.OAUTH2, "user", "pass", null, null), false);
+        prefDB.selectAPI("Test");
+        prefDB.resetCurrentServer();
+        Preferences prefs = new Preferences(context);
+        LayerUtils.removeImageryLayers(context);
+        main.getMap().setPrefs(main, prefs);
+        TestUtils.grantPermissons(device);
+        TestUtils.dismissStartUpDialogs(device, main);
+        TestUtils.stopEasyEdit(main);
+    }
+
+    /**
+     * Post-test teardown
+     */
+    @After
+    public void teardown() {
+        try {
+            mockApiServer.server().shutdown();
+        } catch (IOException ioex) {
+            System.out.println("Stopping mock webserver exception " + ioex); // NOSONAR
+        }
+        try {
+            mockServer.server().shutdown();
+        } catch (IOException ioex) {
+            System.out.println("Stopping mock webserver exception " + ioex); // NOSONAR
+        }
+        prefDB.selectAPI(AdvancedPrefDatabase.ID_DEFAULT);
+        prefDB.close();
+    }
+
+    /**
+     * Start up the authorization activity and check that we get the dialog to select a client key
+     */
+    @Test
+    public void startAuthorization() {
+        ActivityMonitor monitor = instrumentation.addMonitor(Authorize.class.getName(), null, false);
+
+        if (!TestUtils.clickMenuButton(device, main.getString(R.string.menu_tools), false, true)) {
+            TestUtils.clickOverflowButton(device);
+            TestUtils.clickText(device, false, main.getString(R.string.menu_tools), true, false);
+        }
+        TestUtils.scrollTo(main.getString(R.string.menu_tools_oauth_authorisation), false);
+        TestUtils.clickText(device, false, main.getString(R.string.menu_tools_oauth_authorisation), true, false);
+        instrumentation.waitForMonitorWithTimeout(monitor, 30000);
+        instrumentation.removeMonitor(monitor);
+        mockServer.enqueue("loaded");
+        assertTrue(TestUtils.findText(device, false, "OpenStreetMap sandbox", 10000));
+        assertTrue(TestUtils.clickText(device, false, "OpenStreetMap sandbox", true));
+        assertTrue(TestUtils.findText(device, false, "Loaded", 10000));
+        try {
+            assertTrue(mockServer.takeRequest().toString().contains("1111111111"));
+        } catch (InterruptedException e) {
+            fail(e.getMessage());
+        }
+    }
+}

--- a/src/main/assets/keys2-default.txt
+++ b/src/main/assets/keys2-default.txt
@@ -1,5 +1,5 @@
 #
-# This file hold the OAuth1 and OAuth2 authentication keys as a courtesy for private builds and F_droid, they are not the same as those used for our distribution
+# This file holds the OAuth1 and OAuth2 authentication keys as a courtesy for private builds and F_droid, they are not the same as those used for our distribution
 #
 # File format, tab separated fields  
 # <name> <key type>  <key>   <overwrite> <additional 1>  <additional 2>

--- a/src/main/java/de/blau/android/exception/NoOAuthConfigurationException.java
+++ b/src/main/java/de/blau/android/exception/NoOAuthConfigurationException.java
@@ -1,0 +1,31 @@
+package de.blau.android.exception;
+
+import java.io.IOException;
+
+public class NoOAuthConfigurationException extends IOException {
+
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Construct a new exception
+     * 
+     * @param message the error message
+     */
+    public NoOAuthConfigurationException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Construct a new exception
+     * 
+     * @param message the error message
+     * @param cause the original Exception
+     */
+    NoOAuthConfigurationException(final String message, final Throwable cause) {
+        super(message);
+        initCause(cause);
+    }
+}

--- a/src/main/java/de/blau/android/net/OAuth1aHelper.java
+++ b/src/main/java/de/blau/android/net/OAuth1aHelper.java
@@ -1,5 +1,7 @@
 package de.blau.android.net;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -11,6 +13,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import de.blau.android.App;
 import de.blau.android.PostAsyncActionHandler;
+import de.blau.android.exception.NoOAuthConfigurationException;
 import de.blau.android.exception.OsmException;
 import de.blau.android.prefs.API.Auth;
 import de.blau.android.resources.KeyDatabaseHelper;
@@ -30,7 +33,9 @@ import se.akerfeldt.okhttp.signpost.OkHttpOAuthProvider;
  * 
  */
 public class OAuth1aHelper extends OAuthHelper {
-    private static final String DEBUG_TAG = OAuth1aHelper.class.getSimpleName().substring(0, Math.min(23, OAuth1aHelper.class.getSimpleName().length()));
+
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, OAuth1aHelper.class.getSimpleName().length());
+    private static final String DEBUG_TAG = OAuth1aHelper.class.getSimpleName().substring(0, TAG_LEN);
 
     private static final String CALLBACK_URL       = "vespucci:/oauth/";
     private static final String AUTHORIZE_PATH     = "oauth/authorize";
@@ -52,7 +57,7 @@ public class OAuth1aHelper extends OAuthHelper {
      * 
      * @throws OsmException if no configuration could be found for the API instance
      */
-    public OAuth1aHelper(@NonNull Context context, @NonNull String apiName) throws OsmException {
+    public OAuth1aHelper(@NonNull Context context, @NonNull String apiName) throws NoOAuthConfigurationException {
         try (KeyDatabaseHelper keyDatabase = new KeyDatabaseHelper(context)) {
             OAuthConfiguration configuration = KeyDatabaseHelper.getOAuthConfiguration(keyDatabase.getReadableDatabase(), apiName, Auth.OAUTH1A);
             if (configuration != null) {
@@ -60,7 +65,7 @@ public class OAuth1aHelper extends OAuthHelper {
                 return;
             }
             logMissingApi(apiName);
-            throw new OsmException("No matching OAuth configuration found for API " + apiName);
+            throw new NoOAuthConfigurationException("No matching OAuth configuration found for API " + apiName);
         }
     }
 

--- a/src/main/java/de/blau/android/net/OAuth2Helper.java
+++ b/src/main/java/de/blau/android/net/OAuth2Helper.java
@@ -1,5 +1,7 @@
 package de.blau.android.net;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -28,6 +30,7 @@ import de.blau.android.App;
 import de.blau.android.AsyncResult;
 import de.blau.android.ErrorCodes;
 import de.blau.android.PostAsyncActionHandler;
+import de.blau.android.exception.NoOAuthConfigurationException;
 import de.blau.android.exception.OsmException;
 import de.blau.android.osm.OsmXml;
 import de.blau.android.prefs.API;
@@ -51,7 +54,8 @@ import okhttp3.Response;
  */
 public class OAuth2Helper extends OAuthHelper {
 
-    private static final String DEBUG_TAG = OAuth2Helper.class.getSimpleName().substring(0, Math.min(23, OAuth2Helper.class.getSimpleName().length()));
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, OAuth2Helper.class.getSimpleName().length());
+    private static final String DEBUG_TAG = OAuth2Helper.class.getSimpleName().substring(0, TAG_LEN);
 
     public static final String REDIRECT_URI = "vespucci:/oauth2/";
     // instead of hardwiring these we could extract them from
@@ -94,7 +98,7 @@ public class OAuth2Helper extends OAuthHelper {
      * 
      * @throws OsmException if no configuration could be found for the API instance
      */
-    public OAuth2Helper(@NonNull Context context, @NonNull String apiName) throws OsmException {
+    public OAuth2Helper(@NonNull Context context, @NonNull String apiName) throws NoOAuthConfigurationException {
         try (KeyDatabaseHelper keyDatabase = new KeyDatabaseHelper(context)) {
             configuration = KeyDatabaseHelper.getOAuthConfiguration(keyDatabase.getReadableDatabase(), apiName, Auth.OAUTH2);
             if (configuration != null) {
@@ -105,7 +109,7 @@ public class OAuth2Helper extends OAuthHelper {
         } catch (IllegalArgumentException e) {
             Log.e(DEBUG_TAG, e.getMessage());
         }
-        throw new OsmException("No matching OAuth 2 configuration found for API " + apiName);
+        throw new NoOAuthConfigurationException("No matching OAuth 2 configuration found for API " + apiName);
     }
 
     /**

--- a/src/main/java/de/blau/android/net/OAuthHelper.java
+++ b/src/main/java/de/blau/android/net/OAuthHelper.java
@@ -30,9 +30,22 @@ public abstract class OAuthHelper {
     protected static final int TIMEOUT = 10;
 
     public static class OAuthConfiguration {
-        private String key;
-        private String secret;
-        private String oauthUrl;
+        private final String name;
+        private String       key;
+        private String       secret;
+        private String       oauthUrl;
+
+        public OAuthConfiguration(@NonNull String name) {
+            this.name = name;
+        }
+
+        /**
+         * @return the name
+         */
+        @Nullable
+        public String getName() {
+            return name;
+        }
 
         /**
          * @param key the key to set

--- a/src/main/java/de/blau/android/prefs/VespucciURLActivity.java
+++ b/src/main/java/de/blau/android/prefs/VespucciURLActivity.java
@@ -20,7 +20,7 @@ import de.blau.android.AsyncResult;
 import de.blau.android.Authorize;
 import de.blau.android.PostAsyncActionHandler;
 import de.blau.android.R;
-import de.blau.android.exception.OsmException;
+import de.blau.android.exception.NoOAuthConfigurationException;
 import de.blau.android.net.OAuth1aHelper;
 import de.blau.android.net.OAuth2Helper;
 import de.blau.android.net.OAuthHelper;
@@ -38,7 +38,8 @@ import de.blau.android.util.Util;
  *
  */
 public class VespucciURLActivity extends AppCompatActivity implements OnClickListener {
-    private static final String DEBUG_TAG = VespucciURLActivity.class.getSimpleName().substring(0, Math.min(23, VespucciURLActivity.class.getSimpleName().length()));
+    private static final String DEBUG_TAG = VespucciURLActivity.class.getSimpleName().substring(0,
+            Math.min(23, VespucciURLActivity.class.getSimpleName().length()));
 
     private static final int    REQUEST_PRESETEDIT   = 0;
     private static final String OAUTH1A_PATH         = "oauth";
@@ -113,7 +114,7 @@ public class VespucciURLActivity extends AppCompatActivity implements OnClickLis
                 ScreenMessage.toastTopError(this, getString(R.string.toast_oauth_communication));
             } catch (TimeoutException e) {
                 ScreenMessage.toastTopError(this, getString(R.string.toast_oauth_timeout));
-            } catch (OsmException e) {
+            } catch (NoOAuthConfigurationException e) {
                 ScreenMessage.toastTopError(this, getString(R.string.toast_no_oauth, apiName));
             } catch (IllegalArgumentException e) {
                 ScreenMessage.toastTopError(this, getString(R.string.toast_oauth_handshake_failed, e.getMessage()));

--- a/src/main/java/de/blau/android/resources/KeyDatabaseHelper.java
+++ b/src/main/java/de/blau/android/resources/KeyDatabaseHelper.java
@@ -34,7 +34,7 @@ public class KeyDatabaseHelper extends SQLiteOpenHelper {
     private static final int    TAG_LEN   = Math.min(23, KeyDatabaseHelper.class.getSimpleName().length());
     private static final String DEBUG_TAG = KeyDatabaseHelper.class.getSimpleName().substring(0, TAG_LEN);
 
-    private static final String DATABASE_NAME    = "keys";
+    static final String         DATABASE_NAME    = "keys";
     private static final int    DATABASE_VERSION = 4;
     private static final int    FIELD_COUNT      = 4;
     private static final String AND              = " AND ";

--- a/src/main/java/de/blau/android/resources/KeyDatabaseHelper.java
+++ b/src/main/java/de/blau/android/resources/KeyDatabaseHelper.java
@@ -4,6 +4,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 import android.content.ContentValues;
@@ -29,7 +31,7 @@ import de.blau.android.util.ScreenMessage;
  */
 public class KeyDatabaseHelper extends SQLiteOpenHelper {
 
-    private static final int TAG_LEN = Math.min(23, KeyDatabaseHelper.class.getSimpleName().length());
+    private static final int    TAG_LEN   = Math.min(23, KeyDatabaseHelper.class.getSimpleName().length());
     private static final String DEBUG_TAG = KeyDatabaseHelper.class.getSimpleName().substring(0, TAG_LEN);
 
     private static final String DATABASE_NAME    = "keys";
@@ -157,7 +159,30 @@ public class KeyDatabaseHelper extends SQLiteOpenHelper {
     }
 
     /**
-     * Retrieve the OAuth2 configuration for an API
+     * Duplicate key identified by its name
+     * 
+     * @param db readable SQLiteDatabase
+     * @param name the key name
+     * @param type type of the entry
+     * @param newName the name of the duplicated entry
+     */
+    @Nullable
+    public static void copyKey(@NonNull SQLiteDatabase db, @NonNull String name, @NonNull EntryType type, @NonNull String newName) {
+        try (Cursor dbresult = db.query(KEYS_TABLE, new String[] { KEY_FIELD, ADD1_FIELD, ADD2_FIELD }, NAME_FIELD + "=?  AND " + TYPE_FIELD + "=?",
+                new String[] { name, type.toString() }, null, null, null)) {
+            if (dbresult.getCount() == 1) {
+                boolean haveEntry = dbresult.moveToFirst();
+                if (haveEntry) {
+                    replaceOrDeleteKey(db, newName, type, dbresult.getString(0), true, false, dbresult.getString(1), dbresult.getString(2));
+                    return;
+                }
+            }
+        }
+        Log.d(DEBUG_TAG, "copying key " + name + " " + type + " to " + newName + " failed");
+    }
+
+    /**
+     * Retrieve the OAuth configuration for an API
      * 
      * @param db readable SQLiteDatabase
      * @param name the API name
@@ -174,13 +199,7 @@ public class KeyDatabaseHelper extends SQLiteOpenHelper {
                 boolean haveEntry = dbresult.moveToFirst();
                 if (haveEntry) {
                     try {
-                        OAuthConfiguration result = new OAuthConfiguration();
-                        result.setKey(dbresult.getString(dbresult.getColumnIndexOrThrow(KEY_FIELD)));
-                        if (oAuth1a) {
-                            result.setSecret(dbresult.getString(dbresult.getColumnIndexOrThrow(ADD1_FIELD)));
-                        }
-                        result.setOauthUrl(dbresult.getString(dbresult.getColumnIndexOrThrow(ADD2_FIELD)));
-                        return result;
+                        return getOAuthConfigurationFromCursor(oAuth1a, dbresult, name);
                     } catch (IllegalArgumentException iaex) {
                         Log.e(DEBUG_TAG, "error in entry for " + name);
                     }
@@ -188,6 +207,49 @@ public class KeyDatabaseHelper extends SQLiteOpenHelper {
             }
             return null;
         }
+    }
+
+    /**
+     * Retrieve the OAuth configurations for a specific OAuth variant
+     * 
+     * @param db readable SQLiteDatabase
+     * @param auth current Authentication type
+     * @return a List of configurations (potentially empty)
+     */
+    @NonNull
+    public static List<OAuthConfiguration> getOAuthConfigurations(@NonNull SQLiteDatabase db, @NonNull Auth auth) {
+        final boolean oAuth1a = auth == Auth.OAUTH1A;
+        List<OAuthConfiguration> configurations = new ArrayList<>();
+        try (Cursor dbresult = db.query(KEYS_TABLE, new String[] { NAME_FIELD, KEY_FIELD, ADD1_FIELD, ADD2_FIELD },
+                TYPE_FIELD + "='" + (oAuth1a ? EntryType.API_OAUTH1_KEY : EntryType.API_OAUTH2_KEY) + "'", null, null, null, null)) {
+            if (dbresult.getCount() >= 1) {
+                boolean haveEntry = dbresult.moveToFirst();
+                while (haveEntry) {
+                    configurations.add(getOAuthConfigurationFromCursor(oAuth1a, dbresult, dbresult.getString(dbresult.getColumnIndexOrThrow(NAME_FIELD))));
+                    haveEntry = dbresult.moveToNext();
+                }
+            }
+        }
+        return configurations;
+    }
+
+    /**
+     * Get an OAuthConfiguration from a Cursor
+     * 
+     * @param oAuth1a true if it should be an OAuth1a config
+     * @param dbresult the Cursor
+     * @param name the name to use
+     * @return the config
+     */
+    @NonNull
+    private static OAuthConfiguration getOAuthConfigurationFromCursor(final boolean oAuth1a, @NonNull Cursor dbresult, @NonNull String name) {
+        OAuthConfiguration result = new OAuthConfiguration(name);
+        result.setKey(dbresult.getString(dbresult.getColumnIndexOrThrow(KEY_FIELD)));
+        if (oAuth1a) {
+            result.setSecret(dbresult.getString(dbresult.getColumnIndexOrThrow(ADD1_FIELD)));
+        }
+        result.setOauthUrl(dbresult.getString(dbresult.getColumnIndexOrThrow(ADD2_FIELD)));
+        return result;
     }
 
     /**

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -699,7 +699,7 @@
     <!--  -->
     <string name="toast_oauth_retry">Try uploading again after allowing OAuth access to your OSM account.</string>
     <string name="toast_oauth">Please allow OAuth access to your OSM account.</string>
-    <string name="toast_no_oauth">No OAuth configuration available for API \"%1$s\", please set login and password.</string>
+    <string name="toast_no_oauth">No OAuth configuration available for API \"%1$s\", please set login and password if supported.</string>
     <string name="toast_oauth_not_enabled">OAuth is not enabled for the current API.</string>
     <string name="toast_oauth_timeout">Timeout during authentication handshake, please try again.</string>
     <string name="toast_oauth_communication">Communication error during authentication handshake, please try again.</string>
@@ -1615,6 +1615,7 @@
     <string name="readonly_url">Read-only API URL (optional)</string>
     <string name="notes_url">Notes API URL (optional)</string>
     <string name="copy_of">Copy of %1$s</string>
+    <string name="choose_oauth_config">Choose OAuth configuration</string>
     <!-- common terms -->
     <string name="add">Add</string>
     <string name="edit">Edit</string>

--- a/src/test/java/de/blau/android/net/OAuth2Test.java
+++ b/src/test/java/de/blau/android/net/OAuth2Test.java
@@ -26,6 +26,7 @@ import de.blau.android.App;
 import de.blau.android.Logic;
 import de.blau.android.Main;
 import de.blau.android.ShadowWorkManager;
+import de.blau.android.exception.NoOAuthConfigurationException;
 import de.blau.android.exception.OsmException;
 import de.blau.android.prefs.API;
 import de.blau.android.prefs.AdvancedPrefDatabase;
@@ -101,7 +102,7 @@ public class OAuth2Test {
             assertEquals("1212121212", parsed.getQueryParameter("client_id"));
             String codeChallenge = parsed.getQueryParameter("code_challenge");
             assertNotNull(codeChallenge);
-        } catch (OsmException e) {
+        } catch (OsmException | NoOAuthConfigurationException e) {
             fail(e.getMessage());
         }
     }

--- a/src/testCommon/resources/fixtures/loaded.html
+++ b/src/testCommon/resources/fixtures/loaded.html
@@ -1,0 +1,4 @@
+<html>
+<head></head>
+<body>Loaded</body>
+</html>

--- a/src/testCommon/resources/fixtures/loaded.yaml
+++ b/src/testCommon/resources/fixtures/loaded.yaml
@@ -1,0 +1,4 @@
+statusCode: 200       
+delay: 0              
+body: 'loaded.html'
+                 


### PR DESCRIPTION
If you add a new API config it will not have an OAuth client key available except if you load one from a file. As often you are simply modifying an existing API entry the change now allows you to select from one of the existing client configurations.

Resolves  https://github.com/MarcusWolschon/osmeditor4android/issues/2887