### PR TITLE
Fix error in StyleableFileLayer.hasStateFile

### DIFF
--- a/src/main/java/de/blau/android/layer/StyleableFileLayer.java
+++ b/src/main/java/de/blau/android/layer/StyleableFileLayer.java
@@ -3,7 +3,6 @@ package de.blau.android.layer;
 import java.io.InputStream;
 
 import android.content.Context;
-import android.net.Uri;
 import androidx.annotation.NonNull;
 import de.blau.android.contract.FileExtensions;
 import de.blau.android.util.Hash;
@@ -37,7 +36,9 @@ public abstract class StyleableFileLayer extends StyleableLayer {
      * @return true if a state file exists
      */
     protected boolean hasStateFile(@NonNull Context context) {
-        setStateFileName(Uri.parse(contentId).getEncodedPath());
+        if (stateFileName == null) {
+            return false;
+        }
         try (InputStream stream = context.openFileInput(stateFileName)) {
             return true;
         } catch (Exception ex) {

--- a/src/main/java/de/blau/android/layer/StyleableLayer.java
+++ b/src/main/java/de/blau/android/layer/StyleableLayer.java
@@ -154,6 +154,7 @@ public abstract class StyleableLayer extends MapViewLayer implements StyleableIn
      * @param context an Android Context
      * @return a StyleableLayer
      */
+    @Nullable
     protected abstract StyleableLayer load(@NonNull Context context);
 
     @Override

--- a/src/main/java/de/blau/android/layer/geojson/MapOverlay.java
+++ b/src/main/java/de/blau/android/layer/geojson/MapOverlay.java
@@ -198,7 +198,7 @@ public class MapOverlay extends StyleableFileLayer
         final Preferences prefs = map.getPrefs();
         initStyling(!hasStateFile(map.getContext()), prefs.getGeoJsonStrokeWidth(), prefs.getGeoJsonLabelSource(), prefs.getGeoJsonLabelMinZoom(),
                 prefs.getGeoJsonSynbol());
-        paint.setColor(ColorUtil.generateColor(map.getLayerTypeCount(LayerType.GEOJSON), 9,
+        setColor(ColorUtil.generateColor(map.getLayerTypeCount(LayerType.GEOJSON), 9,
                 map.getDataStyle().getInternal(DataStyle.GEOJSON_DEFAULT).getPaint().getColor()));
     }
 

--- a/src/main/java/de/blau/android/layer/gpx/MapOverlay.java
+++ b/src/main/java/de/blau/android/layer/gpx/MapOverlay.java
@@ -109,7 +109,7 @@ public class MapOverlay extends StyleableFileLayer
         // this is slightly annoying as we need to protect against overwriting already saved state
         initStyling(!hasStateFile(context), prefs.getGpxStrokeWidth(), prefs.getGpxLabelSource(), prefs.getGpxLabelMinZoom(), prefs.getGpxSynbol());
         DataStyle styles = map.getDataStyle();
-        paint.setColor(ColorUtil.generateColor(map.getLayerTypeCount(LayerType.GPX), 9, styles.getInternal(DataStyle.GPS_TRACK).getPaint().getColor()));
+        setColor(ColorUtil.generateColor(map.getLayerTypeCount(LayerType.GPX), 9, styles.getInternal(DataStyle.GPS_TRACK).getPaint().getColor()));
 
         // the following can only be changed in the DataStyle
         FeatureStyle fs = styles.getInternal(DataStyle.LABELTEXT_NORMAL);
@@ -476,16 +476,17 @@ public class MapOverlay extends StyleableFileLayer
     public synchronized StyleableLayer load(@NonNull Context context) {
         Log.d(DEBUG_TAG, "Loading state from " + stateFileName);
         MapOverlay restoredOverlay = savingHelper.load(context, stateFileName, true, true, false);
-        if (restoredOverlay != null) {
-            Log.d(DEBUG_TAG, "read saved state");
-            wayPointPaint = restoredOverlay.wayPointPaint;
-            labelKey = restoredOverlay.labelKey;
-            labelMinZoom = restoredOverlay.labelMinZoom;
-            if (playbackTask == null && restoredOverlay.pausedPoint != null) {
-                // restart playback
-                playbackTask = new GpxPlayback();
-                playbackTask.execute(restoredOverlay.pausedPoint);
-            }
+        if (restoredOverlay == null) {
+            return null;
+        }
+        Log.d(DEBUG_TAG, "read saved state");
+        wayPointPaint = restoredOverlay.wayPointPaint;
+        labelKey = restoredOverlay.labelKey;
+        labelMinZoom = restoredOverlay.labelMinZoom;
+        if (playbackTask == null && restoredOverlay.pausedPoint != null) {
+            // restart playback
+            playbackTask = new GpxPlayback();
+            playbackTask.execute(restoredOverlay.pausedPoint);
         }
         return restoredOverlay;
     }


### PR DESCRIPTION
Due to probably a c&p error we were overwriting the state file instead of just testing for it. Further we were not initializing the symboly colour properly in the GPX layer.

See https://github.com/MarcusWolschon/osmeditor4android/issues/2911