### PR TITLE
Ignore oneway=no when reversing a way

### DIFF
--- a/src/main/java/de/blau/android/osm/Reverse.java
+++ b/src/main/java/de/blau/android/osm/Reverse.java
@@ -44,8 +44,11 @@ final class Reverse {
     private static final String PERCENT          = "%";
     private static final String DEGREE           = "°";
 
+    /**
+     * Direction dependent key, note oneway is handled specially
+     */
     private static final Set<String> directionDependentKeys   = Collections
-            .unmodifiableSet(new HashSet<>(Arrays.asList(Tags.KEY_ONEWAY, Tags.KEY_INCLINE, Tags.KEY_DIRECTION, Tags.KEY_CONVEYING, Tags.KEY_PRIORITY)));
+            .unmodifiableSet(new HashSet<>(Arrays.asList(Tags.KEY_INCLINE, Tags.KEY_DIRECTION, Tags.KEY_CONVEYING, Tags.KEY_PRIORITY)));
     private static final Set<String> directionDependentValues = Collections
             .unmodifiableSet(new HashSet<>(Arrays.asList(Tags.VALUE_RIGHT, Tags.VALUE_LEFT, Tags.VALUE_FORWARD, Tags.VALUE_BACKWARD)));
 
@@ -80,14 +83,36 @@ final class Reverse {
         for (Entry<String, String> entry : tags.entrySet()) {
             String key = entry.getKey();
             String value = entry.getValue();
-            if (((Tags.KEY_HIGHWAY.equals(key) && (Tags.VALUE_MOTORWAY.equals(value) || Tags.VALUE_MOTORWAY_LINK.equals(value)))
-                    || directionDependentKeys.contains(key) || key.endsWith(LEFT_POSTFIX) || key.endsWith(RIGHT_POSTFIX) || key.endsWith(BACKWARD_POSTFIX)
-                    || key.endsWith(FORWARD_POSTFIX) || key.contains(FORWARD_INFIX) || key.contains(BACKWARD_INFIX) || key.contains(RIGHT_INFIX)
-                    || key.contains(LEFT_INFIX) || directionDependentValues.contains(value)) && !matchExceptions(e, key)) {
+            // @formatter:off
+            if ((implicitOneway(key, value)
+                    || directionDependentKeys.contains(key) 
+                    || (e instanceof Way && ((Way)e).getOneway() != 0)
+                    || key.endsWith(LEFT_POSTFIX) 
+                    || key.endsWith(RIGHT_POSTFIX) 
+                    || key.endsWith(BACKWARD_POSTFIX)
+                    || key.endsWith(FORWARD_POSTFIX) 
+                    || key.contains(FORWARD_INFIX) 
+                    || key.contains(BACKWARD_INFIX) 
+                    || key.contains(RIGHT_INFIX)
+                    || key.contains(LEFT_INFIX) 
+                    || directionDependentValues.contains(value)) 
+                    && !matchExceptions(e, key)) {
                 result.put(key, value);
             }
+         // @formatter:on
         }
         return result;
+    }
+
+    /**
+     * Check that this is an implicit one way
+     * 
+     * @param key tag key
+     * @param value tag value
+     * @return true if oneway
+     */
+    private static boolean implicitOneway(@NonNull String key, @NonNull String value) {
+        return Tags.KEY_HIGHWAY.equals(key) && (Tags.VALUE_MOTORWAY.equals(value) || Tags.VALUE_MOTORWAY_LINK.equals(value));
     }
 
     /**

--- a/src/main/java/de/blau/android/osm/Way.java
+++ b/src/main/java/de/blau/android/osm/Way.java
@@ -388,9 +388,10 @@ public class Way extends StyledOsmElement implements WayInterface, BoundedObject
     public int getOneway() {
         String oneway = getTagWithKey(Tags.KEY_ONEWAY);
         if (oneway != null) {
-            if (Tags.VALUE_YES.equalsIgnoreCase(oneway) || Tags.VALUE_TRUE.equalsIgnoreCase(oneway) || "1".equals(oneway)) {
+            if (Tags.VALUE_YES.equalsIgnoreCase(oneway) || Tags.VALUE_TRUE.equalsIgnoreCase(oneway) || Tags.VALUE_ONE.equals(oneway)) {
                 return 1;
-            } else if ("-1".equals(oneway) || Tags.VALUE_REVERSE.equalsIgnoreCase(oneway)) {
+            }
+            if (Tags.VALUE_MINUS_ONE.equals(oneway) || Tags.VALUE_REVERSE.equalsIgnoreCase(oneway)) {
                 return -1;
             }
         }

--- a/src/test/java/de/blau/android/osm/ReverseTest.java
+++ b/src/test/java/de/blau/android/osm/ReverseTest.java
@@ -17,7 +17,7 @@ import androidx.test.filters.LargeTest;
 import de.blau.android.App;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk=33)
+@Config(sdk = 33)
 @LargeTest
 public class ReverseTest {
 
@@ -26,26 +26,38 @@ public class ReverseTest {
      */
     @Test
     public void reverse() {
-        reverseTag("direction","up","down");
-        reverseTag("direction","down","up");
-        reverseTag("direction","NW","SE");
-        reverseTag("direction","45°","225°");
-        reverseTag("direction","45","225");
-        reverseTag("direction","forward","backward");
-        reverseTag("direction","backward","forward");
-        reverseTag("incline","up","down");
-        reverseTag("incline","down","up");
-        reverseTag("incline","10°","-10°");
-        reverseTag("incline","-10°","10°");
-        reverseTag("oneway","yes","-1");
-        reverseTag("conveying","forward","backward");
-        reverseTag("conveying","backward","forward");
-        reverseTag("priority","forward","backward");
-        reverseTag("priority","backward","forward");
+        reverseTag("direction", "up", "down");
+        reverseTag("direction", "down", "up");
+        reverseTag("direction", "NW", "SE");
+        reverseTag("direction", "45°", "225°");
+        reverseTag("direction", "45", "225");
+        reverseTag("direction", "forward", "backward");
+        reverseTag("direction", "backward", "forward");
+        reverseTag("incline", "up", "down");
+        reverseTag("incline", "down", "up");
+        reverseTag("incline", "10°", "-10°");
+        reverseTag("incline", "-10°", "10°");
+        reverseTag("oneway", "yes", "-1");
+        reverseTag("oneway", "true", "-1");
+        reverseTag("oneway", "1", "-1");
+        reverseTag("conveying", "forward", "backward");
+        reverseTag("conveying", "backward", "forward");
+        reverseTag("priority", "forward", "backward");
+        reverseTag("priority", "backward", "forward");
+    }
+    
+    @Test
+    public void ignoreNoOneWay() {
+        Map<String, String> tags = new HashMap<>();
+        tags.put("oneway", "no");
+        Way e = OsmElementFactory.createWay(-1L, 1L, System.currentTimeMillis() / 1000, OsmElement.STATE_CREATED);
+        e.setTags(tags);
+        Map<String, String> dirTags = Reverse.getDirectionDependentTags(e);
+        assertFalse(dirTags.containsKey("oneway"));
     }
 
     /**
-     * Test that way reversing has the intended effects
+     * Test that way reversing has the intended effects on a way node
      */
     @Test
     public void reverseSide() {
@@ -74,14 +86,14 @@ public class ReverseTest {
         n.setTags(tags);
         dirTags = Reverse.getDirectionDependentTags(n);
         assertFalse(dirTags.containsKey(Tags.KEY_SIDE));
-        
+
         tags = new HashMap<>();
         tags.put(Tags.KEY_HIGHWAY, "residential");
         tags.put(Tags.KEY_ONEWAY, Tags.VALUE_TRUE);
         w.setTags(tags);
         dirTags = Reverse.getDirectionDependentTags(n);
         assertTrue(dirTags.containsKey(Tags.KEY_SIDE));
-        
+
         tags = new HashMap<>();
         tags.put(Tags.KEY_HIGHWAY, "residential");
         tags.put(Tags.KEY_ONEWAY, Tags.VALUE_MINUS_ONE);
@@ -89,9 +101,9 @@ public class ReverseTest {
         dirTags = Reverse.getDirectionDependentTags(n);
         assertTrue(dirTags.containsKey(Tags.KEY_SIDE));
     }
-    
+
     /**
-     * Get the tag value changed by assuming that the way was reversed 
+     * Get the tag value changed by assuming that the way was reversed
      * 
      * @param key the key
      * @param value the original value
@@ -100,14 +112,14 @@ public class ReverseTest {
     private void reverseTag(String key, String value, String result) {
         Way e = OsmElementFactory.createWay(-1L, 1L, System.currentTimeMillis() / 1000, OsmElement.STATE_CREATED);
         // don't bother added way nodes for now
-        
+
         Map<String, String> tags = new HashMap<>();
         tags.put(key, value);
-        
+
         e.setTags(tags);
         Map<String, String> dirTags = Reverse.getDirectionDependentTags(e);
         assertTrue(dirTags.containsKey(key));
-        assertEquals(value,dirTags.get(key));
+        assertEquals(value, dirTags.get(key));
         Reverse.reverseDirectionDependentTags(e, dirTags, true);
         assertTrue(e.hasTagWithValue(key, result));
     }


### PR DESCRIPTION
This suppresses a bogus warning as oneway=no has no dependency on the way direction.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/2924