### PR TITLE
Show a warning if there is no prior state available

### DIFF
--- a/src/main/java/de/blau/android/dialogs/AbstractReviewDialog.java
+++ b/src/main/java/de/blau/android/dialogs/AbstractReviewDialog.java
@@ -31,6 +31,7 @@ import de.blau.android.R;
 import de.blau.android.osm.Node;
 import de.blau.android.osm.OsmElement;
 import de.blau.android.osm.Relation;
+import de.blau.android.osm.UndoStorage;
 import de.blau.android.osm.Way;
 import de.blau.android.util.ImmersiveDialogFragment;
 import de.blau.android.util.ThemeUtils;
@@ -233,7 +234,7 @@ public abstract class AbstractReviewDialog extends ImmersiveDialogFragment {
                     boolean deleted = elemenState == OsmElement.STATE_DELETED;
                     final FragmentActivity fragmentActivity = (FragmentActivity) view.getContext();
                     if (elemenState == OsmElement.STATE_MODIFIED || deleted) {
-                        ElementInfo.showDialog(fragmentActivity, 0, e, !deleted, true, parentTag);
+                        ElementInfo.showDialog(fragmentActivity, UndoStorage.ORIGINAL_ELEMENT_INDEX, e, !deleted, true, parentTag);
                     } else {
                         ElementInfo.showDialog(fragmentActivity, e, !deleted, parentTag);
                     }

--- a/src/main/java/de/blau/android/easyedit/ElementSelectionActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/ElementSelectionActionModeCallback.java
@@ -52,6 +52,7 @@ import de.blau.android.osm.RelationMember;
 import de.blau.android.osm.RelationUtils;
 import de.blau.android.osm.Server;
 import de.blau.android.osm.Tags;
+import de.blau.android.osm.UndoStorage;
 import de.blau.android.osm.Way;
 import de.blau.android.prefs.PrefEditor;
 import de.blau.android.prefs.Preferences;
@@ -389,7 +390,7 @@ public abstract class ElementSelectionActionModeCallback extends EasyEditActionM
             main.descheduleAutoLock();
             // as we want to display relation membership changes too
             // we can't rely on the element status
-            ElementInfo.showDialog(main, 0, element, false);
+            ElementInfo.showDialog(main, UndoStorage.ORIGINAL_ELEMENT_INDEX, element, false);
             break;
         case MENUITEM_UPLOAD:
             main.descheduleAutoLock();

--- a/src/main/java/de/blau/android/osm/UndoStorage.java
+++ b/src/main/java/de/blau/android/osm/UndoStorage.java
@@ -1,5 +1,7 @@
 package de.blau.android.osm;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -49,7 +51,10 @@ import de.blau.android.util.Util;
 public class UndoStorage implements Serializable {
     private static final long serialVersionUID = 3L;
 
-    private static final String DEBUG_TAG = UndoStorage.class.getSimpleName().substring(0, Math.min(23, UndoStorage.class.getSimpleName().length()));
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, UndoStorage.class.getSimpleName().length());
+    private static final String DEBUG_TAG = UndoStorage.class.getSimpleName().substring(0, TAG_LEN);
+
+    public static final int ORIGINAL_ELEMENT_INDEX = 0;
 
     // Original storages for "contains" checks and restoration
     private Storage currentStorage;

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -337,6 +337,7 @@
     <string name="goto_element">Go to element</string>
     <string name="edit_properties">Edit Tags</string>
     <string name="toast_element_not_found_on_restore">Could not find element on restore</string>
+    <string name="toast_element_no_prior_state">Element has been modified, but there is no local prior state to compare to.</string>
     <!--  GeoJSON feature display dialog -->
     <string name="feature_information">GeoJSON feature info</string>
     <string name="vt_feature_information">Vector tile feature info</string>


### PR DESCRIPTION
If modified data has been loaded from an .osm file there is no undo checkpoints with prior state. Leading to the confusing situation that there are changes to upload but the info modal for the element doesn't show changes.

Resolves https://github.com/MarcusWolschon/osmeditor4android/issues/2926