### PR TITLE
Not so augmented diffs

### DIFF
--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -4343,12 +4343,15 @@ public class Logic {
             @Override
             protected Integer doInBackground(Void arg) {
                 int result = 0;
+                final StorageDelegator delegator = getDelegator();
                 try (OutputStream out = new BufferedOutputStream(fout)) {
-                    OsmXml.write(getDelegator().getCurrentStorage(), getDelegator().getApiStorage(), out, App.getUserAgent());
+                    delegator.lockReads();
+                    OsmXml.write(delegator.getCurrentStorage(), delegator.getApiStorage(), out, App.getUserAgent());
                 } catch (IllegalArgumentException | IllegalStateException | XmlPullParserException | IOException e) {
                     result = ErrorCodes.FILE_WRITE_FAILED;
                     Log.e(DEBUG_TAG, "Problem writing", e);
                 } finally {
+                    delegator.unlockReads();
                     SavingHelper.close(fout);
                 }
                 return result;
@@ -4357,14 +4360,6 @@ public class Logic {
             @Override
             protected void onPostExecute(Integer result) {
                 Progress.dismissDialog(activity, Progress.PROGRESS_SAVING);
-                Map mainMap = activity instanceof Main ? ((Main) activity).getMap() : null;
-                if (mainMap != null) {
-                    try {
-                        viewBox.setRatio(mainMap, (float) mainMap.getWidth() / (float) mainMap.getHeight());
-                    } catch (OsmException e) {
-                        Log.d(DEBUG_TAG, "writeOsmFile got " + e.getMessage());
-                    }
-                }
                 if (result == 0) {
                     if (postSaveHandler != null) {
                         postSaveHandler.onSuccess();

--- a/src/main/java/de/blau/android/Main.java
+++ b/src/main/java/de/blau/android/Main.java
@@ -2370,6 +2370,10 @@ public class Main extends AuthorisationEnabledActivity
                 }
             });
             return true;
+        case R.id.menu_transfer_export_augmented_diff:
+            descheduleAutoLock();
+            saveAugmentedDiff(this, delegator, prefs);
+            return true;
         case R.id.menu_transfer_read_file:
         case R.id.menu_transfer_read_pbf_file:
             descheduleAutoLock();
@@ -2678,6 +2682,30 @@ public class Main extends AuthorisationEnabledActivity
             @Override
             public boolean save(FragmentActivity currentActivity, Uri fileUri) {
                 SavingHelper.asyncExport(currentActivity, delegator, fileUri);
+                SelectFile.savePref(prefs, R.string.config_osmPreferredDir_key, fileUri);
+                return true;
+            }
+        });
+    }
+    
+    /**
+     * Show the file picker and save current changes to an osmChanges file
+     * 
+     * @param activity a FragmentActivity
+     * @param delegator a StorageDelegator instance
+     * @param prefs current Preferences
+     */
+    public static void saveAugmentedDiff(@NonNull FragmentActivity activity, @NonNull final StorageDelegator delegator, @NonNull Preferences prefs) {
+        SelectFile.save(activity, null, R.string.config_osmPreferredDir_key, new SaveFile() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public boolean save(FragmentActivity currentActivity, Uri fileUri) {
+                try {
+                    delegator.exportAugmentedDiff(currentActivity.getContentResolver().openOutputStream(fileUri));
+                } catch (Exception e) {
+                    // FIXME do something here
+                }
                 SelectFile.savePref(prefs, R.string.config_osmPreferredDir_key, fileUri);
                 return true;
             }

--- a/src/main/java/de/blau/android/osm/AugmentedXmlSerializable.java
+++ b/src/main/java/de/blau/android/osm/AugmentedXmlSerializable.java
@@ -1,0 +1,26 @@
+package de.blau.android.osm;
+
+import java.io.IOException;
+
+import org.xmlpull.v1.XmlSerializer;
+
+/**
+ * Serialize to AugmentedDiff XML
+ * 
+ * @author simon
+ *
+ */
+public interface AugmentedXmlSerializable {
+
+    /**
+     * Generate augmented diff format OSM XML files
+     * 
+     * @param serializer the XML serializer
+     * @param original if true the original version, otherwise the current, only relevant for indirect changes
+     * @param undo instance of UndoStorage only used if original is true
+     * @throws IllegalArgumentException if the serializer encountered an illegal argument
+     * @throws IllegalStateException if the serializer detects an illegal state
+     * @throws IOException if writing to the serializer fails
+     */
+    void toAugmentedXml(XmlSerializer serializer, boolean original, UndoStorage undo) throws IllegalArgumentException, IllegalStateException, IOException;
+}

--- a/src/main/java/de/blau/android/osm/BoundingBox.java
+++ b/src/main/java/de/blau/android/osm/BoundingBox.java
@@ -1,5 +1,6 @@
 package de.blau.android.osm;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
 import static de.blau.android.util.GeoMath.OSM_SCALE;
 
 import java.io.IOException;
@@ -28,11 +29,12 @@ import de.blau.android.util.rtree.BoundedObject;
  * @author mb
  * @author Simon Poole
  */
-public class BoundingBox implements Serializable, JosmXmlSerializable, BoundedObject {
+public class BoundingBox implements Serializable, XmlSerializable, JosmXmlSerializable, BoundedObject {
 
     private static final long serialVersionUID = -2708721312405863618L;
 
-    private static final String DEBUG_TAG = BoundingBox.class.getSimpleName().substring(0, Math.min(23, BoundingBox.class.getSimpleName().length()));
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, BoundingBox.class.getSimpleName().length());
+    private static final String DEBUG_TAG = BoundingBox.class.getSimpleName().substring(0, TAG_LEN);
 
     static final String MINLAT_ATTR = "minlat";
     static final String MINLON_ATTR = "minlon";
@@ -548,9 +550,20 @@ public class BoundingBox implements Serializable, JosmXmlSerializable, BoundedOb
     }
 
     @Override
+    public void toXml(XmlSerializer s, Long changeSetId) throws IllegalArgumentException, IllegalStateException, IOException {
+        toXml(s, false);
+    }
+
+    @Override
     public void toJosmXml(final XmlSerializer s) throws IllegalArgumentException, IllegalStateException, IOException {
+        toXml(s, true);
+    }
+
+    private void toXml(final XmlSerializer s, boolean josm) throws IllegalArgumentException, IllegalStateException, IOException {
         s.startTag("", BOUNDS_TAG);
-        s.attribute("", ORIGIN_ATTR, "");
+        if (josm) {
+            s.attribute("", ORIGIN_ATTR, "");
+        }
         s.attribute("", MAXLON_ATTR, Double.toString((right / 1E7)));
         s.attribute("", MAXLAT_ATTR, Double.toString((top / 1E7)));
         s.attribute("", MINLON_ATTR, Double.toString((left / 1E7)));

--- a/src/main/java/de/blau/android/osm/Node.java
+++ b/src/main/java/de/blau/android/osm/Node.java
@@ -121,6 +121,11 @@ public class Node extends OsmElement implements GeoPoint, BoundedObject {
         toXml(s, null, true);
     }
 
+    @Override
+    public void toAugmentedXml(XmlSerializer s, boolean original, UndoStorage undo) throws IllegalArgumentException, IllegalStateException, IOException {
+        toXml(s, null, false);
+    }
+
     /**
      * Generate XML format OSM files
      * 
@@ -135,10 +140,20 @@ public class Node extends OsmElement implements GeoPoint, BoundedObject {
             throws IllegalArgumentException, IllegalStateException, IOException {
         s.startTag("", NAME);
         attributesToXml(s, changeSetId, josm);
+        if (!isDeleted()) {
+            coordToXmlAttr(s, lat, lon);
+            tagsToXml(s);
+        }
+        s.endTag("", NAME);
+    }
+
+    /**
+     * @param s
+     * @throws IOException
+     */
+    public static void coordToXmlAttr(final XmlSerializer s, int lat, int lon) throws IOException {
         s.attribute("", LAT_ATTR, BigDecimal.valueOf(lat).scaleByPowerOfTen(-COORDINATE_SCALE).stripTrailingZeros().toPlainString());
         s.attribute("", LON_ATTR, BigDecimal.valueOf(lon).scaleByPowerOfTen(-COORDINATE_SCALE).stripTrailingZeros().toPlainString());
-        tagsToXml(s);
-        s.endTag("", NAME);
     }
 
     @Override

--- a/src/main/java/de/blau/android/osm/OsmChangeParser.java
+++ b/src/main/java/de/blau/android/osm/OsmChangeParser.java
@@ -1,5 +1,7 @@
 package de.blau.android.osm;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -21,7 +23,8 @@ import de.blau.android.tasks.OsnParser;
  */
 public class OsmChangeParser extends OsmParser {
 
-    private static final String DEBUG_TAG = OsmChangeParser.class.getSimpleName().substring(0, Math.min(23, OsmChangeParser.class.getSimpleName().length()));
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, OsmChangeParser.class.getSimpleName().length());
+    private static final String DEBUG_TAG = OsmChangeParser.class.getSimpleName().substring(0, TAG_LEN);
 
     /**
      * Place holder for a node referenced by a way, but not in the OsmChange file
@@ -116,7 +119,7 @@ public class OsmChangeParser extends OsmParser {
      * @return the OsmElement state
      * @throws OsmParseException if the action is unknown
      */
-    private byte action2state(@NonNull String action) throws OsmParseException {
+    protected static byte action2state(@NonNull String action) throws OsmParseException {
         switch (action) {
         case OsmXml.CREATE:
             return OsmElement.STATE_CREATED;

--- a/src/main/java/de/blau/android/osm/OsmElement.java
+++ b/src/main/java/de/blau/android/osm/OsmElement.java
@@ -33,12 +33,12 @@ import de.blau.android.util.IssueAlert;
 import de.blau.android.util.Util;
 import de.blau.android.validation.Validator;
 
-public abstract class OsmElement implements OsmElementInterface, Serializable, XmlSerializable, JosmXmlSerializable {
+public abstract class OsmElement implements OsmElementInterface, Serializable, XmlSerializable, JosmXmlSerializable, AugmentedXmlSerializable {
 
     private static final long serialVersionUID = 7711945069147743675L;
 
     private static final String DEBUG_TAG = Relation.class.getSimpleName().substring(0, Math.min(23, Relation.class.getSimpleName().length()));
-    
+
     public static final long NEW_OSM_ID = -1;
 
     public static final byte STATE_UNCHANGED = 0;
@@ -377,6 +377,15 @@ public abstract class OsmElement implements OsmElementInterface, Serializable, X
         return (tags != null) && (tags.size() > 0);
     }
 
+    /**
+     * check if this element is deleted
+     * 
+     * @return true if this element is deleted
+     */
+    public boolean isDeleted() {
+        return STATE_DELETED == state;
+    }
+
     @Override
     public String toString() {
         return getName() + " " + osmId;
@@ -391,6 +400,14 @@ public abstract class OsmElement implements OsmElementInterface, Serializable, X
      * @throws IOException if writing to the serializer fails
      */
     protected void tagsToXml(@NonNull final XmlSerializer s) throws IllegalArgumentException, IllegalStateException, IOException {
+        tagsToXml(s, tags);
+    }
+
+    /**
+     * @param s
+     * @throws IOException
+     */
+    public static void tagsToXml(final XmlSerializer s, Map<String, String> tags) throws IOException {
         if (tags != null) {
             for (Entry<String, String> tag : tags.entrySet()) {
                 s.startTag("", TAG);
@@ -425,7 +442,7 @@ public abstract class OsmElement implements OsmElementInterface, Serializable, X
         if (timestamp >= 0) {
             s.attribute("", TIMESTAMP_ATTR, DateFormatter.getUtcFormat(OsmParser.TIMESTAMP_FORMAT).format(getTimestamp() * 1000));
         }
-        s.attribute("", VISIBLE_ATTR, TRUE_VALUE); // it could be argued that this should follow the state too
+        s.attribute("", VISIBLE_ATTR, Boolean.toString(!isDeleted()));
     }
 
     /**
@@ -715,7 +732,7 @@ public abstract class OsmElement implements OsmElementInterface, Serializable, X
                 wrapper.setElement(this);
                 return ch.poole.osm.josmtemplateparser.Util.listFormat(rs, wrapper.getType(), wrapper, getTags());
             } catch (JosmTemplateParseException e) {
-                Log.e(DEBUG_TAG,"nameFromTemplate " + e.getMessage());
+                Log.e(DEBUG_TAG, "nameFromTemplate " + e.getMessage());
             }
         }
         return null;

--- a/src/main/java/de/blau/android/osm/OsmXml.java
+++ b/src/main/java/de/blau/android/osm/OsmXml.java
@@ -1,11 +1,16 @@
 package de.blau.android.osm;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 
 import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlPullParserFactory;
@@ -14,6 +19,10 @@ import org.xmlpull.v1.XmlSerializer;
 import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import de.blau.android.osm.UndoStorage.UndoElement;
+import de.blau.android.osm.UndoStorage.UndoNode;
+import de.blau.android.osm.UndoStorage.UndoRelation;
+import de.blau.android.osm.UndoStorage.UndoWay;
 
 /**
  * Provide reading and writing data files in OSM and JOSM format
@@ -22,7 +31,9 @@ import androidx.annotation.Nullable;
  *
  */
 public final class OsmXml {
-    private static final String DEBUG_TAG = OsmXml.class.getSimpleName().substring(0, Math.min(23, OsmXml.class.getSimpleName().length()));
+
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, OsmXml.class.getSimpleName().length());
+    private static final String DEBUG_TAG = OsmXml.class.getSimpleName().substring(0, TAG_LEN);
 
     public static final String UTF_8 = "UTF-8";
 
@@ -37,7 +48,17 @@ public final class OsmXml {
     public static final String VERSION_0_6 = "0.6";
     public static final String VERSION     = "version";
     public static final String GENERATOR   = "generator";
+    // augmented diff constants
+    private static final String OSM_ADIFF         = "osm-adiff";
+    private static final String OSM_ADIFF_VERSION = "1.0";
+    private static final String NEW               = "new";
+    private static final String OLD               = "old";
+    private static final String TYPE              = "type";
+    private static final String ACTION            = "action";
 
+    /**
+     * Try to order relations so that parent relations come later
+     */
     private static final Comparator<Relation> relationOrder = (r1, r2) -> {
         if (r1.hasParentRelation(r2)) {
             return -1;
@@ -46,6 +67,18 @@ public final class OsmXml {
             return 1;
         }
         return 0;
+    };
+
+    /**
+     * Comparator to avoid unpleasant surprises when processing unsorted OSM data with osmium and tools based on it
+     */
+    private static final Comparator<OsmElement> sortItLikeJochen = (e1, e2) -> {
+        long id1 = e1.getOsmId();
+        long id2 = e2.getOsmId();
+        if ((id1 < 0 && id2 > 0) || (id1 > 0 && id2 < 0)) { // signs different
+            return Long.compare(id1, id2);
+        }
+        return Long.compare(Math.abs(id1), Math.abs(id2));
     };
 
     /**
@@ -90,17 +123,61 @@ public final class OsmXml {
         List<Relation> modifiedRelations = new ArrayList<>();
         List<Relation> deletedRelations = new ArrayList<>();
 
-        for (Node elem : storage.getNodes()) {
+        count = fillLists(storage.getNodes(), maxChanges, count, createdNodes, modifiedNodes, deletedNodes);
+        if (count < maxChanges) {
+            count += fillLists(storage.getWays(), maxChanges, count, createdWays, modifiedWays, deletedWays);
+        }
+        if (count < maxChanges) {
+            fillLists(storage.getRelations(), maxChanges, count, createdRelations, modifiedRelations, deletedRelations);
+        }
+
+        sortRelations(createdRelations, modifiedRelations, deletedRelations);
+
+        // NOTE as deleted elements cannot be referenced we need to undelete them in MODIFY elements before we reference
+        // them, this will not always work for relations, see below
+        serializeElements(serializer, CREATE, changeSetId, createdNodes);
+        serializeElements(serializer, MODIFY, changeSetId, modifiedNodes);
+
+        serializeElements(serializer, CREATE, changeSetId, createdWays);
+        serializeElements(serializer, MODIFY, changeSetId, modifiedWays);
+
+        // if a newly created relation references deleted relations, they would need to be undeleted in a separate pass
+        serializeElements(serializer, CREATE, changeSetId, createdRelations);
+        serializeElements(serializer, MODIFY, changeSetId, modifiedRelations);
+
+        // delete in opposite order
+        serializeElements(serializer, DELETE, changeSetId, deletedRelations);
+        serializeElements(serializer, DELETE, changeSetId, deletedWays);
+        serializeElements(serializer, DELETE, changeSetId, deletedNodes);
+
+        serializer.endTag(null, OSM_CHANGE);
+        serializer.endDocument();
+    }
+
+    /**
+     * Add elements with changes to the appropriate lists
+     * 
+     * @param storage the element Storage
+     * @param maxChanges the max number of changes allowed
+     * @param count the current count
+     * @param created the list for created elements
+     * @param modified the list for modified elements
+     * @param deleted the list for deleted elements
+     * @return the number of elements added
+     */
+    private static <E extends OsmElement> int fillLists(@NonNull final List<E> elements, int maxChanges, int count, @NonNull final List<E> created,
+            @NonNull final List<E> modified, @NonNull final List<E> deleted) {
+        for (E elem : elements) {
             Log.d(DEBUG_TAG, "node added to list for upload, id " + elem.getOsmId());
             switch (elem.state) {
             case OsmElement.STATE_CREATED:
-                createdNodes.add(elem);
+                created.add(elem);
                 break;
             case OsmElement.STATE_MODIFIED:
-                modifiedNodes.add(elem);
+                modified.add(elem);
                 break;
             case OsmElement.STATE_DELETED:
-                deletedNodes.add(elem);
+                deleted.add(elem);
                 break;
             default:
                 logNotModified(elem);
@@ -108,145 +185,32 @@ public final class OsmXml {
             }
             count++;
             if (count >= maxChanges) {
-                break;
+                return count;
             }
         }
-        if (count < maxChanges) {
-            for (Way elem : storage.getWays()) {
-                Log.d(DEBUG_TAG, "way added to list for upload, id " + elem.osmId);
-                switch (elem.state) {
-                case OsmElement.STATE_CREATED:
-                    createdWays.add(elem);
-                    break;
-                case OsmElement.STATE_MODIFIED:
-                    modifiedWays.add(elem);
-                    break;
-                case OsmElement.STATE_DELETED:
-                    deletedWays.add(elem);
-                    break;
-                default:
-                    logNotModified(elem);
-                    continue;
-                }
-                count++;
-                if (count >= maxChanges) {
-                    break;
-                }
-            }
-        }
-        if (count < maxChanges) {
-            for (Relation elem : storage.getRelations()) {
-                Log.d(DEBUG_TAG, "relation added to list for upload, id " + elem.osmId);
-                switch (elem.state) {
-                case OsmElement.STATE_CREATED:
-                    createdRelations.add(elem);
-                    break;
-                case OsmElement.STATE_MODIFIED:
-                    modifiedRelations.add(elem);
-                    break;
-                case OsmElement.STATE_DELETED:
-                    deletedRelations.add(elem);
-                    break;
-                default:
-                    logNotModified(elem);
-                    continue;
-                }
-                count++;
-                if (count >= maxChanges) {
-                    break;
-                }
-            }
-        }
-        if (!createdRelations.isEmpty()) {
-            // sort the relations so that children come first, will not handle loops and similar brokenness
-            Collections.sort(createdRelations, relationOrder);
-        }
-        if (!modifiedRelations.isEmpty()) {
-            // sort the relations so that children come first, will not handle loops and similar brokenness
-            Collections.sort(modifiedRelations, relationOrder);
-        }
-        if (!deletedRelations.isEmpty()) {
-            // sort the relations so that parents come first, will not handle loops and similar brokenness
-            Collections.sort(deletedRelations, (r1, r2) -> {
-                if (r1.hasParentRelation(r2)) {
-                    return 1;
-                }
-                if (r2.hasParentRelation(r1)) {
-                    return -1;
-                }
-                return 0;
-            });
-        }
-
-        // NOTE as deleted elements cannot be referenced we need to undelete them in MODIFY elements before we reference
-        // them, this will not always work for relations, see below
-        serializeCreatedElements(serializer, changeSetId, createdNodes);
-        serializeModifiedElements(serializer, changeSetId, modifiedNodes);
-
-        serializeCreatedElements(serializer, changeSetId, createdWays);
-        serializeModifiedElements(serializer, changeSetId, modifiedWays);
-
-        // if a newly created relation references deleted relations, they would need to be undeleted in a separate pass
-        serializeCreatedElements(serializer, changeSetId, createdRelations);
-        serializeModifiedElements(serializer, changeSetId, modifiedRelations);
-
-        // delete in opposite order
-        if (!deletedNodes.isEmpty() || !deletedWays.isEmpty() || !deletedRelations.isEmpty()) {
-            serializer.startTag(null, DELETE);
-            for (OsmElement elem : deletedRelations) {
-                elem.toXml(serializer, changeSetId);
-            }
-            for (OsmElement elem : deletedWays) {
-                elem.toXml(serializer, changeSetId);
-            }
-            for (OsmElement elem : deletedNodes) {
-                elem.toXml(serializer, changeSetId);
-            }
-            serializer.endTag(null, DELETE);
-        }
-
-        serializer.endTag(null, OSM_CHANGE);
-        serializer.endDocument();
+        return count;
     }
 
     /**
-     * Serialize a MODIFY section
+     * Serialize elements in an action section
      * 
      * @param <T> type of element to serialize
      * @param serializer the serializer
+     * @param action the action (CREATE, MODIFY, DELETE)
      * @param changeSetId the changeset id
-     * @param modifiedElements the list of elements
+     * @param elements the list of elements
      * @throws IOException if serializing fails
      */
-    private static <T extends OsmElement> void serializeModifiedElements(@NonNull XmlSerializer serializer, @NonNull Long changeSetId,
-            @NonNull List<T> modifiedElements) throws IOException {
-        if (!modifiedElements.isEmpty()) {
-            serializer.startTag(null, MODIFY);
-            for (OsmElement elem : modifiedElements) {
-                elem.toXml(serializer, changeSetId);
-            }
-            serializer.endTag(null, MODIFY);
+    private static <T extends OsmElement> void serializeElements(@NonNull XmlSerializer serializer, @NonNull String action, @Nullable Long changeSetId,
+            @NonNull List<T> elements) throws IOException {
+        if (elements.isEmpty()) {
+            return;
         }
-    }
-
-    /**
-     * Serialize a CREATE section
-     * 
-     * @param <T> type of element to serialize
-     * @param serializer the serializer
-     * @param changeSetId the changeset id
-     * @param createdElements the list of elements
-     * @throws IOException if serializing fails
-     */
-    private static <T extends OsmElement> void serializeCreatedElements(@NonNull XmlSerializer serializer, @NonNull Long changeSetId,
-            @NonNull List<T> createdElements) throws IOException {
-        if (!createdElements.isEmpty()) {
-            serializer.startTag(null, CREATE);
-            for (OsmElement elem : createdElements) {
-                elem.toXml(serializer, changeSetId);
-            }
-            serializer.endTag(null, CREATE);
+        serializer.startTag(null, action);
+        for (OsmElement elem : elements) {
+            elem.toXml(serializer, changeSetId);
         }
+        serializer.endTag(null, action);
     }
 
     /**
@@ -259,7 +223,7 @@ public final class OsmXml {
     }
 
     /**
-     * Writes currentStorage + deleted objects to an OutputStream in JOSM format.
+     * Writes currentStorage + deleted objects to an OutputStream in (J)OSM format.
      * 
      * Output is sorted as suggested by Jochen Topf
      * 
@@ -282,66 +246,273 @@ public final class OsmXml {
         serializer.attribute(null, VERSION, VERSION_0_6);
         serializer.attribute(null, JOSM_UPLOAD, TRUE);
 
-        /**
-         * Comparator to avoid unpleasant surprises when processing unsorted OSM data with osmium and tools based on it
-         */
-        final Comparator<OsmElement> sortItLikeJochen = (e1, e2) -> {
-            long id1 = e1.getOsmId();
-            long id2 = e2.getOsmId();
-            if ((id1 < 0 && id2 > 0) || (id1 > 0 && id2 < 0)) { // signs different
-                return Long.compare(id1, id2);
-            }
-            return Long.compare(Math.abs(id1), Math.abs(id2));
-        };
-
         List<Node> saveNodes = new ArrayList<>(current.getNodes());
         List<Way> saveWays = new ArrayList<>(current.getWays());
         List<Relation> saveRelations = new ArrayList<>(current.getRelations());
 
         if (api != null) {
-            for (Node elem : api.getNodes()) {
-                if (elem.state == OsmElement.STATE_DELETED) {
-                    saveNodes.add(elem);
-                }
-            }
-            for (Way elem : api.getWays()) {
-                if (elem.state == OsmElement.STATE_DELETED) {
-                    saveWays.add(elem);
-                }
-            }
-            for (Relation elem : api.getRelations()) {
-                if (elem.state == OsmElement.STATE_DELETED) {
-                    saveRelations.add(elem);
-                }
-            }
+            addDeleted(api.getNodes(), saveNodes);
+            addDeleted(api.getWays(), saveWays);
+            addDeleted(api.getRelations(), saveRelations);
         }
 
-        //
-        for (BoundingBox b : current.getBoundingBoxes()) {
-            b.toJosmXml(serializer);
-        }
+        josmSerializer(serializer, current.getBoundingBoxes());
 
         Collections.sort(saveNodes, sortItLikeJochen);
         Collections.sort(saveWays, sortItLikeJochen);
         Collections.sort(saveRelations, sortItLikeJochen);
 
-        if (!saveNodes.isEmpty()) {
-            for (OsmElement elem : saveNodes) {
-                elem.toJosmXml(serializer);
-            }
-        }
-        if (!saveWays.isEmpty()) {
-            for (OsmElement elem : saveWays) {
-                elem.toJosmXml(serializer);
-            }
-        }
-        if (!saveRelations.isEmpty()) {
-            for (OsmElement elem : saveRelations) {
-                elem.toJosmXml(serializer);
-            }
-        }
+        josmSerializer(serializer, saveNodes);
+        josmSerializer(serializer, saveWays);
+        josmSerializer(serializer, saveRelations);
 
         serializer.endTag(null, OSM);
         serializer.endDocument();
+    }
+
+    /**
+     * Add deleted OsmElements to a list
+     * 
+     * @param <E> the type of element
+     * @param apiElements all the elements of one type from the api storage
+     * @param elements the list to add to
+     */
+    private static <E extends OsmElement> void addDeleted(@NonNull List<E> apiElements, @NonNull List<E> elements) {
+        for (E elem : apiElements) {
+            if (elem.state == OsmElement.STATE_DELETED) {
+                elements.add(elem);
+            }
+        }
+    }
+
+    /**
+     * Serialize a list of OsmElements in (J)OSM format
+     * 
+     * @param serializer the Serializer
+     * @param elements the List of elements
+     * @throws IOException if serializing fails
+     */
+    private static <E extends JosmXmlSerializable> void josmSerializer(XmlSerializer serializer, List<E> elements) throws IOException {
+        if (!elements.isEmpty()) {
+            for (E elem : elements) {
+                elem.toJosmXml(serializer);
+            }
+        }
+    }
+
+    /**
+     * Writes created/changed/deleted data to outputStream in Augmented Diff format
+     * https://wiki.openstreetmap.org/wiki/Overpass_API/Augmented_Diffs
+     * 
+     * @param storage current storage, needed for indirectly affected objects
+     * @param apiStorage a Storage object with the changes
+     * @param undo current UndoStorage
+     * @param outputStream stream to write to
+     * @param generator a String for the generator attribute
+     * 
+     * @throws XmlPullParserException on a parser error
+     * @throws IllegalArgumentException on a parser error
+     * @throws IllegalStateException on a parser error
+     * @throws IOException if writing to the OutputStream fails
+     */
+    public static void writeAugmentedDiff(Storage storage, @NonNull Storage apiStorage, @NonNull UndoStorage undo, @NonNull OutputStream outputStream,
+            @NonNull String generator) throws IllegalArgumentException, IllegalStateException, IOException, XmlPullParserException {
+        XmlSerializer serializer = XmlPullParserFactory.newInstance().newSerializer();
+        serializer.setOutput(outputStream, UTF_8);
+        serializer.startDocument(UTF_8, null);
+        serializer.startTag(null, OSM_ADIFF);
+        serializer.attribute(null, VERSION, OSM_ADIFF_VERSION);
+        serializer.attribute(null, GENERATOR, generator);
+
+        List<Node> createdNodes = new ArrayList<>();
+        Map<Long, UndoNode> oldModifiedNodes = new HashMap<>();
+        LinkedHashSet<Node> modifiedNodes = new LinkedHashSet<>();
+        Map<Long, UndoNode> oldDeletedNodes = new HashMap<>();
+        List<Node> deletedNodes = new ArrayList<>();
+        List<Way> createdWays = new ArrayList<>();
+        Map<Long, UndoWay> oldModifiedWays = new HashMap<>();
+        LinkedHashSet<Way> modifiedWays = new LinkedHashSet<>();
+        Map<Long, UndoWay> oldDeletedWays = new HashMap<>();
+        List<Way> deletedWays = new ArrayList<>();
+        List<Relation> createdRelations = new ArrayList<>();
+        Map<Long, UndoRelation> oldModifiedRelations = new HashMap<>();
+        LinkedHashSet<Relation> modifiedRelations = new LinkedHashSet<>();
+        Map<Long, UndoRelation> oldDeletedRelations = new HashMap<>();
+        List<Relation> deletedRelations = new ArrayList<>();
+
+        fillAugmentedLists(apiStorage.getNodes(), undo, createdNodes, oldModifiedNodes, modifiedNodes, oldDeletedNodes, deletedNodes);
+        for (Node n : modifiedNodes) { // created and deleted nodes modified any parent ways
+            List<Way> waysForNode = storage.getWays(n);
+            modifiedWays.addAll(waysForNode);
+            for (Way w : waysForNode) {
+                addOriginal(undo, oldModifiedWays, w);
+            }
+            addParentRelations(modifiedRelations, oldModifiedRelations, undo, n);
+        }
+
+        fillAugmentedLists(apiStorage.getWays(), undo, createdWays, oldModifiedWays, modifiedWays, oldDeletedWays, deletedWays);
+        for (Way w : modifiedWays) {
+            addParentRelations(modifiedRelations, oldModifiedRelations, undo, w);
+        }
+
+        fillAugmentedLists(apiStorage.getRelations(), undo, createdRelations, oldModifiedRelations, modifiedRelations, oldDeletedRelations, deletedRelations);
+        for (Relation r : new ArrayList<>(modifiedRelations)) { // protect against CME
+            addParentRelations(modifiedRelations, oldModifiedRelations, undo, r);
+        }
+
+        List<Relation> tempModifiedRelations = new ArrayList<>(modifiedRelations);
+        sortRelations(createdRelations, tempModifiedRelations, deletedRelations);
+
+        augmentedSerializeElements(serializer, CREATE, null, createdNodes, undo);
+        augmentedSerializeElements(serializer, MODIFY, oldModifiedNodes, new ArrayList<>(modifiedNodes), undo);
+
+        augmentedSerializeElements(serializer, CREATE, null, createdWays, undo);
+        augmentedSerializeElements(serializer, MODIFY, oldModifiedWays, new ArrayList<>(modifiedWays), undo);
+
+        // if a newly created relation references deleted relations, they would need to be undeleted in a separate pass
+        augmentedSerializeElements(serializer, CREATE, null, createdRelations, undo);
+        augmentedSerializeElements(serializer, MODIFY, oldModifiedRelations, tempModifiedRelations, undo);
+
+        // delete in opposite order
+        augmentedSerializeElements(serializer, DELETE, oldDeletedRelations, deletedRelations, undo);
+        augmentedSerializeElements(serializer, DELETE, oldDeletedWays, deletedWays, undo);
+        augmentedSerializeElements(serializer, DELETE, oldDeletedNodes, deletedNodes, undo);
+
+        serializer.endTag(null, OSM_ADIFF);
+        serializer.endDocument();
+    }
+
+    /**
+     * Add modified relations from parent relations of a modified element
+     * 
+     * @param modifiedRelations list of modified relations
+     * @param oldModifiedRelations map holding old versions
+     * @param undo undo storage for those old versions
+     * @param e the element
+     */
+    private static void addParentRelations(@NonNull LinkedHashSet<Relation> modifiedRelations, @NonNull Map<Long, UndoRelation> oldModifiedRelations,
+            @NonNull UndoStorage undo, @NonNull OsmElement e) {
+        List<Relation> parents = e.getParentRelations();
+        if (parents != null && !modifiedRelations.contains(e)) {
+            for (Relation r : parents) {
+                modifiedRelations.add(r);
+                addOriginal(undo, oldModifiedRelations, r);
+            }
+        }
+    }
+
+    /**
+     * Sort relations lists
+     * 
+     * @param createdRelations list with created relations
+     * @param modifiedRelations list with modified relations
+     * @param deletedRelations list with deleted relations
+     */
+    private static void sortRelations(@NonNull List<Relation> createdRelations, @NonNull List<Relation> modifiedRelations,
+            @NonNull List<Relation> deletedRelations) {
+        // sort the relations so that children come first, will not handle loops and similar brokenness
+        if (!createdRelations.isEmpty()) {
+            Collections.sort(createdRelations, relationOrder);
+        }
+        if (!modifiedRelations.isEmpty()) {
+            Collections.sort(modifiedRelations, relationOrder);
+        }
+        if (!deletedRelations.isEmpty()) {
+            Collections.sort(deletedRelations, (r1, r2) -> {
+                if (r1.hasParentRelation(r2)) {
+                    return 1;
+                }
+                if (r2.hasParentRelation(r1)) {
+                    return -1;
+                }
+                return 0;
+            });
+        }
+    }
+
+    /**
+     * Files lists and maps for producing augmented diffs
+     * 
+     * @param storage the OsmElement Storage
+     * @param undo the current UndoStorage
+     * @param created list for create element
+     * @param oldModified map for initial version of modified elements
+     * @param modified list for modified elements
+     * @param oldDeleted map for initial version of deleted elements
+     * @param deleted list for deleted elements
+     */
+    private static <E extends OsmElement, U extends UndoElement> void fillAugmentedLists(@NonNull List<E> elements, @NonNull UndoStorage undo,
+            @NonNull List<E> created, @NonNull Map<Long, U> oldModified, @NonNull LinkedHashSet<E> modified, @NonNull Map<Long, U> oldDeleted,
+            @NonNull List<E> deleted) {
+        for (E elem : elements) {
+            Log.d(DEBUG_TAG, "element added to list for upload, id " + elem.getOsmId());
+            switch (elem.state) {
+            case OsmElement.STATE_CREATED:
+                created.add(elem);
+                break;
+            case OsmElement.STATE_MODIFIED:
+                addOriginal(undo, oldModified, elem);
+                modified.add(elem);
+                break;
+            case OsmElement.STATE_DELETED:
+                addOriginal(undo, oldDeleted, elem);
+                deleted.add(elem);
+                break;
+            default:
+                logNotModified(elem);
+                continue;
+            }
+        }
+    }
+
+    /**
+     * Retrieves the original version if any of the OsmElement elem and stores it in a Map
+     * 
+     * @param <U>
+     * @param <E>
+     * @param undo the UndoStorage
+     * @param originals map holding the original versions
+     * @param elem the OsmELement in question
+     */
+    @SuppressWarnings("unchecked")
+    private static <U extends UndoElement, E extends OsmElement> void addOriginal(@NonNull UndoStorage undo, @NonNull Map<Long, U> originals, @NonNull E elem) {
+        originals.put(elem.getOsmId(), (U) undo.getOriginal(elem));
+    }
+
+    /**
+     * Serialize a section for a specific action (CREATE, MODIFY, DELETE)
+     * 
+     * @param <T> type of element to serialize
+     * @param <U> type of undo element to serialize
+     * @param serializer the Serializer
+     * @param action the action
+     * @param oldElements map of old elements
+     * @param elements the list of elements
+     * @param undo current UndoStorage
+     * @throws IOException if serializing fails
+     */
+    private static <T extends OsmElement, U extends UndoElement> void augmentedSerializeElements(@NonNull XmlSerializer serializer, @NonNull String action,
+            @Nullable Map<Long, U> oldElements, @NonNull List<T> elements, @NonNull UndoStorage undo) throws IOException {
+        if (elements.isEmpty()) {
+            return;
+        }
+        for (OsmElement elem : elements) {
+            serializer.startTag(null, ACTION);
+            serializer.attribute(null, TYPE, action);
+            if (oldElements != null) {
+                serializer.startTag(null, OLD);
+                U undoElement = oldElements.get(elem.getOsmId());
+                if (undoElement != null) {
+                    undoElement.toAugmentedXml(serializer, true, undo);
+                } else { // unchanged "old"
+                    elem.toAugmentedXml(serializer, true, undo);
+                }
+                serializer.endTag(null, OLD);
+            }
+            serializer.startTag(null, NEW);
+            elem.toAugmentedXml(serializer, false, null);
+            serializer.endTag(null, NEW);
+            serializer.endTag(null, ACTION);
+        }
     }
 }

--- a/src/main/java/de/blau/android/osm/Relation.java
+++ b/src/main/java/de/blau/android/osm/Relation.java
@@ -29,14 +29,13 @@ import de.blau.android.validation.Validator;
  *
  */
 public class Relation extends StyledOsmElement implements RelationInterface, BoundedObject {
-    /**
-     * 
-     */
+
     private static final long serialVersionUID = 1104911642016294268L;
 
     private final List<RelationMember> members;
 
-    public static final String NAME = "relation";
+    public static final String NAME                = "relation";
+    static final String        AUGMENTED_DIFF_NAME = "rel";
 
     /**
      * Abbreviation
@@ -253,6 +252,34 @@ public class Relation extends StyledOsmElement implements RelationInterface, Bou
         s.endTag("", NAME);
     }
 
+    @Override
+    public void toAugmentedXml(XmlSerializer s, boolean original, UndoStorage undo) throws IllegalArgumentException, IllegalStateException, IOException {
+        s.startTag("", AUGMENTED_DIFF_NAME);
+        attributesToXml(s, null, false);
+        if (!isDeleted()) {
+            getBounds().toXml(s, null);
+            for (RelationMember member : members) {
+                s.startTag("", MEMBER_ATTR);
+                s.attribute("", MEMBER_TYPE_ATTR, member.getType());
+                s.attribute("", MEMBER_REF_ATTR, Long.toString(member.getRef()));
+                s.attribute("", MEMBER_ROLE_ATTR, member.getRole());
+                OsmElement e = member.getElement();
+                if (e instanceof Node) {
+                    GeoPoint p = (GeoPoint) (original && undo != null ? undo.getOriginal(e) : e);
+                    if (p == null) {
+                        p = (Node) e;
+                    }
+                    Node.coordToXmlAttr(s, p.getLat(), p.getLon());
+                } else if (e instanceof Way) {
+                    ((Way) e).wayNodesToAugmentedXml(s, original, undo);
+                }
+                s.endTag("", MEMBER_ATTR);
+            }
+            tagsToXml(s);
+        }
+        s.endTag("", AUGMENTED_DIFF_NAME);
+    }
+
     /**
      * Completely remove member from relation (even if present more than once) Does not update backlink
      * 
@@ -415,7 +442,6 @@ public class Relation extends StyledOsmElement implements RelationInterface, Bou
                 description = route + " " + description;
             }
             break;
-
         case Tags.VALUE_BOUNDARY:
             String b = getTagWithKey(Tags.KEY_BOUNDARY);
             if (b != null) {

--- a/src/main/java/de/blau/android/osm/StorageDelegator.java
+++ b/src/main/java/de/blau/android/osm/StorageDelegator.java
@@ -3495,6 +3495,18 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
     }
 
     /**
+     * Exports changes as an augmented diff file.
+     */
+    public void exportAugmentedDiff(OutputStream outputStream) throws Exception {
+        try {
+            lockReads();
+            OsmXml.writeAugmentedDiff(getCurrentStorage(), getApiStorage(), getUndo(), outputStream, App.getUserAgent());
+        } finally {
+            unlockReads();
+        }
+    }
+
+    /**
      * Merge additional data with existing, copy to a new storage because this may fail
      * 
      * This may throw an IllegalStateException if existing data was inconsistent

--- a/src/main/java/de/blau/android/osm/UndoStorage.java
+++ b/src/main/java/de/blau/android/osm/UndoStorage.java
@@ -2,6 +2,7 @@ package de.blau.android.osm;
 
 import static de.blau.android.contract.Constants.LOG_TAG_LEN;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -13,6 +14,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+
+import org.xmlpull.v1.XmlSerializer;
 
 import android.content.Context;
 import android.util.Log;
@@ -652,7 +655,7 @@ public class UndoStorage implements Serializable {
      * 
      * @author Jan
      */
-    public abstract class UndoElement implements OsmElementInterface, Serializable {
+    public abstract class UndoElement implements OsmElementInterface, Serializable, AugmentedXmlSerializable {
         private static final long serialVersionUID = 2L;
 
         final OsmElement element;
@@ -837,6 +840,17 @@ public class UndoStorage implements Serializable {
         public boolean wasInCurrentStorage() {
             return inCurrentStorage;
         }
+
+        /**
+         * Serialize the attributes to XML
+         * 
+         * @param s the Serializer
+         * @throws IOException
+         */
+        protected void attributesToXml(@NonNull final XmlSerializer s) throws IOException {
+            s.attribute("", OsmElement.ID_ATTR, Long.toString(osmId));
+            s.attribute("", OsmElement.VERSION_ATTR, Long.toString(osmVersion));
+        }
     }
 
     /**
@@ -890,6 +904,15 @@ public class UndoStorage implements Serializable {
         @Override
         public BoundingBox getBounds(Checkpoint checkpoint) {
             return new BoundingBox(getLon(), getLat());
+        }
+
+        @Override
+        public void toAugmentedXml(XmlSerializer s, boolean original, UndoStorage undo) throws IllegalArgumentException, IllegalStateException, IOException {
+            s.startTag("", Node.NAME);
+            attributesToXml(s);
+            Node.coordToXmlAttr(s, lat, lon);
+            OsmElement.tagsToXml(s, getTags());
+            s.endTag("", Node.NAME);
         }
     }
 
@@ -985,6 +1008,35 @@ public class UndoStorage implements Serializable {
         public BoundingBox getBounds(Checkpoint checkpoint) {
             return UndoStorage.getBounds(checkpoint, nodes);
         }
+
+        @Override
+        public void toAugmentedXml(XmlSerializer s, boolean original, UndoStorage undo) throws IllegalArgumentException, IllegalStateException, IOException {
+            s.startTag("", Way.NAME);
+            attributesToXml(s);
+            UndoStorage.this.getBounds(nodes).toXml(s, null);
+            wayNodesToAugmentedXml(s);
+            OsmElement.tagsToXml(s, getTags());
+            s.endTag("", Way.NAME);
+
+        }
+
+        /**
+         * @param s
+         * @throws IOException
+         */
+        public void wayNodesToAugmentedXml(XmlSerializer s) throws IOException {
+            for (Node node : nodes) {
+                s.startTag("", Way.NODE);
+                s.attribute("", Way.REF, Long.toString(node.getOsmId()));
+                UndoNode undoNode = (UndoNode) UndoStorage.this.getOriginal(node);
+                if (undoNode == null) {
+                    Node.coordToXmlAttr(s, node.getLat(), node.getLon());
+                } else {
+                    Node.coordToXmlAttr(s, undoNode.getLat(), undoNode.getLon());
+                }
+                s.endTag("", Way.NODE);
+            }
+        }
     }
 
     /**
@@ -1071,6 +1123,38 @@ public class UndoStorage implements Serializable {
         public BoundingBox getBounds(Checkpoint checkpoint) {
             return UndoStorage.getBounds(checkpoint, getMembers(), 1);
         }
+
+        @Override
+        public void toAugmentedXml(XmlSerializer s, boolean original, UndoStorage undo) throws IllegalArgumentException, IllegalStateException, IOException {
+            s.startTag("", Relation.AUGMENTED_DIFF_NAME);
+            attributesToXml(s);
+            UndoStorage.this.getBounds(members, 1).toXml(s, null);
+            for (RelationMember member : members) {
+                s.startTag("", Relation.MEMBER_ATTR);
+                s.attribute("", Relation.MEMBER_TYPE_ATTR, member.getType());
+                s.attribute("", Relation.MEMBER_REF_ATTR, Long.toString(member.getRef()));
+                s.attribute("", Relation.MEMBER_ROLE_ATTR, member.getRole());
+                OsmElement e = member.getElement();
+                UndoElement undoElement = UndoStorage.this.getOriginal(member.getType(), member.getRef());
+                if (Node.NAME.equals(member.getType())) {
+                    if (undoElement != null) {
+                        Node.coordToXmlAttr(s, ((UndoNode) undoElement).getLat(), ((UndoNode) undoElement).getLon());
+                    } else if (e != null) {// member has to be downloaded
+                        Node.coordToXmlAttr(s, ((Node) e).getLat(), ((Node) e).getLon());
+                    }
+                } else if (Way.NAME.equals(member.getType())) {
+                    if (undoElement != null) {
+                        ((UndoWay) undoElement).wayNodesToAugmentedXml(s);
+                    } else if (e != null) {// member has to be downloaded
+                        ((Way) e).wayNodesToAugmentedXml(s, true, UndoStorage.this);
+                    }
+                }
+                s.endTag("", Relation.MEMBER_ATTR);
+            }
+            OsmElement.tagsToXml(s, getTags());
+            s.endTag("", Relation.AUGMENTED_DIFF_NAME);
+
+        }
     }
 
     /**
@@ -1133,6 +1217,15 @@ public class UndoStorage implements Serializable {
         return null;
     }
 
+    @Nullable
+    public UndoElement getOriginal(@NonNull String elementName, long osmId) {
+        List<UndoElement> undoElements = getElements(undoCheckpoints, elementName, osmId);
+        if (!undoElements.isEmpty()) {
+            return undoElements.get(0);
+        }
+        return null;
+    }
+
     /**
      * Get a list of all UndoElements for a specific element
      * 
@@ -1170,6 +1263,27 @@ public class UndoStorage implements Serializable {
         for (Checkpoint checkpoint : checkpoints) {
             for (UndoElement undoElement : checkpoint.elements.values()) {
                 if (undoElement.element.getName().equals(name) && undoElement.osmId == osmId) {
+                    result.add(undoElement);
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Get a list of all UndoElements for a specific element
+     * 
+     * @param checkpoints list of checkpoints
+     * @param element the element
+     * @return a list of UndoElements empty if nothing found
+     */
+    @NonNull
+    private List<UndoElement> getElements(@NonNull LinkedList<Checkpoint> checkpoints, @NonNull String elementName, long osmId) {
+        List<UndoElement> result = new ArrayList<>();
+        for (Checkpoint checkpoint : checkpoints) {
+            for (UndoElement undoElement : checkpoint.elements.values()) {
+                if (undoElement.element.getName().equals(elementName) && undoElement.osmId == osmId) {
                     result.add(undoElement);
                     break;
                 }
@@ -1240,26 +1354,75 @@ public class UndoStorage implements Serializable {
     private static BoundingBox getBounds(@NonNull Checkpoint checkpoint, @NonNull List<RelationMember> members, int depth) {
         // NOTE this will only return a bb covering the downloaded elements
         BoundingBox result = null;
+        if (depth > Relation.MAX_DEPTH) {
+            Log.e(DEBUG_TAG, "getBounds relation nested too deep");
+            return null;
+        }
+        for (RelationMember rm : members) {
+            OsmElement e = rm.getElement();
+            UndoElement ue = checkpoint.elements.get(e);
+            BoundingBox box = null;
+            if (ue != null) {
+                if (ue instanceof UndoRelation) {
+                    box = getBounds(checkpoint, ((UndoRelation) ue).getMembers(), depth + 1);
+                } else if (ue instanceof UndoWay) {
+                    box = getBounds(checkpoint, ((UndoWay) ue).nodes);
+                } else {
+                    box = ue.getBounds(checkpoint);
+                }
+            } else if (e != null) {
+                if (e instanceof Relation) {
+                    box = getBounds(checkpoint, ((Relation) e).getMembers(), depth + 1);
+                } else if (e instanceof Way) {
+                    box = getBounds(checkpoint, ((Way) e).getNodes());
+                } else {
+                    box = e.getBounds();
+                }
+            }
+            if (box == null) {
+                continue;
+            }
+            if (result == null) {
+                result = box;
+            } else {
+                if (box != null) {
+                    result.union(box);
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Return a bounding box covering the relation with loop protection
+     * 
+     * This will stop when depth > MAX_DEPTH, the method attempts to use the original version of the members
+     * 
+     * @param checkpoint the current Checkpoint holding the element
+     * @param members the relation members
+     * @param depth current depth in the tree we are at
+     * @return the BoundingBox or null if it cannot be determined
+     */
+    @Nullable
+    private BoundingBox getBounds(@NonNull List<RelationMember> members, int depth) {
+        // NOTE this will only return a bb covering the downloaded elements
+        BoundingBox result = null;
         if (depth <= Relation.MAX_DEPTH) {
             for (RelationMember rm : members) {
                 OsmElement e = rm.getElement();
-                UndoElement ue = checkpoint.elements.get(e);
+                UndoElement ue = getOriginal(rm.getType(), rm.getRef());
                 BoundingBox box = null;
                 if (ue != null) {
                     if (ue instanceof UndoRelation) {
-                        box = getBounds(checkpoint, ((UndoRelation) ue).getMembers(), depth + 1);
+                        box = getBounds(((UndoRelation) ue).getMembers(), depth + 1);
                     } else if (ue instanceof UndoWay) {
-                        box = getBounds(checkpoint, ((UndoWay) ue).nodes);
-                    } else {
-                        box = ue.getBounds(checkpoint);
+                        box = getBounds(((UndoWay) ue).nodes);
                     }
                 } else if (e != null) {
                     if (e instanceof Relation) {
-                        box = getBounds(checkpoint, ((Relation) e).getMembers(), depth + 1);
+                        box = getBounds(((Relation) e).getMembers(), depth + 1);
                     } else if (e instanceof Way) {
-                        box = getBounds(checkpoint, ((Way) e).getNodes());
-                    } else {
-                        box = e.getBounds();
+                        box = getBounds(((Way) e).getNodes());
                     }
                 }
                 if (box != null) {
@@ -1279,7 +1442,7 @@ public class UndoStorage implements Serializable {
     }
 
     /**
-     * Return a bounding box covering a way
+     * Return a bounding box covering a list of nodes
      * 
      * The method tries to use any node that is contained in the Checkpoint, if this is not the top checkpoint and the
      * way contains nodes that were changed in later checkpoints the result will be incorrect.
@@ -1293,6 +1456,37 @@ public class UndoStorage implements Serializable {
         BoundingBox result = null;
         for (Node n : nodes) {
             UndoNode un = (UndoNode) checkpoint.elements.get(n);
+            if (un == null) {
+                if (result == null) {
+                    result = new BoundingBox(n.getLon(), n.getLat());
+                } else {
+                    result.union(n.getLon(), n.getLat());
+                }
+            } else {
+                if (result == null) {
+                    result = new BoundingBox(un.getLon(), un.getLat());
+                } else {
+                    result.union(un.getLon(), un.getLat());
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Return a bounding box covering a list of nodes
+     * 
+     * The method uses the original nodes
+     * 
+     * @param checkpoint the current Checkpoint holding the way
+     * @param nodes the list of way nodes
+     * @return the BoundingBox or null (for a degenerate Way with no nodes)
+     */
+    @Nullable
+    public BoundingBox getBounds(@NonNull List<Node> nodes) {
+        BoundingBox result = null;
+        for (Node n : nodes) {
+            UndoNode un = (UndoNode) getOriginal(n);
             if (un == null) {
                 if (result == null) {
                     result = new BoundingBox(n.getLon(), n.getLat());

--- a/src/main/java/de/blau/android/osm/Way.java
+++ b/src/main/java/de/blau/android/osm/Way.java
@@ -18,6 +18,7 @@ import com.github.micycle1.clipper2.core.Point64;
 import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import de.blau.android.osm.UndoStorage.UndoNode;
 import de.blau.android.util.GeoMath;
 import de.blau.android.util.Geometry;
 import de.blau.android.util.rtree.BoundedObject;
@@ -147,20 +148,60 @@ public class Way extends StyledOsmElement implements WayInterface, BoundedObject
      */
     private void toXml(@NonNull final XmlSerializer s, @Nullable Long changeSetId, boolean josm)
             throws IllegalArgumentException, IllegalStateException, IOException {
+        checkForNodes();
         s.startTag("", NAME);
         attributesToXml(s, changeSetId, josm);
-        if (nodes != null) {
-            for (Node node : nodes) {
-                s.startTag("", NODE);
-                s.attribute("", REF, Long.toString(node.getOsmId()));
-                s.endTag("", NODE);
-            }
-        } else {
-            Log.i(DEBUG_TAG, "Way without nodes");
-            throw new IllegalArgumentException("Way " + getOsmId() + " has no nodes");
+        for (Node node : nodes) {
+            s.startTag("", NODE);
+            s.attribute("", REF, Long.toString(node.getOsmId()));
+            s.endTag("", NODE);
         }
         tagsToXml(s);
         s.endTag("", NAME);
+    }
+
+    /**
+     * Check if we have nodes, else throw an exception
+     */
+    private void checkForNodes() {
+        if (nodes == null) {
+            Log.i(DEBUG_TAG, "Way without nodes");
+            throw new IllegalArgumentException("Way " + getOsmId() + " has no nodes");
+        }
+    }
+
+    @Override
+    public void toAugmentedXml(XmlSerializer s, boolean original, UndoStorage undo) throws IllegalArgumentException, IllegalStateException, IOException {
+        checkForNodes();
+        s.startTag("", NAME);
+        attributesToXml(s, null, false);
+        if (!isDeleted()) {
+            getBounds().toXml(s, null);
+            wayNodesToAugmentedXml(s, original, undo);
+            tagsToXml(s);
+        }
+        s.endTag("", NAME);
+    }
+
+    /**
+     * Outptu way nodes in augemented diff format
+     * 
+     * @param s the serializer
+     * @param original if true try to output the original coords
+     * @param undo UndoStorage instance for when original is true
+     * @throws IOException is serializing fails
+     */
+    public void wayNodesToAugmentedXml(@NonNull XmlSerializer s, boolean original, UndoStorage undo) throws IOException {
+        for (Node node : nodes) {
+            s.startTag("", NODE);
+            s.attribute("", REF, Long.toString(node.getOsmId()));
+            GeoPoint point = original && undo != null ? (UndoNode) undo.getOriginal(node) : node;
+            if (point == null) {
+                point = node;
+            }
+            Node.coordToXmlAttr(s, point.getLat(), point.getLon());
+            s.endTag("", NODE);
+        }
     }
 
     /**

--- a/src/main/res/menu-v24/main_menu_nosubmenus.xml
+++ b/src/main/res/menu-v24/main_menu_nosubmenus.xml
@@ -111,6 +111,9 @@
                 android:id="@+id/menu_transfer_apply_osc_file"
                 android:title="@string/menu_transfer_apply_osc_file" />
             <item
+                android:id="@+id/menu_transfer_export_augmented_diff"
+                android:title="@string/menu_transfer_export_augmented_diff" />
+            <item
                 android:id="@+id/menu_transfer_save_file"
                 android:title="@string/menu_transfer_save_file" />
             <item

--- a/src/main/res/menu/main_menu.xml
+++ b/src/main/res/menu/main_menu.xml
@@ -113,6 +113,9 @@
                         android:id="@+id/menu_transfer_apply_osc_file"
                         android:title="@string/menu_transfer_apply_osc_file" />
                     <item
+                        android:id="@+id/menu_transfer_export_augmented_diff"
+                        android:title="@string/menu_transfer_export_augmented_diff" />
+                    <item
                         android:id="@+id/menu_transfer_save_file"
                         android:title="@string/menu_transfer_save_file" />
                     <item

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1167,6 +1167,7 @@
     <string name="menu_transfer_file">File…</string>
     <string name="menu_transfer_export">Export changes to OSC file</string>
     <string name="menu_transfer_apply_osc_file">Apply changes from OSC file</string>
+    <string name="menu_transfer_export_augmented_diff">Export changes to Augmented Diff file</string>
     <string name="menu_transfer_read_file">Read from JOSM file…</string>
     <string name="menu_transfer_read_pbf_file">Read from PBF file</string>
     <string name="menu_transfer_save_file">Save to JOSM file…</string>


### PR DESCRIPTION
Support saving and reading changes in augmented diff format

Points to note:

- ~~we currently do not propagate geometry changes to otherwise unchanged
parent elements (ways and relations). This will be an option.~~

- element attributes that we currently don't store, aka user and changeset id, are
not included in the output.

Together with code to read the diffs this could potentially resolve
https://github.com/MarcusWolschon/osmeditor4android/issues/2939