### PR TITLE
Improve locking in logic

### DIFF
--- a/src/androidTest/java/de/blau/android/ModeTest.java
+++ b/src/androidTest/java/de/blau/android/ModeTest.java
@@ -75,7 +75,7 @@ public class ModeTest {
     public void lock() {
         UiObject lock = TestUtils.getLock(device);
 
-        logic.setLocked(true);
+        logic.setUiLocked(true);
         logic.setZoom(main.getMap(), 20);
         main.getMap().invalidate();
         main.runOnUiThread(new Runnable() {
@@ -88,7 +88,7 @@ public class ModeTest {
         device.waitForIdle();
         UiObject map = device.findObject(new UiSelector().resourceId(device.getCurrentPackageName() + ":id/map_view"));
         assertTrue(map.exists());
-        assertTrue(logic.isLocked());
+        assertTrue(logic.isUiLocked());
         try {
             assertTrue(!lock.isSelected());
         } catch (UiObjectNotFoundException e1) {
@@ -113,7 +113,7 @@ public class ModeTest {
         } catch (UiObjectNotFoundException e) {
             fail(e.getMessage());
         }
-        assertTrue(!logic.isLocked());
+        assertTrue(!logic.isUiLocked());
 
         assertEquals(Mode.MODE_EASYEDIT, logic.getMode()); // start with this and cycle through the modes
 

--- a/src/androidTest/java/de/blau/android/TestUtils.java
+++ b/src/androidTest/java/de/blau/android/TestUtils.java
@@ -567,7 +567,7 @@ public final class TestUtils {
      * @param device the UiDevice
      */
     public static void unlock(@NonNull UiDevice device) {
-        if (App.getLogic().isLocked()) {
+        if (App.getLogic().isUiLocked()) {
             clickOnLock(device);
         }
     }
@@ -594,7 +594,7 @@ public final class TestUtils {
      * @param device the UiDevice
      */
     public static void lock(@NonNull UiDevice device) {
-        if (!App.getLogic().isLocked()) {
+        if (!App.getLogic().isUiLocked()) {
             clickOnLock(device);
         }
     }

--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -692,7 +692,7 @@ public class Logic {
      * @param stringId the resource id of the string representing the checkpoint name
      */
     public void createCheckpoint(@Nullable Activity activity, int stringId) {
-        Resources r = activity != null ? activity.getResources() : App.resources();
+        Resources r = getResources(activity);
         final UndoStorage undo = getDelegator().getUndo();
         boolean firstCheckpoint = !undo.canUndo();
         undo.createCheckpoint(r.getString(stringId), getSelectedIds());
@@ -700,6 +700,16 @@ public class Logic {
         if (firstCheckpoint && activity instanceof AppCompatActivity) {
             ((AppCompatActivity) activity).invalidateOptionsMenu();
         }
+    }
+
+    /**
+     * Get resources for this app
+     * 
+     * @param context a potentially null Android context
+     * @return Resrources
+     */
+    private Resources getResources(@Nullable Context context) {
+        return context != null ? context.getResources() : App.resources();
     }
 
     /**
@@ -720,7 +730,7 @@ public class Logic {
      * @param force if true remove even if not empty
      */
     public void removeCheckpoint(@Nullable Activity activity, int stringId, boolean force) {
-        Resources r = activity != null ? activity.getResources() : App.resources();
+        Resources r = getResources(activity);
         getDelegator().getUndo().removeCheckpoint(r.getString(stringId), force);
     }
 
@@ -1572,7 +1582,6 @@ public class Logic {
         try {
             lock();
             final Selection currentSelection = selectionStack.getFirst();
-
             if (draggingNode || draggingWay || draggingHandle || draggingNote) {
                 int lat = yToLatE7(absoluteY);
                 int lon = xToLonE7(absoluteX);

--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -313,7 +313,7 @@ public class Logic {
     /**
      * Screen locked or not
      */
-    private boolean locked;
+    private boolean uiLocked;
 
     /**
      * The viewBox for the map. All changes on this Object are made in here or in {@link Tracker}.
@@ -364,7 +364,7 @@ public class Logic {
     Logic() {
         viewBox = new ViewBox(getDelegator().getLastBox());
         mode = Mode.MODE_EASYEDIT;
-        setLocked(true);
+        setUiLocked(true);
         executorService = Executors.newFixedThreadPool(EXECUTOR_THREADS);
         uiHandler = new Handler(Looper.getMainLooper());
         selectionStack = new ArrayDeque<>();
@@ -416,15 +416,15 @@ public class Logic {
     /**
      * @return locked status
      */
-    public boolean isLocked() {
-        return locked;
+    public boolean isUiLocked() {
+        return uiLocked;
     }
 
     /**
      * @param locked set locked status
      */
-    public void setLocked(boolean locked) {
-        this.locked = locked;
+    public void setUiLocked(boolean locked) {
+        this.uiLocked = locked;
     }
 
     /**
@@ -1372,7 +1372,7 @@ public class Logic {
         draggingHandle = false;
         draggingNote = false;
         draggedNode = null;
-        if (!isLocked() && isInEditZoomRange() && mode.elementsGeomEditable()) {
+        if (!isUiLocked() && isInEditZoomRange() && mode.elementsGeomEditable()) {
             if (activity instanceof Main && !((Main) activity).getEasyEditManager().draggingEnabled()) {
                 // dragging is currently only supported in element selection modes
                 return;

--- a/src/main/java/de/blau/android/Main.java
+++ b/src/main/java/de/blau/android/Main.java
@@ -1392,7 +1392,7 @@ public class Main extends ConfigurationChangeAwareActivity
             selectElements(logic, storageDelegator, Way.NAME, rcData.getWays());
             selectElements(logic, storageDelegator, Relation.NAME, rcData.getRelations());
             FloatingActionButton lock = getLock();
-            if (logic.isLocked() && lock != null) {
+            if (logic.isUiLocked() && lock != null) {
                 lock.performClick();
             }
             if (easyEditManager != null) {
@@ -1703,10 +1703,10 @@ public class Main extends ConfigurationChangeAwareActivity
             if (drawableState.length == 0 || drawableState[0] != android.R.attr.state_pressed) {
                 logic.setMode(Main.this, Mode.modeForTag((String) b.getTag()));
                 ((FloatingActionButton) b).setImageState(new int[] { android.R.attr.state_pressed }, false);
-                logic.setLocked(false);
+                logic.setUiLocked(false);
                 enableSimpleActionsButton();
             } else {
-                logic.setLocked(true);
+                logic.setUiLocked(true);
                 ((FloatingActionButton) b).setImageState(new int[] { 0 }, false);
                 disableSimpleActionsButton();
             }
@@ -1760,7 +1760,7 @@ public class Main extends ConfigurationChangeAwareActivity
             lock.setImageDrawable(mStates);
             lock.hide(); // workaround https://issuetracker.google.com/issues/117476935
             lock.show();
-            if (l.isLocked()) {
+            if (l.isUiLocked()) {
                 lock.setImageState(new int[] { 0 }, false);
             } else {
                 lock.setImageState(new int[] { android.R.attr.state_pressed }, false);
@@ -1774,7 +1774,7 @@ public class Main extends ConfigurationChangeAwareActivity
      * Unlock the main display
      */
     public void unlock() {
-        if (App.getLogic().isLocked()) {
+        if (App.getLogic().isUiLocked()) {
             getLock().performClick();
         }
     }
@@ -1803,7 +1803,7 @@ public class Main extends ConfigurationChangeAwareActivity
             return null;
         }
         Logic logic = App.getLogic();
-        if (logic.isLocked()) {
+        if (logic.isUiLocked()) {
             lock.setImageState(new int[] { 0 }, false);
             disableSimpleActionsButton();
         } else {
@@ -1903,7 +1903,7 @@ public class Main extends ConfigurationChangeAwareActivity
         final Logic logic = App.getLogic();
         MenuItem undo = menu.findItem(R.id.menu_undo);
         UndoStorage undoStorage = logic.getUndo();
-        undo.setVisible(!logic.isLocked() && (undoStorage.canUndo() || undoStorage.canRedo()));
+        undo.setVisible(!logic.isUiLocked() && (undoStorage.canUndo() || undoStorage.canRedo()));
         View undoView = undo.getActionView();
         undoView.setOnClickListener(undoListener);
         undoView.setOnLongClickListener(undoListener);
@@ -1947,7 +1947,7 @@ public class Main extends ConfigurationChangeAwareActivity
         menu.findItem(R.id.menu_transfer_save_notes_new_and_changed).setEnabled(storagePermissionGranted);
 
         // main menu items
-        menu.findItem(R.id.menu_search_objects).setEnabled(!logic.isLocked());
+        menu.findItem(R.id.menu_search_objects).setEnabled(!logic.isUiLocked());
 
         Filter filter = logic.getFilter();
         if (filter instanceof TagFilter && !prefs.getEnableTagFilter()) {
@@ -3688,7 +3688,7 @@ public class Main extends ConfigurationChangeAwareActivity
             boolean isInEditZoomRange = logic.isInEditZoomRange();
 
             if (isInEditZoomRange) {
-                if (logic.isLocked()) {
+                if (logic.isUiLocked()) {
                     ScreenMessage.toastTopInfo(Main.this, R.string.toast_unlock_to_edit);
                     Tip.showOptionalDialog(Main.this, R.string.tip_locked_mode_key, R.string.tip_locked_mode);
                 } else {
@@ -3700,7 +3700,7 @@ public class Main extends ConfigurationChangeAwareActivity
             } else {
                 switch (clickedObjects.size()) {
                 case 0:
-                    if (!logic.isLocked()) {
+                    if (!logic.isUiLocked()) {
                         ScreenMessage.toastTopInfo(Main.this, R.string.toast_not_in_edit_range);
                     }
                     break;
@@ -3727,7 +3727,7 @@ public class Main extends ConfigurationChangeAwareActivity
             final Logic logic = App.getLogic();
             clickedNodesAndWays = getClickedOsmElements(logic, x, y);
             int elementCount = clickedNodesAndWays.size();
-            if (logic.isLocked()) {
+            if (logic.isUiLocked()) {
                 // display context menu
                 getClickedObjects(x, y);
                 int clickedObjectsCount = clickedObjects.size();
@@ -4008,7 +4008,7 @@ public class Main extends ConfigurationChangeAwareActivity
                 return;
             }
             final OsmElement element = clickedNodesAndWays.get(itemId);
-            if (App.getLogic().isLocked()) {
+            if (App.getLogic().isUiLocked()) {
                 ElementInfo.showDialog(Main.this, element);
                 return;
             }
@@ -4036,7 +4036,7 @@ public class Main extends ConfigurationChangeAwareActivity
         @Override
         public void onDoubleTap(View v, float x, float y) {
             final Logic logic = App.getLogic();
-            if (logic.isLocked()) {
+            if (logic.isUiLocked()) {
                 ScreenMessage.toastTopInfo(Main.this, R.string.toast_unlock_to_edit);
                 return;
             }
@@ -4648,7 +4648,7 @@ public class Main extends ConfigurationChangeAwareActivity
      * Lock screen if we are in a mode in which that can reasonably be done
      */
     public void lock() {
-        if (App.getLogic().isLocked()) {
+        if (App.getLogic().isUiLocked()) {
             return;
         }
         EasyEditManager manager = getEasyEditManager();

--- a/src/main/java/de/blau/android/Main.java
+++ b/src/main/java/de/blau/android/Main.java
@@ -3661,13 +3661,14 @@ public class Main extends ConfigurationChangeAwareActivity
         @Override
         public boolean onTouch(final View v, final MotionEvent m) {
             descheduleAutoLock();
+            final Logic logic = App.getLogic();
             if (m.getAction() == MotionEvent.ACTION_DOWN) {
                 clickedObjects.clear();
                 clickedNodesAndWays = null;
-                App.getLogic().handleTouchEventDown(Main.this, m.getX(), m.getY());
+                logic.handleTouchEventDown(Main.this, m.getX(), m.getY());
             }
             if (m.getAction() == MotionEvent.ACTION_UP) {
-                App.getLogic().handleTouchEventUp(m.getX(), m.getY());
+                logic.handleTouchEventUp(m.getX(), m.getY());
                 scheduleAutoLock();
             }
             if (!v.onTouchEvent(m)) { // give any layer specific handlers a chance
@@ -3683,11 +3684,11 @@ public class Main extends ConfigurationChangeAwareActivity
 
         @Override
         public void onClick(View v, float x, float y) {
-            if (App.getLogic().getClickableElements() == null && !getEasyEditManager().elementsOnly()) {
+            final Logic logic = App.getLogic();
+            if (logic.getClickableElements() == null && !getEasyEditManager().elementsOnly()) {
                 getClickedObjects(x, y);
             }
 
-            final Logic logic = App.getLogic();
             Mode mode = logic.getMode();
             boolean isInEditZoomRange = logic.isInEditZoomRange();
 

--- a/src/main/java/de/blau/android/Map.java
+++ b/src/main/java/de/blau/android/Map.java
@@ -700,7 +700,7 @@ public class Map extends SurfaceView implements IMapView {
 
         final Logic logic = App.getLogic();
         boolean imageryAlignMode = logic.getMode() == Mode.MODE_ALIGN_BACKGROUND;
-        if (zoomLevel > STORAGE_BOX_LIMIT && !imageryAlignMode && (!logic.isLocked() || alwaysDrawBoundingBoxes)) {
+        if (zoomLevel > STORAGE_BOX_LIMIT && !imageryAlignMode && (!logic.isUiLocked() || alwaysDrawBoundingBoxes)) {
             de.blau.android.layer.data.MapOverlay<OsmElement> dataLayer = getDataLayer();
             if (dataLayer != null && dataLayer.isVisible()) {
                 paintStorageBox(canvas, dataLayer.getDownloadedBoxes());

--- a/src/main/java/de/blau/android/NearbyPoiUpdateListener.java
+++ b/src/main/java/de/blau/android/NearbyPoiUpdateListener.java
@@ -15,6 +15,7 @@ import de.blau.android.layer.UpdateInterface;
 import de.blau.android.osm.Node;
 import de.blau.android.osm.OsmElement;
 import de.blau.android.osm.Relation;
+import de.blau.android.osm.StorageDelegator;
 import de.blau.android.osm.Way;
 import de.blau.android.util.Screen;
 import de.blau.android.util.collections.LowAllocArrayList;
@@ -64,18 +65,23 @@ public class NearbyPoiUpdateListener<E> implements UpdateInterface.OnUpdateListe
         withoutFilter = (OsmElement e, Filter filter) -> e.hasTagKey(defaultKeys);
 
         display = () -> {
-            all.clear();
-            final Filter filter = App.getLogic().getFilter();
-            filterElements(all, nodes, filter);
-            filterElements(all, ways, filter != null);
-            filterElements(all, relations, filter != null);
-            final double[] center = map.getViewBox().getCenter();
-            final int[] loc = new int[] { (int) (center[1] * 1E7), (int) (center[0] * 1E7) };
-            synchronized (App.getDelegator()) {
-                Collections.sort(all, (OsmElement e1, OsmElement e2) -> Double.compare(e1.getMinDistance(loc), e2.getMinDistance(loc)));
+            StorageDelegator delegator = App.getDelegator();
+            try {
+                if (delegator.tryLock()) {
+                    all.clear();
+                    final Filter filter = App.getLogic().getFilter();
+                    filterElements(all, nodes, filter);
+                    filterElements(all, ways, filter != null);
+                    filterElements(all, relations, filter != null);
+                    final double[] center = map.getViewBox().getCenter();
+                    final int[] loc = new int[] { (int) (center[1] * 1E7), (int) (center[0] * 1E7) };
+                    Collections.sort(all, (OsmElement e1, OsmElement e2) -> Double.compare(e1.getMinDistance(loc), e2.getMinDistance(loc)));
+                    layout.getAdapter().notifyDataSetChanged();
+                    updates = 0;
+                }
+            } finally {
+                delegator.unlock();
             }
-            layout.getAdapter().notifyDataSetChanged();
-            updates = 0;
         };
     }
 

--- a/src/main/java/de/blau/android/PoiListAdapter.java
+++ b/src/main/java/de/blau/android/PoiListAdapter.java
@@ -86,7 +86,7 @@ public class PoiListAdapter extends RecyclerView.Adapter<PoiListAdapter.PoiViewH
             map.getViewBox().moveTo(map, (int) (elementCenter[0] * 1E7D), (int) (elementCenter[1] * 1E7D));
             if (ctx instanceof Main) {
                 final Main main = (Main) ctx;
-                if (App.getLogic().isLocked()) {
+                if (App.getLogic().isUiLocked()) {
                     map.invalidate();
                     ElementInfo.showDialog(main, element);
                 } else {

--- a/src/main/java/de/blau/android/layer/data/MapOverlay.java
+++ b/src/main/java/de/blau/android/layer/data/MapOverlay.java
@@ -471,11 +471,17 @@ public class MapOverlay<O extends OsmElement> extends NonSerializeableLayer
         final Logic logic = App.getLogic();
         tmpDrawingEditMode = logic.getMode();
         tmpFilter = logic.getFilter();
-        tmpDrawingSelectedNodes = logic.getSelectedNodes();
-        tmpDrawingSelectedWays = logic.getSelectedWays();
-        tmpClickableElements = logic.getClickableElements();
-        tmpDrawingSelectedRelationWays = logic.getSelectedRelationWays();
-        tmpDrawingSelectedRelationNodes = logic.getSelectedRelationNodes();
+        try {
+            if (logic.tryLock()) {
+                tmpDrawingSelectedNodes = logic.getSelectedNodes();
+                tmpDrawingSelectedWays = logic.getSelectedWays();
+                tmpClickableElements = logic.getClickableElements();
+                tmpDrawingSelectedRelationWays = logic.getSelectedRelationWays();
+                tmpDrawingSelectedRelationNodes = logic.getSelectedRelationNodes();
+            }
+        } finally {
+            logic.unlock();
+        }
         tmpPresets = App.getCurrentPresets(context);
         tmpLocked = logic.isUiLocked();
 

--- a/src/main/java/de/blau/android/layer/data/MapOverlay.java
+++ b/src/main/java/de/blau/android/layer/data/MapOverlay.java
@@ -477,7 +477,7 @@ public class MapOverlay<O extends OsmElement> extends NonSerializeableLayer
         tmpDrawingSelectedRelationWays = logic.getSelectedRelationWays();
         tmpDrawingSelectedRelationNodes = logic.getSelectedRelationNodes();
         tmpPresets = App.getCurrentPresets(context);
-        tmpLocked = logic.isLocked();
+        tmpLocked = logic.isUiLocked();
 
         currentStyle = styles.getCurrent();
 

--- a/src/main/java/de/blau/android/osm/StorageDelegator.java
+++ b/src/main/java/de/blau/android/osm/StorageDelegator.java
@@ -3838,12 +3838,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
      */
     @Override
     public void prune(@NonNull BoundingBox box) {
-        try {
-            lock();
-            prune(App.getLogic(), box);
-        } finally {
-            unlock();
-        }
+        prune(App.getLogic(), box);
     }
 
     /**

--- a/src/main/java/de/blau/android/util/EditState.java
+++ b/src/main/java/de/blau/android/util/EditState.java
@@ -64,7 +64,7 @@ public class EditState implements Serializable {
      * @param changesetId the current changeset id (or -1)
      */
     public EditState(@NonNull Main main, @NonNull Logic logic, @Nullable String imageFileName, @NonNull BoundingBox box, boolean followGPS, long changesetId) {
-        savedLocked = logic.isLocked();
+        savedLocked = logic.isUiLocked();
         savedMode = logic.getMode();
         savedSelection = new ArrayList<>();
         for (Selection selection : logic.getSelectionStack()) {
@@ -112,7 +112,7 @@ public class EditState implements Serializable {
      * @param logic the current Logic instance
      */
     public void setSelected(@NonNull Main main, @NonNull Logic logic) {
-        logic.setLocked(savedLocked);
+        logic.setUiLocked(savedLocked);
         logic.setMode(main, savedMode);
         Log.d(DEBUG_TAG, "savedMode " + savedMode);
         Deque<Selection> selectionStack = new ArrayDeque<>();

--- a/src/main/java/de/blau/android/util/SavingHelper.java
+++ b/src/main/java/de/blau/android/util/SavingHelper.java
@@ -68,7 +68,7 @@ public class SavingHelper<T extends Serializable> {
      *            ignored
      * @return true if successful, false if saving failed for some reason
      */
-    public synchronized boolean save(@NonNull Context context, @NonNull String filename, @NonNull T object, boolean compress) {
+    public boolean save(@NonNull Context context, @NonNull String filename, @NonNull T object, boolean compress) {
         return save(context, filename, object, compress, false);
     }
 


### PR DESCRIPTION
There are some ANRs caused by lock contention getting selected elements and layer management in particular saving the layer state (which can be quite slow).

The PR simply replaces the use of synchronized in Logic with an ReentrantLock, this however could probably be substantially more fine grained. 

This is currently still buggy and will deadlock quickly.