### PR TITLE
Catch exceptions thrown by foreground service start up

### DIFF
--- a/src/main/java/de/blau/android/services/TrackerService.java
+++ b/src/main/java/de/blau/android/services/TrackerService.java
@@ -361,9 +361,7 @@ public class TrackerService extends Service {
      * this.
      */
     public void startTracking() {
-        Intent intent = new Intent(this, TrackerService.class);
-        intent.putExtra(TRACK_KEY, true);
-        startService(intent);
+        startService(TRACK_KEY);
     }
 
     /**
@@ -372,9 +370,7 @@ public class TrackerService extends Service {
      * this.
      */
     public void startAutoDownload() {
-        Intent intent = new Intent(this, TrackerService.class);
-        intent.putExtra(AUTODOWNLOAD_KEY, true);
-        startService(intent);
+        startService(AUTODOWNLOAD_KEY);
     }
 
     /**
@@ -383,9 +379,24 @@ public class TrackerService extends Service {
      * this.
      */
     public void startBugAutoDownload() {
+        startService(BUGAUTODOWNLOAD_KEY);
+    }
+
+    /**
+     * Create the Intent and start the foreground service
+     * 
+     * @param key the key indicating which service to start
+     * 
+     */
+    private void startService(@NonNull String key) {
         Intent intent = new Intent(this, TrackerService.class);
-        intent.putExtra(BUGAUTODOWNLOAD_KEY, true);
-        startService(intent);
+        intent.putExtra(key, true);
+        try {
+            ContextCompat.startForegroundService(this, intent);
+        } catch (IllegalStateException | SecurityException ex) {
+            Log.e(DEBUG_TAG, "Can't start service " + ex.getMessage());
+            ScreenMessage.toastTopError(this, getString(R.string.gps_service_start_failure, ex.getLocalizedMessage()));
+        }
     }
 
     /**

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1655,6 +1655,7 @@
     <string name="tracking_active_text">Recording a GPS track or auto-downloading</string>
     <string name="tracking_long_text">Vespucci is recording a GPX track or auto-downloading. To completely exit press the button below or the back button in the app.</string>
     <string name="gps_failure">Failed to enable GPS</string>
+    <string name="gps_service_start_failure">Failed to start GPS service, try again.\n\nError: %1$s</string>
     <!-- element description -->
     <string name="address_housenumber">Address %1$s</string>
     <string name="address_housenumber_street">Address %1$s %2$s</string>


### PR DESCRIPTION
While such issues shouldn't happen (we start the service from the foreground) we've seen at least one crash dump caused by it, and the additional restrictions from Android 14 potentially make it more likely.