### PR TITLE
Edge to edge fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -636,6 +636,7 @@ dependencies {
     implementation "androidx.multidex:multidex:2.0.1"
     implementation "androidx.cardview:cardview:1.0.0"
     implementation "androidx.viewpager:viewpager:1.1.0-alpha01"
+    implementation "androidx.coordinatorlayout:coordinatorlayout:1.3.0"
     
     //non-Android google 
     implementation 'com.google.protobuf:protobuf-java:3.12.2'

--- a/src/main/java/de/blau/android/propertyeditor/PresetFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/PresetFragment.java
@@ -10,7 +10,6 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
-import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.KeyEvent;
@@ -34,12 +33,10 @@ import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 import de.blau.android.App;
-import de.blau.android.BuildConfig;
 import de.blau.android.Feedback;
 import de.blau.android.HelpViewer;
 import de.blau.android.Logic;
 import de.blau.android.R;
-import de.blau.android.contract.Flavors;
 import de.blau.android.contract.Github;
 import de.blau.android.osm.OsmElement;
 import de.blau.android.osm.OsmElement.ElementType;
@@ -471,21 +468,15 @@ public class PresetFragment extends BaseFragment implements PresetUpdate, Preset
     public void onCreateOptionsMenu(final Menu menu, final MenuInflater inflater) {
         super.onCreateOptionsMenu(menu, inflater);
         ActionMenuView menuView = (ActionMenuView) getView().findViewById(R.id.preset_menu);
-        // the library providing the Feedback UI is not supported under SDK 15
-        boolean enablePresetFeedback = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT && BuildConfig.FLAVOR.equals(Flavors.CURRENT);
         if (paneMode) {
             menuView.setVisibility(View.VISIBLE);
             getActivity().getMenuInflater().inflate(R.menu.preset_nav_menu, menuView.getMenu());
             menuView.setOnMenuItemClickListener(this::onOptionsItemSelected);
-            if (enablePresetFeedback) {
-                // this adds the item as the last one
-                menu.add(Menu.NONE, R.id.menu_preset_feedback, 20, R.string.menu_preset_feedback).setEnabled(propertyEditorListener.isConnected());
-            }
+            // this adds the item as the last one
+            menu.add(Menu.NONE, R.id.menu_preset_feedback, 20, R.string.menu_preset_feedback).setEnabled(propertyEditorListener.isConnected());
         } else {
             inflater.inflate(R.menu.preset_menu, menu);
-            if (enablePresetFeedback) {
-                menu.findItem(R.id.menu_preset_feedback).setVisible(true).setEnabled(propertyEditorListener.isConnected());
-            }
+            menu.findItem(R.id.menu_preset_feedback).setVisible(true).setEnabled(propertyEditorListener.isConnected());
         }
     }
 

--- a/src/main/java/de/blau/android/util/ScreenMessage.java
+++ b/src/main/java/de/blau/android/util/ScreenMessage.java
@@ -297,7 +297,7 @@ public final class ScreenMessage {
      */
     public static void barError(@Nullable Activity activity, int res) {
         if (activity != null) {
-            barError(activity.findViewById(android.R.id.content), res);
+            barError(getTargetView(activity), res);
         }
     }
 
@@ -327,7 +327,7 @@ public final class ScreenMessage {
      */
     public static void barError(@Nullable Activity activity, String msg) {
         if (activity != null) {
-            barError(activity.findViewById(android.R.id.content), msg);
+            barError(getTargetView(activity), msg);
         }
     }
 
@@ -374,7 +374,7 @@ public final class ScreenMessage {
      */
     public static void barError(@Nullable Activity activity, int msgRes, int actionRes, View.OnClickListener listener) {
         if (activity != null) {
-            barError(activity.findViewById(android.R.id.content), msgRes, actionRes, listener);
+            barError(getTargetView(activity), msgRes, actionRes, listener);
         }
     }
 
@@ -411,7 +411,7 @@ public final class ScreenMessage {
      */
     public static void barInfo(@Nullable Activity activity, int res) {
         if (activity != null) {
-            barInfo(activity.findViewById(android.R.id.content), res);
+            barInfo(getTargetView(activity), res);
         }
     }
 
@@ -467,7 +467,7 @@ public final class ScreenMessage {
      */
     public static void barInfo(@Nullable Activity activity, @NonNull String msg) {
         if (activity != null) {
-            barInfo(activity.findViewById(android.R.id.content), msg);
+            barInfo(getTargetView(activity), msg);
         }
     }
 
@@ -479,7 +479,7 @@ public final class ScreenMessage {
      */
     public static void barInfoShort(@Nullable Activity activity, @NonNull String msg) {
         if (activity != null) {
-            barInfo(activity.findViewById(android.R.id.content), msg, BaseTransientBottomBar.LENGTH_SHORT);
+            barInfo(getTargetView(activity), msg, BaseTransientBottomBar.LENGTH_SHORT);
         }
     }
 
@@ -530,8 +530,25 @@ public final class ScreenMessage {
      */
     public static void barInfo(@Nullable Activity activity, String msg, int actionRes, @Nullable View.OnClickListener listener) {
         if (activity != null) {
-            barInfo(activity.findViewById(android.R.id.content), msg, actionRes, listener);
+            barInfo(getTargetView(activity), msg, actionRes, listener);
         }
+    }
+
+    /**
+     * Get a view for the SnackBar
+     * 
+     * If there is a view with the id "coordinator" that is returned otherwise the content view.
+     * 
+     * @param activity the target Activity
+     * @return a View or null
+     */
+    @Nullable
+    private static View getTargetView(@NonNull Activity activity) {
+        View targetView = activity.findViewById(R.id.coordinator);
+        if (targetView == null) {
+            targetView = activity.findViewById(android.R.id.content);
+        }
+        return targetView;
     }
 
     /**
@@ -567,7 +584,7 @@ public final class ScreenMessage {
      */
     public static void barWarning(@Nullable Activity activity, int res) {
         if (activity != null) {
-            barWarning(activity.findViewById(android.R.id.content), res, BaseTransientBottomBar.LENGTH_LONG);
+            barWarning(getTargetView(activity), res, BaseTransientBottomBar.LENGTH_LONG);
         }
     }
 
@@ -579,7 +596,7 @@ public final class ScreenMessage {
      */
     public static void barWarningShort(@Nullable Activity activity, int res) {
         if (activity != null) {
-            barWarning(activity.findViewById(android.R.id.content), res, BaseTransientBottomBar.LENGTH_SHORT);
+            barWarning(getTargetView(activity), res, BaseTransientBottomBar.LENGTH_SHORT);
         }
     }
 
@@ -610,7 +627,7 @@ public final class ScreenMessage {
      */
     public static void barWarning(@Nullable Activity activity, @NonNull String msg) {
         if (activity != null) {
-            barWarning(activity.findViewById(android.R.id.content), msg, BaseTransientBottomBar.LENGTH_LONG);
+            barWarning(getTargetView(activity), msg, BaseTransientBottomBar.LENGTH_LONG);
         }
     }
 
@@ -657,7 +674,7 @@ public final class ScreenMessage {
      * @param listener called when action is selected
      */
     public static void barWarning(@NonNull Activity activity, @NonNull String msg, int actionRes, View.OnClickListener listener) {
-        barWarning(activity.findViewById(android.R.id.content), msg, actionRes, listener);
+        barWarning(getTargetView(activity), msg, actionRes, listener);
     }
 
     /**

--- a/src/main/res/layout/list_activity.xml
+++ b/src/main/res/layout/list_activity.xml
@@ -17,44 +17,50 @@
             android:layout_width="match_parent"
             android:layout_height="0dp" 
             android:layout_weight="0" />
-        <RelativeLayout
+        <androidx.coordinatorlayout.widget.CoordinatorLayout
+            android:id="@+id/coordinator"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:paddingLeft="8dp" 
-            android:paddingRight="8dp"
             android:layout_weight="1">
-            <ListView android:id="@android:id/list"
+            <RelativeLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:background="?attr/colorPrimary"
-                android:drawSelectorOnTop="false"
-                android:layout_marginBottom="64dp" />
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/add"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_toLeftOf="@+id/more"
-                android:layout_alignWithParentIfMissing="true"
-                android:layout_alignParentBottom="true"
-                android:clickable="true" android:src="?attr/add"
-                app:backgroundTint="?attr/colorAccent"
-                app:fabSize="mini" app:useCompatPadding="true" />
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/more" 
-                android:visibility="gone"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentRight="true"
-                android:layout_alignParentEnd="true"
-                android:layout_alignParentBottom="true"
-                android:clickable="true" android:src="?attr/more"
-                app:backgroundTint="?attr/colorAccent"
-                app:fabSize="mini" app:useCompatPadding="true" />
-        </RelativeLayout>
+                android:paddingLeft="8dp" 
+                android:paddingRight="8dp">
+                <ListView android:id="@android:id/list"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:background="?attr/colorPrimary"
+                    android:drawSelectorOnTop="false"
+                    android:layout_marginBottom="64dp" />
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    android:id="@+id/add"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_toLeftOf="@+id/more"
+                    android:layout_alignWithParentIfMissing="true"
+                    android:layout_alignParentBottom="true"
+                    android:clickable="true" 
+                    android:src="?attr/add"
+                    app:backgroundTint="?attr/colorAccent"
+                    app:fabSize="mini" 
+                    app:useCompatPadding="true" />
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    android:id="@+id/more" android:visibility="gone"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentRight="true"
+                    android:layout_alignParentEnd="true"
+                    android:layout_alignParentBottom="true"
+                    android:clickable="true" android:src="?attr/more"
+                    app:backgroundTint="?attr/colorAccent"
+                    app:fabSize="mini" 
+                    app:useCompatPadding="true" />
+            </RelativeLayout>
+        </androidx.coordinatorlayout.widget.CoordinatorLayout>
         <de.blau.android.views.BottomInset
             android:layout_width="match_parent"
-            android:layout_height="0dp" 
-            android:layout_weight="0" />
+            android:layout_height="0dp" android:layout_weight="0" />
     </LinearLayout>
     <de.blau.android.views.RightInset
         android:layout_width="0dp" 

--- a/src/main/res/layout/main.xml
+++ b/src/main/res/layout/main.xml
@@ -7,98 +7,112 @@
     android:layout_height="match_parent"
     android:orientation="horizontal">
     <de.blau.android.views.LeftInset
-        android:layout_width="0dp" 
-        android:layout_height="match_parent"
+        android:layout_width="0dp" android:layout_height="match_parent"
         android:layout_weight="0" />
-    <LinearLayout
+    <LinearLayout 
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="match_parent" 
         android:layout_weight="1"
         android:orientation="vertical">
         <de.blau.android.views.TopInset
             android:layout_width="match_parent"
             android:layout_height="0dp" 
             android:layout_weight="0" />
-        <androidx.appcompat.widget.Toolbar
-            android:id="@+id/mainToolbar"
+        <androidx.coordinatorlayout.widget.CoordinatorLayout
+            android:id="@+id/coordinator"
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            android:layout_weight="0"
-            android:background="?attr/colorPrimary"
-            android:minHeight="?attr/actionBarSize">
-        </androidx.appcompat.widget.Toolbar>
-        <de.blau.android.views.SplitPaneLayout
-            android:id="@+id/pane_layout"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            spl:orientation="vertical"
-            spl:splitterBackground="?attr/SplitterBGV"
-            spl:handleBackground="?attr/SplitterHandleH"
-            spl:handleDraggingBackground="@drawable/splitter_handle_dragging_h"
-            spl:splitterPosition="100%" 
-            spl:splitterSize="5dip"
-            android:layout_weight="99999">
-            <RelativeLayout android:id="@+id/mainMap"
+            android:layout_height="match_parent"
+            android:layout_weight="1">
+            <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="fill_parent">
-                <com.google.android.material.floatingactionbutton.FloatingActionButton
-                    android:id="@+id/floatingLock"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_alignParentLeft="true"
-                    android:layout_gravity="top"
-                    android:layout_margin="8dp" 
-                    android:clickable="true"
-                    android:src="@drawable/lock_bi_state"
-                    app:backgroundTint="?attr/colorAccent"
-                    app:fabSize="mini" app:useCompatPadding="true" />
-                <com.google.android.material.floatingactionbutton.FloatingActionButton
-                    android:id="@+id/layers"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_alignParentRight="true"
-                    android:layout_gravity="top"
-                    android:layout_margin="0dp" android:clickable="true"
-                    android:src="@drawable/ic_view_headline_black_36dp"
-                    android:theme="@style/Theme.customMain"
-                    app:backgroundTint="?attr/colorControlNormal"
-                    app:fabSize="mini" 
-                    app:useCompatPadding="true" />
-                <com.google.android.material.floatingactionbutton.FloatingActionButton
-                    android:id="@+id/follow"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_alignParentLeft="true"
-                    android:layout_centerVertical="true"
-                    android:layout_gravity="top"
-                    android:clickable="true"
-                    android:src="@drawable/ic_gps_fixed_black_36dp"
-                    android:theme="@style/Theme.customMain"
-                    app:backgroundTint="?attr/colorControlNormal"
-                    app:fabSize="mini" 
-                    app:useCompatPadding="true" />
-                <de.blau.android.views.ZoomControls
-                    android:id="@+id/zoom_controls"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_alignParentRight="true"
-                    android:layout_alignParentBottom="true" />
-            </RelativeLayout>
-            <ViewStub android:id="@+id/pane2"
-                android:layout_width="fill_parent"
-                android:layout_height="0dp" />
-        </de.blau.android.views.SplitPaneLayout>
-        <FrameLayout android:id="@+id/bottomBar"
-            android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            android:layout_weight="0"
-            android:background="?attr/colorPrimary">
-            <include android:id="@+id/bottomToolbar"
-                layout="@layout/toolbar" />
-            <ViewStub android:id="@+id/cab_stub"
-                android:layout_width="match_parent"
-                android:layout_height="?attr/actionBarSize" />
-        </FrameLayout>
+                android:layout_height="match_parent"
+                android:layout_weight="1" 
+                android:orientation="vertical">
+                <androidx.appcompat.widget.Toolbar
+                    android:id="@+id/mainToolbar"
+                    android:layout_width="match_parent"
+                    android:layout_height="?attr/actionBarSize"
+                    android:layout_weight="0"
+                    android:background="?attr/colorPrimary"
+                    android:minHeight="?attr/actionBarSize">
+                </androidx.appcompat.widget.Toolbar>
+                <de.blau.android.views.SplitPaneLayout
+                    android:id="@+id/pane_layout"
+                    android:layout_width="fill_parent"
+                    android:layout_height="fill_parent"
+                    spl:orientation="vertical"
+                    spl:splitterBackground="?attr/SplitterBGV"
+                    spl:handleBackground="?attr/SplitterHandleH"
+                    spl:handleDraggingBackground="@drawable/splitter_handle_dragging_h"
+                    spl:splitterPosition="100%" 
+                    spl:splitterSize="5dip"
+                    android:layout_weight="99999">
+                    <RelativeLayout
+                        android:id="@+id/mainMap"
+                        android:layout_width="match_parent"
+                        android:layout_height="fill_parent">
+                        <com.google.android.material.floatingactionbutton.FloatingActionButton
+                            android:id="@+id/floatingLock"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_alignParentLeft="true"
+                            android:layout_gravity="top"
+                            android:layout_margin="8dp"
+                            android:clickable="true"
+                            android:src="@drawable/lock_bi_state"
+                            app:backgroundTint="?attr/colorAccent"
+                            app:fabSize="mini"
+                            app:useCompatPadding="true" />
+                        <com.google.android.material.floatingactionbutton.FloatingActionButton
+                            android:id="@+id/layers"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_alignParentRight="true"
+                            android:layout_gravity="top"
+                            android:layout_margin="0dp"
+                            android:clickable="true"
+                            android:src="@drawable/ic_view_headline_black_36dp"
+                            android:theme="@style/Theme.customMain"
+                            app:backgroundTint="?attr/colorControlNormal"
+                            app:fabSize="mini"
+                            app:useCompatPadding="true" />
+                        <com.google.android.material.floatingactionbutton.FloatingActionButton
+                            android:id="@+id/follow"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_alignParentLeft="true"
+                            android:layout_centerVertical="true"
+                            android:layout_gravity="top"
+                            android:clickable="true"
+                            android:src="@drawable/ic_gps_fixed_black_36dp"
+                            android:theme="@style/Theme.customMain"
+                            app:backgroundTint="?attr/colorControlNormal"
+                            app:fabSize="mini"
+                            app:useCompatPadding="true" />
+                        <de.blau.android.views.ZoomControls
+                            android:id="@+id/zoom_controls"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_alignParentRight="true"
+                            android:layout_alignParentBottom="true" />
+                    </RelativeLayout>
+                    <ViewStub android:id="@+id/pane2"
+                        android:layout_width="fill_parent"
+                        android:layout_height="0dp" />
+                </de.blau.android.views.SplitPaneLayout>
+                <FrameLayout android:id="@+id/bottomBar"
+                    android:layout_width="match_parent"
+                    android:layout_height="?attr/actionBarSize"
+                    android:layout_weight="0"
+                    android:background="?attr/colorPrimary">
+                    <include android:id="@+id/bottomToolbar"
+                        layout="@layout/toolbar" />
+                    <ViewStub android:id="@+id/cab_stub"
+                        android:layout_width="match_parent"
+                        android:layout_height="?attr/actionBarSize" />
+                </FrameLayout>
+            </LinearLayout>
+        </androidx.coordinatorlayout.widget.CoordinatorLayout>
         <de.blau.android.views.BottomInset
             android:layout_width="match_parent"
             android:layout_height="0dp" 

--- a/src/main/res/layout/pane_view.xml
+++ b/src/main/res/layout/pane_view.xml
@@ -4,91 +4,102 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:spl="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="match_parent" 
     android:orientation="vertical">
     <de.blau.android.views.TopInset
-        android:layout_width="match_parent"
+        android:layout_width="match_parent" 
         android:layout_height="0dp"
         android:layout_weight="0" />
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/propertyEditorBar"
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/coordinator"
         android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        android:layout_weight="0"
-        android:background="?attr/colorPrimary"
-        android:minHeight="?attr/actionBarSize">
-    </androidx.appcompat.widget.Toolbar>
-    <de.blau.android.views.SplitPaneLayout
-        android:id="@+id/pane_layout"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
-        android:layout_weight="1"
-        spl:orientation="horizontal"
-        spl:splitterBackground="?attr/SplitterBGH"
-        spl:handleBackground="?attr/SplitterHandleV"
-        spl:handleDraggingBackground="@drawable/splitter_handle_dragging_v"
-        spl:splitterPosition="66%"
-        spl:splitterSize="5dip">
-        <de.blau.android.views.ExtendedViewPager
-            xmlns:android="http://schemas.android.com/apk/res/android"
-            android:id="@+id/pager"
-            android:layout_width="0dp"
+        android:layout_height="match_parent" 
+        android:layout_weight="1">
+        <LinearLayout android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:paddingRight="5dp"
-            android:paddingEnd="5dp">
-            <de.blau.android.views.ExtendedPagerTabStrip
-                android:id="@+id/pager_header"
-                style="?attr/PagerTabStrip"
+            android:layout_weight="1" 
+            android:orientation="vertical">
+            <androidx.appcompat.widget.Toolbar
+                android:id="@+id/propertyEditorBar"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_gravity="top"
-                android:paddingBottom="4dp"
-                android:paddingTop="4dp" />
-        </de.blau.android.views.ExtendedViewPager>
-        <de.blau.android.views.SplitPaneLayout
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:paddingLeft="5dp"
-            android:paddingStart="5dp"
-            spl:orientation="vertical"
-            spl:splitterBackground="?attr/SplitterBGV"
-            spl:handleBackground="?attr/SplitterHandleH"
-            spl:handleDraggingBackground="@drawable/splitter_handle_dragging_h"
-            spl:splitterPosition="33%"
-            spl:splitterSize="5dip">
-            <LinearLayout
-                android:id="@+id/recent_preset_row"
+                android:layout_height="?attr/actionBarSize"
+                android:layout_weight="0"
+                android:background="?attr/colorPrimary"
+                android:minHeight="?attr/actionBarSize">
+            </androidx.appcompat.widget.Toolbar>
+            <de.blau.android.views.SplitPaneLayout
+                android:id="@+id/pane_layout"
                 android:layout_width="fill_parent"
-                android:layout_height="0dp"
-                android:orientation="vertical"
-                android:paddingBottom="4dp">
-                <LinearLayout
-                    android:id="@+id/pane_alternative_layout"
+                android:layout_height="fill_parent"
+                android:layout_weight="1" 
+                spl:orientation="horizontal"
+                spl:splitterBackground="?attr/SplitterBGH"
+                spl:handleBackground="?attr/SplitterHandleV"
+                spl:handleDraggingBackground="@drawable/splitter_handle_dragging_v"
+                spl:splitterPosition="66%" 
+                spl:splitterSize="5dip">
+                <de.blau.android.views.ExtendedViewPager
+                    xmlns:android="http://schemas.android.com/apk/res/android"
+                    android:id="@+id/pager" 
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:paddingRight="5dp" 
+                    android:paddingEnd="5dp">
+                    <de.blau.android.views.ExtendedPagerTabStrip
+                        android:id="@+id/pager_header"
+                        style="?attr/PagerTabStrip"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="top"
+                        android:paddingBottom="4dp"
+                        android:paddingTop="4dp" />
+                </de.blau.android.views.ExtendedViewPager>
+                <de.blau.android.views.SplitPaneLayout
                     android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:padding="0dp"
-                    android:saveEnabled="false">
-                </LinearLayout>
-                <LinearLayout
-                    android:id="@+id/pane_mru_layout"
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:padding="0dp"
-                    android:saveEnabled="false">
-                </LinearLayout>
-            </LinearLayout>
-            <LinearLayout
-                android:id="@+id/preset_row"
-                android:layout_width="fill_parent"
-                android:layout_height="0dp"
-                android:orientation="vertical"
-                android:paddingTop="4dp" />
-        </de.blau.android.views.SplitPaneLayout>
-    </de.blau.android.views.SplitPaneLayout>
+                    android:layout_height="fill_parent"
+                    android:paddingLeft="5dp" 
+                    android:paddingStart="5dp"
+                    spl:orientation="vertical"
+                    spl:splitterBackground="?attr/SplitterBGV"
+                    spl:handleBackground="?attr/SplitterHandleH"
+                    spl:handleDraggingBackground="@drawable/splitter_handle_dragging_h"
+                    spl:splitterPosition="33%" 
+                    spl:splitterSize="5dip">
+                    <LinearLayout
+                        android:id="@+id/recent_preset_row"
+                        android:layout_width="fill_parent"
+                        android:layout_height="0dp"
+                        android:orientation="vertical"
+                        android:paddingBottom="4dp">
+                        <LinearLayout
+                            android:id="@+id/pane_alternative_layout"
+                            android:layout_width="fill_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical"
+                            android:padding="0dp"
+                            android:saveEnabled="false">
+                        </LinearLayout>
+                        <LinearLayout
+                            android:id="@+id/pane_mru_layout"
+                            android:layout_width="fill_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical"
+                            android:padding="0dp"
+                            android:saveEnabled="false">
+                        </LinearLayout>
+                    </LinearLayout>
+                    <LinearLayout
+                        android:id="@+id/preset_row"
+                        android:layout_width="fill_parent"
+                        android:layout_height="0dp"
+                        android:orientation="vertical"
+                        android:paddingTop="4dp" />
+                </de.blau.android.views.SplitPaneLayout>
+            </de.blau.android.views.SplitPaneLayout>
+        </LinearLayout>
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
     <de.blau.android.views.BottomInset
-        android:layout_width="match_parent"
+        android:layout_width="match_parent" 
         android:layout_height="0dp"
         android:layout_weight="0" />
 </LinearLayout>

--- a/src/main/res/layout/tab_view.xml
+++ b/src/main/res/layout/tab_view.xml
@@ -9,43 +9,54 @@
         android:layout_width="0dp" 
         android:layout_height="match_parent"
         android:layout_weight="0" />
-    <LinearLayout
+    <LinearLayout 
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="match_parent" 
         android:layout_weight="0"
         android:orientation="vertical">
         <de.blau.android.views.TopInset
             android:layout_width="match_parent"
             android:layout_height="0dp" 
             android:layout_weight="0" />
-        <androidx.appcompat.widget.Toolbar
-            android:id="@+id/propertyEditorBar"
+        <androidx.coordinatorlayout.widget.CoordinatorLayout
+            android:id="@+id/coordinator"
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            android:layout_weight="0"
-            android:background="?attr/colorPrimary"
-            android:minHeight="?attr/actionBarSize">
-        </androidx.appcompat.widget.Toolbar>
-        <de.blau.android.views.ExtendedViewPager
-            android:id="@+id/pager" android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_weight="1">
-            <de.blau.android.views.ExtendedPagerTabStrip
-                android:id="@+id/pager_header"
-                style="?attr/PagerTabStrip"
+            <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_gravity="top" 
-                android:paddingBottom="4dp"
-                android:paddingTop="4dp" />
-        </de.blau.android.views.ExtendedViewPager>
+                android:layout_height="match_parent"
+                android:layout_weight="1" 
+                android:orientation="vertical">
+                <androidx.appcompat.widget.Toolbar
+                    android:id="@+id/propertyEditorBar"
+                    android:layout_width="match_parent"
+                    android:layout_height="?attr/actionBarSize"
+                    android:layout_weight="0"
+                    android:background="?attr/colorPrimary"
+                    android:minHeight="?attr/actionBarSize">
+                </androidx.appcompat.widget.Toolbar>
+                <de.blau.android.views.ExtendedViewPager
+                    android:id="@+id/pager"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1">
+                    <de.blau.android.views.ExtendedPagerTabStrip
+                        android:id="@+id/pager_header"
+                        style="?attr/PagerTabStrip"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="top"
+                        android:paddingBottom="4dp"
+                        android:paddingTop="4dp" />
+                </de.blau.android.views.ExtendedViewPager>
+            </LinearLayout>
+        </androidx.coordinatorlayout.widget.CoordinatorLayout>
         <de.blau.android.views.BottomInset
             android:layout_width="match_parent"
-            android:layout_height="0dp" 
-            android:layout_weight="0" />
+            android:layout_height="0dp" android:layout_weight="0" />
     </LinearLayout>
     <de.blau.android.views.RightInset
-        android:layout_width="0dp" 
-        android:layout_height="match_parent"
+        android:layout_width="0dp" android:layout_height="match_parent"
         android:layout_weight="0" />
 </LinearLayout>

--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -528,6 +528,8 @@
         name="Theme.customActionBar"
         parent="@style/Theme.AppCompat">
         <item name="windowActionModeOverlay">true</item>
+        <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:windowTranslucentNavigation">true</item>
         <item name="android:windowOptOutEdgeToEdgeEnforcement">false</item>
         <item name="actionBarStyle">@style/TagEditorActionBar</item>
         <item name="autoCompleteTextViewStyle">@style/Widget.AutoCompleteTextView</item>
@@ -733,6 +735,8 @@
         name="Theme.customActionBar.Light"
         parent="@style/Theme.AppCompat.Light">
         <item name="windowActionModeOverlay">true</item>
+        <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:windowTranslucentNavigation">true</item>
         <item name="android:windowOptOutEdgeToEdgeEnforcement">false</item>
         <item name="actionBarStyle">@style/TagEditorActionBarLight</item>
         <item name="autoCompleteTextViewStyle">@style/AutoCompleteTextViewLight</item>


### PR DESCRIPTION
Make bars translucent for filter activities and add a CoordinatorLayout to most activities for Snackbar positioning

This avoids the snackbar overlapping the nav bar (with exception of the PresetFilterActivity that hasn't been modifed).