### PR TITLE
Anchor popup menu on parent view if possible

### DIFF
--- a/src/main/java/de/blau/android/dialogs/UploadConflict.java
+++ b/src/main/java/de/blau/android/dialogs/UploadConflict.java
@@ -18,6 +18,7 @@ import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewParent;
 import android.widget.Button;
 import android.widget.CompoundButton;
 import android.widget.LinearLayout;
@@ -386,7 +387,8 @@ public class UploadConflict extends CancelableDialogFragment {
                     return;
                 }
                 neutral.setOnClickListener((View v) -> {
-                    PopupMenu popup = new InsetAwarePopupMenu(getActivity(), neutral);
+                    ViewParent parent = v.getParent();
+                    PopupMenu popup = new InsetAwarePopupMenu(getActivity(), parent != null ? (View) parent : v, Gravity.START);
                     for (Entry<String, Runnable> action : resolveActions.entrySet()) {
                         MenuItem item = popup.getMenu().add(action.getKey());
                         item.setOnMenuItemClickListener(unused -> {

--- a/src/main/java/de/blau/android/util/InsetAwarePopupMenu.java
+++ b/src/main/java/de/blau/android/util/InsetAwarePopupMenu.java
@@ -27,8 +27,25 @@ public class InsetAwarePopupMenu extends PopupMenu {
 
     private static final String M_POPUP = "mPopup";
 
+    /**
+     * Construct a new instance
+     * 
+     * @param context an Android Context
+     * @param anchor the View to anchor to
+     */
     public InsetAwarePopupMenu(@NonNull Context context, @NonNull View anchor) {
         super(context, anchor);
+    }
+
+    /**
+     * Construct a new instance
+     * 
+     * @param context an Android Context
+     * @param anchor the View to anchor to
+     * @param gravity Gravity value to use
+     */
+    public InsetAwarePopupMenu(@NonNull Context context, @NonNull View anchor, int gravity) {
+        super(context, anchor, gravity);
     }
 
     @Override


### PR DESCRIPTION
If the Dialog used for the conflict resolution modal switches to horizontal arrangement of the buttons, using the button as the anchor of the popup menu can lead to it being cut off on the right hand side.

This PR uses the parent view of the button as the anchor if it exists which will improve the behaviour somewhat, but naturally can't work miracles: if the screen is not wide enough for the font size and text in use nothing is going to fix the issue.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/2981