### PR TITLE
Make uploads more robust

### DIFF
--- a/src/main/java/de/blau/android/osm/StorageDelegator.java
+++ b/src/main/java/de/blau/android/osm/StorageDelegator.java
@@ -77,6 +77,8 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
     public static final String  FILENAME        = LAST_STATE + "." + FileExtensions.RES;
     public static final String  BACKUP_FILENAME = FILENAME + ".backup";
 
+    public static final String V_CHUNK = "v:chunk";
+
     private Storage currentStorage;
 
     private Storage apiStorage;
@@ -3321,7 +3323,10 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
         while (elementCount > 0) {
             String tmpSource = source;
             if (split) {
-                tmpSource = source + " [" + part + "]";
+                if (extraTags == null) {
+                    extraTags = new HashMap<>();
+                }
+                extraTags.put(V_CHUNK, Integer.toString(part));
             }
             server.openChangeset(closeOpenChangeset, comment, tmpSource, Util.toOsmList(imagery), extraTags);
             try {

--- a/src/main/java/de/blau/android/osm/StorageDelegator.java
+++ b/src/main/java/de/blau/android/osm/StorageDelegator.java
@@ -3304,17 +3304,20 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
      * @throws IOException if the upload doesn't work
      */
     public void uploadToServer(@NonNull final Server server, @Nullable final String comment, @Nullable String source, boolean closeOpenChangeset,
-            boolean closeChangeset, @Nullable Map<String, String> extraTags, @Nullable List<OsmElement> elements) throws IOException {
+            boolean closeChangeset, @Nullable Map<String, String> extraTags, @Nullable final List<OsmElement> elements) throws IOException {
 
         dirty = true; // storages will get modified as data is uploaded, these changes need to be saved to file
         removeUnchanged();
         // upload methods set dirty flag too, in case the file is saved during an upload
         boolean fullUpload = elements == null;
-        int uploadElementCount = fullUpload ? getApiElementCount() : elements.size();
-        int notUploadedElementCount = getApiElementCount() - uploadElementCount; // will be zero for normal uploads
+        // we can't modify the original list as that will destroy the record of what we are uploading
+        List<OsmElement> toUpload = !fullUpload ? new ArrayList<>(elements) : null;
+        int uploadElementCount = fullUpload ? getApiElementCount() : toUpload.size();
         boolean split = uploadElementCount > server.getCachedCapabilities().getMaxElementsInChangeset();
         int part = 1;
         int elementCount = uploadElementCount;
+        int uploadedCount = 0;
+
         while (elementCount > 0) {
             String tmpSource = source;
             if (split) {
@@ -3323,36 +3326,41 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
             server.openChangeset(closeOpenChangeset, comment, tmpSource, Util.toOsmList(imagery), extraTags);
             try {
                 lock();
+                int startCount = apiStorage.getElementCount();
                 if (fullUpload) {
-                    server.diffUpload(this, getApiStorage());
+                    server.diffUpload(this, apiStorage);
                 } else {
                     Storage storage = new Storage();
-                    // if we are uploading more than the limit elements
-                    // this will work as uploaded elements will have
-                    // unmodified status
-                    storage.addChangedElements(elements);
+                    storage.addChangedElements(toUpload);
                     server.diffUpload(this, storage);
+                    // remove everything that has been processed from elements
+                    // unmodified status is not enough itself because of deleted elements
+                    for (OsmElement e : new ArrayList<>(toUpload)) {
+                        if (apiStorage.getOsmElement(e.getName(), e.getOsmId()) == null) {
+                            toUpload.remove(e);
+                        }
+                    }
                 }
+                uploadedCount = startCount - apiStorage.getElementCount();
+                elementCount = elementCount - uploadedCount;
             } finally {
                 unlock();
             }
-
             if (closeChangeset || split) { // always close when splitting
                 server.closeChangeset();
             }
             part++;
-            int currentElementCount = getApiElementCount();
-            if (currentElementCount < notUploadedElementCount + elementCount) {
-                elementCount = currentElementCount - notUploadedElementCount;
-            } else {
+            if (uploadedCount == 0) {
                 // element count didn't do anything, that should cause an exception to be
                 // thrown in diffUpload, but it is conceivable that that doesn't happen
                 Log.e(DEBUG_TAG, "Upload had no effect, API element count " + elementCount);
                 throw new ProtocolException("Upload had no effect");
             }
+            if (elementCount > 0 && !split) {
+                Log.e(DEBUG_TAG, "Unexpected remaining elements, originally " + uploadElementCount + " remaining " + elementCount);
+                break;
+            }
         }
-        // yes, again, just to be sure
-        dirty = true;
 
         // reset imagery recording for next upload
         imagery = new ArrayList<>();

--- a/src/test/java/de/blau/android/osm/ApiTest.java
+++ b/src/test/java/de/blau/android/osm/ApiTest.java
@@ -43,9 +43,9 @@ import de.blau.android.exception.OsmIllegalOperationException;
 import de.blau.android.listener.UploadListener;
 import de.blau.android.net.GzipRequestInterceptor;
 import de.blau.android.prefs.API;
+import de.blau.android.prefs.API.AuthParams;
 import de.blau.android.prefs.AdvancedPrefDatabase;
 import de.blau.android.prefs.Preferences;
-import de.blau.android.prefs.API.AuthParams;
 import de.blau.android.util.Util;
 import de.blau.android.validation.Validator;
 import okhttp3.HttpUrl;
@@ -511,7 +511,7 @@ public class ApiTest {
         logic.upload(main, arguments, new FailOnErrorHandler(signal2));
         runLooper();
         SignalUtils.signalAwait(signal, TIMEOUT);
-
+    
         n = (Node) App.getDelegator().getOsmElement(Node.NAME, 101792984);
         assertNotNull(n);
         assertEquals(OsmElement.STATE_UNCHANGED, n.getState());
@@ -615,6 +615,13 @@ public class ApiTest {
         assertNotNull(r);
         assertEquals(OsmElement.STATE_UNCHANGED, r.getState());
         assertEquals(4L, r.getOsmVersion());
+        try {
+            mockServer.takeRequest();
+            RecordedRequest request = mockServer.takeRequest();
+            assertTrue(request.getBody().readUtf8().contains("<tag k=\"v:chunk\" v=\"1\" />"));
+        } catch (InterruptedException e) {
+            fail(e.getMessage());
+        }
     }
 
     /**


### PR DESCRIPTION
This fixes an issue that could only happen if a selective upload was repeated (likely due to API storage being changed during upload) that caused an attempt to re-upload already deleted elements, and makes the calculation of how many elements have been uploaded more robust (potentially the root cause of the issue).