### PR TITLE
Resolve imagery used issues

### DIFF
--- a/src/main/java/de/blau/android/osm/Server.java
+++ b/src/main/java/de/blau/android/osm/Server.java
@@ -770,11 +770,11 @@ public class Server {
      * @param closeOpenChangeset if true attempt to close a potentially open changeset first
      * @param comment value for the comment tag
      * @param source value for the source tag
-     * @param imagery value for the imagery_used tag
+     * @param imagery list of values for the imagery_used tag
      * @param extraTags Additional tags to add
      * @throws IOException on an IO issue
      */
-    public void openChangeset(boolean closeOpenChangeset, @Nullable final String comment, @Nullable final String source, @Nullable final String imagery,
+    public void openChangeset(boolean closeOpenChangeset, @Nullable final String comment, @Nullable final String source, @Nullable final List<String> imagery,
             @Nullable Map<String, String> extraTags) throws IOException {
 
         if (changesetId != -1) { // potentially still open, check if really the case
@@ -795,7 +795,7 @@ public class Server {
             changesetId = -1;
         }
 
-        final XmlSerializable xmlData = new Changeset(generator, comment, source, imagery, extraTags).tagsToXml();
+        final XmlSerializable xmlData = new Changeset(generator, comment, source, imagery, extraTags, getCachedCapabilities()).tagsToXml();
         RequestBody body = new XmlRequestBody() {
             @Override
             public void writeTo(BufferedSink sink) throws IOException {
@@ -857,15 +857,15 @@ public class Server {
      * @param changesetId the id of the changeset
      * @param comment value for the comment tag
      * @param source value for the source tag
-     * @param imagery value for the imagery_used tag
+     * @param imagery list of values for the imagery_used tag
      * @param extraTags Additional tags to add
      * @return a Changeset object
      * @throws IOException on an IO issue
      */
     @Nullable
-    public Changeset updateChangeset(final long changesetId, @Nullable final String comment, @Nullable final String source, @Nullable final String imagery,
-            @Nullable Map<String, String> extraTags) throws IOException {
-        final XmlSerializable xmlData = new Changeset(generator, comment, source, imagery, extraTags).tagsToXml();
+    public Changeset updateChangeset(final long changesetId, @Nullable final String comment, @Nullable final String source,
+            @Nullable final List<String> imagery, @Nullable Map<String, String> extraTags) throws IOException {
+        final XmlSerializable xmlData = new Changeset(generator, comment, source, imagery, extraTags, getCachedCapabilities()).tagsToXml();
         RequestBody body = new XmlRequestBody() {
             @Override
             public void writeTo(BufferedSink sink) throws IOException {

--- a/src/main/java/de/blau/android/osm/StorageDelegator.java
+++ b/src/main/java/de/blau/android/osm/StorageDelegator.java
@@ -465,15 +465,16 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
     public void recordImagery(@Nullable de.blau.android.Map map) {
         if (!imageryRecorded) { // flag is reset when we change imagery
             try {
-                if (map != null) { // currently we only modify data when the map exists
-                    List<String> currentImagery = map.getImageryNames();
-                    for (String i : currentImagery) {
-                        if (!imagery.contains(i) && !"None".equalsIgnoreCase(i)) {
-                            imagery.add(i);
-                        }
-                    }
-                    imageryRecorded = true;
+                if (map == null) { // currently we only modify data when the map exists
+                    return;
                 }
+                List<String> currentImagery = map.getImageryNames();
+                for (String i : currentImagery) {
+                    if (!imagery.contains(i) && !"None".equalsIgnoreCase(i)) {
+                        imagery.add(i);
+                    }
+                }
+                imageryRecorded = true;
             } catch (Exception | Error ignored) { // NOSONAR never fail on anything here
                 // IGNORE
             }
@@ -3329,7 +3330,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
                 }
                 extraTags.put(V_CHUNK, Integer.toString(part));
             }
-            server.openChangeset(closeOpenChangeset, comment, tmpSource, Util.toOsmList(imagery), extraTags);
+            server.openChangeset(closeOpenChangeset, comment, tmpSource, imagery, extraTags);
             try {
                 lock();
                 int startCount = apiStorage.getElementCount();

--- a/src/main/java/de/blau/android/util/Util.java
+++ b/src/main/java/de/blau/android/util/Util.java
@@ -940,4 +940,38 @@ public final class Util {
             ((Activity) ctx).runOnUiThread(action);
         }
     }
+
+    /**
+     * Add a tag incrementing the numeric suffix of key if there is a collision
+     * 
+     * @param key the key
+     * @param value the value
+     * @param tags the exiting tags
+     */
+    public static void addTagWithNumericSuffix(@NonNull String key, @NonNull String value, @NonNull Map<String, String> tags) {
+        String existing = tags.get(key);
+        if (existing == null) {
+            tags.put(key, value);
+            return;
+        }
+        int index = 0;
+        for (String tag : tags.keySet()) {
+            if (!tag.startsWith(key)) {
+                continue;
+            }
+            String[] parts = tag.split("\\:");
+            if (parts.length == 2) {
+                try {
+                    int temp = Integer.parseInt(parts[1]);
+                    if (temp > index) {
+                        index = temp;
+                    }
+                } catch (NumberFormatException nfex) {
+                    // ignore
+                }
+            }
+        }
+        tags.put(key + Tags.NS_SEP + Integer.toString(index + 1), value);
+    }
+
 }

--- a/src/test/java/de/blau/android/osm/ApiTest.java
+++ b/src/test/java/de/blau/android/osm/ApiTest.java
@@ -647,7 +647,7 @@ public class ApiTest {
         mockServer.enqueue(CHANGESET5_FIXTURE);
         final Server s = new Server(ApplicationProvider.getApplicationContext(), prefDB.getCurrentAPI(), GENERATOR_NAME);
         try {
-            Changeset cs = s.updateChangeset(1234567, "ignored", "ignored", "ignored", null);
+            Changeset cs = s.updateChangeset(1234567, "ignored", "ignored", Util.wrapInList("ignored"), null);
             assertNotNull(cs);
             assertEquals(120631739L, cs.getOsmId());
             assertNotNull(cs.getTags());
@@ -667,7 +667,7 @@ public class ApiTest {
         final Server s = new Server(ApplicationProvider.getApplicationContext(), prefDB.getCurrentAPI(), GENERATOR_NAME);
         s.setOpenChangeset(123456789);
         try {
-            s.openChangeset(false, "ignored", "ignored", "ignored", null);
+            s.openChangeset(false, "ignored", "ignored", Util.wrapInList("ignored"), null);
             assertEquals(123456789, s.getOpenChangeset()); // still open
         } catch (IOException e) {
             fail(e.getMessage());
@@ -692,7 +692,7 @@ public class ApiTest {
         final Server s = new Server(ApplicationProvider.getApplicationContext(), prefDB.getCurrentAPI(), GENERATOR_NAME);
         s.setOpenChangeset(123456789);
         try {
-            s.openChangeset(true, "ignored", "ignored", "ignored", null);
+            s.openChangeset(true, "ignored", "ignored", Util.wrapInList("ignored"), null);
             assertEquals(1234567, s.getOpenChangeset()); // new id
         } catch (IOException e) {
             fail(e.getMessage());

--- a/src/test/java/de/blau/android/osm/ChangesetTest.java
+++ b/src/test/java/de/blau/android/osm/ChangesetTest.java
@@ -1,0 +1,61 @@
+package de.blau.android.osm;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.filters.LargeTest;
+import de.blau.android.App;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 33)
+@LargeTest
+public class ChangesetTest {
+    private static final String TEST_SOURCE = "Test Source";
+    private static final String TEST_COMMENT = "Test Comment";
+
+    /**
+     */
+    @Test
+    public void imageryTags1() {     
+        Changeset changeset = new Changeset("vespucci Test", TEST_COMMENT, TEST_SOURCE, Arrays.asList("source1","source2"),
+                null, App.getPreferences(ApplicationProvider.getApplicationContext()).getServer().getCachedCapabilities()) ;
+        
+        assertEquals(TEST_COMMENT,changeset.getTags().get(Tags.KEY_COMMENT));
+        assertEquals(TEST_SOURCE,changeset.getTags().get(Tags.KEY_SOURCE));
+        assertEquals("source1;source2",changeset.getTags().get(Tags.KEY_IMAGERY_USED));
+    }
+    
+    @Test
+    public void imageryTags2() {
+        Changeset changeset = new Changeset("vespucci Test", TEST_COMMENT, TEST_SOURCE, Arrays.asList(
+                "A very long source name, a very long source name, a very long source name, a very long source name, a very long source name, a very long source name, a very long source name, a very long source name, a very long source name, a very long source name, a very long source name","source2"),
+                null, App.getPreferences(ApplicationProvider.getApplicationContext()).getServer().getCachedCapabilities()) ;
+        
+        assertEquals(TEST_COMMENT,changeset.getTags().get(Tags.KEY_COMMENT));
+        assertEquals(TEST_SOURCE,changeset.getTags().get(Tags.KEY_SOURCE));
+        assertEquals("A very long source name, a very long source name, a very long source name, a very long source name, a very long source name, a very long source name, a very long source name, a very long source name, a very long source name, a very long source name, a ver",changeset.getTags().get(Tags.KEY_IMAGERY_USED));
+        assertEquals("source2",changeset.getTags().get(Tags.KEY_IMAGERY_USED + ":1"));
+    }
+    
+    @Test
+    public void imageryTags3() {
+        Changeset changeset = new Changeset("vespucci Test", TEST_COMMENT, TEST_SOURCE, Arrays.asList(
+                "A very long source name 1", "A very long source name 2", "A very long source name 3", "A very long source name 4", 
+                "A very long source name 5", "A very long source name 6", "A very long source name 7", "A very long source name 8", 
+                "A very long source name 6", "A very long source name 7", "A very long source name 8","source2"),
+                null, App.getPreferences(ApplicationProvider.getApplicationContext()).getServer().getCachedCapabilities()) ;
+        
+        assertEquals(TEST_COMMENT,changeset.getTags().get(Tags.KEY_COMMENT));
+        assertEquals(TEST_SOURCE,changeset.getTags().get(Tags.KEY_SOURCE));
+        assertTrue(changeset.getTags().get(Tags.KEY_IMAGERY_USED).endsWith(";A very long source name 6"));
+        assertEquals("A very long source name 7;A very long source name 8;source2",changeset.getTags().get(Tags.KEY_IMAGERY_USED + ":1"));
+    }
+}


### PR DESCRIPTION
This resolves both the imagery list not actually being used from saved state and the length of the image_used tag not being managed.

Resolves https://github.com/MarcusWolschon/osmeditor4android/issues/2994