### PR TITLE
Save list of images in file and not in bundle

### DIFF
--- a/src/main/java/de/blau/android/photos/PhotoViewerFragment.java
+++ b/src/main/java/de/blau/android/photos/PhotoViewerFragment.java
@@ -54,6 +54,7 @@ import de.blau.android.util.ContentResolverUtil;
 import de.blau.android.util.ImageLoader;
 import de.blau.android.util.ImagePagerAdapter;
 import de.blau.android.util.OnPageSelectedListener;
+import de.blau.android.util.SavingHelper;
 import de.blau.android.util.ScreenMessage;
 import de.blau.android.util.SizedDynamicDialogFragment;
 import de.blau.android.util.ThemeUtils;
@@ -406,7 +407,8 @@ public class PhotoViewerFragment<T extends Serializable> extends SizedDynamicDia
             wrap = getArguments().getBoolean(WRAP_KEY, true);
         } else {
             Log.d(DEBUG_TAG, "Initializing from saved state");
-            photoList = Util.getSerializeable(savedInstanceState, PhotoViewerFragment.PHOTO_LIST_KEY, ArrayList.class);
+            String photoListFilename = savedInstanceState.getString(PhotoViewerFragment.PHOTO_LIST_KEY);
+            photoList = new SavingHelper<ArrayList<T>>().load(getContext(), photoListFilename, true);
             startPos = savedInstanceState.getInt(START_POS_KEY);
             photoLoader = Util.getSerializeable(savedInstanceState, PHOTO_LOADER_KEY, ImageLoader.class);
             wrap = savedInstanceState.getBoolean(WRAP_KEY);
@@ -581,13 +583,22 @@ public class PhotoViewerFragment<T extends Serializable> extends SizedDynamicDia
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         Log.d(DEBUG_TAG, "onSaveInstanceState");
-        outState.putSerializable(PHOTO_LIST_KEY, (ArrayList<T>) photoList);
+        String listFilename = photoListFilename();
+        new SavingHelper<ArrayList<T>>().save(getContext(), listFilename, new ArrayList<>(photoList), true);
+        outState.putString(PhotoViewerFragment.PHOTO_LIST_KEY, listFilename);
         // there seems to be a situation in which this is called before viewPager is created
         outState.putInt(START_POS_KEY, viewPager != null ? viewPager.getCurrentItem() : 0);
         if (!photoLoader.equals(defaultLoader)) {
             outState.putSerializable(PhotoViewerFragment.PHOTO_LOADER_KEY, photoLoader);
         }
         outState.putBoolean(WRAP_KEY, wrap);
+    }
+
+    /**
+     * @return the file name under which we save the list
+     */
+    String photoListFilename() {
+        return photoLoader.getClass().getCanonicalName() + ".res";
     }
 
     /**

--- a/src/main/res/layout/photo_viewer.xml
+++ b/src/main/res/layout/photo_viewer.xml
@@ -8,7 +8,8 @@
     <androidx.viewpager.widget.ViewPager xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/pager"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" >
+        android:layout_height="match_parent"
+        android:saveEnabled="false" >
     </androidx.viewpager.widget.ViewPager>
     <androidx.appcompat.widget.ActionMenuView
         android:id="@+id/photoMenuView"
@@ -16,5 +17,6 @@
         android:layout_height="?attr/actionBarSize"
         android:layout_gravity="bottom"
         android:background="@null"
-        android:minHeight="?attr/actionBarSize" />
+        android:minHeight="?attr/actionBarSize"
+        android:saveEnabled="false" />
 </FrameLayout>


### PR DESCRIPTION
Some, obviously very long, sequences were causing a TTLE this saves them in a file and further doesn't save everything twice. This seems to be a bug in Bundle as according to the doc adding a key a second time should replace it and its value, but the bundle actually increases in size.