### PR TITLE
If the query times out overpass returns an undocumented <remark> element

### DIFF
--- a/src/main/java/de/blau/android/osm/OsmParser.java
+++ b/src/main/java/de/blau/android/osm/OsmParser.java
@@ -39,9 +39,10 @@ public class OsmParser extends DefaultHandler {
 
     public static final String TIMESTAMP_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
 
-    protected static final String OVERPASS_NOTE = "note";
-    protected static final String OVERPASS_META = "meta";
-    protected static final String API_ERROR     = "error";
+    protected static final String OVERPASS_NOTE   = "note";
+    protected static final String OVERPASS_META   = "meta";
+    private static final String   OVERPASS_REMARK = "remark";
+    protected static final String API_ERROR       = "error";
 
     /** The storage, where the data will be stored (e.g. as JavaStorage or SqliteStorage). */
     private final Storage storage;
@@ -88,7 +89,7 @@ public class OsmParser extends DefaultHandler {
     protected LongOsmElementMap<Node> nodeIndex = null;
     private LongOsmElementMap<Way>    wayIndex  = null;
 
-    private String characters = null;
+    private StringBuilder buffer = new StringBuilder();
 
     /**
      * Construct a new instance of the parser
@@ -205,7 +206,9 @@ public class OsmParser extends DefaultHandler {
             case OsmXml.OSM:
             case OVERPASS_NOTE:
             case OVERPASS_META:
+            case OVERPASS_REMARK:
             case API_ERROR:
+                buffer.setLength(0);
                 break;
             default:
                 throw new OsmParseException("Unknown element " + name);
@@ -252,7 +255,9 @@ public class OsmParser extends DefaultHandler {
                 currentRelation = null;
                 break;
             case API_ERROR:
-                throw new OsmParseException("Internal API error: " + characters);
+                throw new OsmParseException("Internal API error: " + buffer.toString());
+            case OVERPASS_REMARK:
+                throw new OsmParseException(buffer.toString());
             default:
                 // ignore everything else
             }
@@ -264,7 +269,7 @@ public class OsmParser extends DefaultHandler {
 
     @Override
     public void characters(char[] ch, int start, int length) throws SAXException {
-        characters = new String(ch, start, length);
+        buffer.append(new String(ch, start, length));
     }
 
     /**

--- a/src/main/java/de/blau/android/overpass/Server.java
+++ b/src/main/java/de/blau/android/overpass/Server.java
@@ -207,7 +207,6 @@ public final class Server {
      * @param query the query
      * @param merge merge the received data instead of replacing existing data
      * @param select if true select results
-     * @param handler a listener to call when we are done
      */
     @NonNull
     public static AsyncResult query(@NonNull final Context context, @NonNull String query, boolean merge, boolean select) {

--- a/src/testCommon/resources/fixtures/overpass-timeout.xml
+++ b/src/testCommon/resources/fixtures/overpass-timeout.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="Overpass API 0.7.62.8 e802775f">
+    <note>The data included in this document is from www.openstreetmap.org. The data is made available under ODbL.</note>
+    <meta osm_base="2025-10-08T09:40:11Z" areas="2025-10-08T06:54:44Z" />
+    <remark> runtime error: Query timed out in "query" at line 3 after 11 seconds.</remark>
+</osm>

--- a/src/testCommon/resources/fixtures/overpass-timeout.yaml
+++ b/src/testCommon/resources/fixtures/overpass-timeout.yaml
@@ -1,0 +1,4 @@
+statusCode: 200       
+delay: 0              
+body: 'overpass-timeout.xml'
+                 


### PR DESCRIPTION
This adds support for parsing &lt;remark&gt;.