### PR TITLE
Fix regression in overpass console by using serializable parse tree

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -681,7 +681,7 @@ dependencies {
     implementation "ch.poole:OpeningHoursFragment:0.16.0"
     implementation 'ch.poole.android:numberpicker:1.0.10'
     implementation 'ch.poole.android:numberpickerpreference:2.0.1'
-    implementation "ch.poole.osm:JosmFilterParser:0.12.1"
+    implementation "ch.poole.osm:JosmFilterParser:0.13.0"
     implementation "ch.poole.osm:JosmTemplateParser:0.2.0"
     implementation 'ch.poole.android:sprites:0.0.4'
     implementation 'ch.poole.android:indeterminate-checkbox:1.1.0@aar'
@@ -801,7 +801,7 @@ marathon {
 //        allowlist {
 //            fullyQualifiedTestnameFilter =
 //               [            
-//                    'de.blau.android.osm.UploadConflictTest#referencesMissing'
+//                    'de.blau.android.search.ObjectSearchTest#overpass'
 //               ] 
 //        }
 //    }

--- a/src/main/java/de/blau/android/search/Wrapper.java
+++ b/src/main/java/de/blau/android/search/Wrapper.java
@@ -1,5 +1,6 @@
 package de.blau.android.search;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -266,7 +267,7 @@ public class Wrapper implements Meta {
     }
 
     @Override
-    public Object getPreset(@NonNull String presetPath) {
+    public Serializable getPreset(@NonNull String presetPath) {
         if (context == null) {
             throw unsupported("preset:");
         }
@@ -282,7 +283,7 @@ public class Wrapper implements Meta {
     }
 
     @Override
-    public boolean matchesPreset(@NonNull Object preset) {
+    public boolean matchesPreset(@NonNull Serializable preset) {
         SortedMap<String, String> tags = element.getTags();
         ElementType type = element.getType();
         if (preset instanceof PresetItem && matches((PresetItem) preset, type, tags)) {
@@ -396,8 +397,8 @@ public class Wrapper implements Meta {
     }
 
     @Override
-    public boolean isChild(@NonNull Type type, @NonNull Meta meta, @NonNull List<Object> parents) {
-        for (Object o : parents) {
+    public boolean isChild(@NonNull Type type, @NonNull Meta meta, @NonNull List<Serializable> parents) {
+        for (Serializable o : parents) {
             if (o instanceof Relation) {
                 if (element.hasParentRelation((Relation) o)) {
                     return true;
@@ -410,8 +411,8 @@ public class Wrapper implements Meta {
     }
 
     @Override
-    public boolean isParent(@NonNull Type type, @NonNull Meta meta, @NonNull List<Object> children) {
-        for (Object o : children) {
+    public boolean isParent(@NonNull Type type, @NonNull Meta meta, @NonNull List<Serializable> children) {
+        for (Serializable o : children) {
             if (element instanceof Relation) {
                 if (((OsmElement) o).hasParentRelation((Relation) element)) {
                     return true;
@@ -425,8 +426,8 @@ public class Wrapper implements Meta {
 
     @NonNull
     @Override
-    public List<Object> getMatchingElements(@NonNull Condition c) {
-        List<Object> result = new ArrayList<>();
+    public List<Serializable> getMatchingElements(@NonNull Condition c) {
+        List<Serializable> result = new ArrayList<>();
         SearchResult sr = getMatchingElementsInternal(c);
         result.addAll(sr.nodes);
         result.addAll(sr.ways);
@@ -536,7 +537,7 @@ public class Wrapper implements Meta {
     }
 
     @Override
-    public @NonNull Meta wrap(Object arg0) {
+    public @NonNull Meta wrap(Serializable arg0) {
         if (context == null) {
             throw unsupported("unknown");
         }

--- a/src/test/java/de/blau/android/search/WrapperTest.java
+++ b/src/test/java/de/blau/android/search/WrapperTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -307,17 +308,17 @@ public class WrapperTest {
      */
     @Test
     public void matchesPresetTest() {
-        Object secondary = wrapper.getPreset("Highways|Streets|Secondary");
+        Serializable secondary = wrapper.getPreset("Highways|Streets|Secondary");
         assertTrue(secondary instanceof PresetItem);
         Way way = (Way) delegator.getOsmElement(Way.NAME, 571087535L);
         assertNotNull(way);
         wrapper.setElement(way);
         assertTrue(wrapper.matchesPreset(secondary));
-        Object primary = wrapper.getPreset("Highways|Streets|Primary");
+        Serializable primary = wrapper.getPreset("Highways|Streets|Primary");
         assertTrue(primary instanceof PresetItem);
         assertFalse(wrapper.matchesPreset(primary));
 
-        Object streets = wrapper.getPreset("Highways|Streets|*");
+        Serializable streets = wrapper.getPreset("Highways|Streets|*");
         assertTrue(streets instanceof PresetGroup);
         assertTrue(wrapper.matchesPreset(streets));
         assertTrue(wrapper.matchesPreset(streets));
@@ -444,7 +445,7 @@ public class WrapperTest {
         Way way = (Way) delegator.getOsmElement(Way.NAME, 111762730L);
         assertNotNull(way);
         wrapper.setElement(way);
-        List<Object> objects = wrapper.getMatchingElements(new Version(8));
+        List<Serializable> objects = wrapper.getMatchingElements(new Version(8));
         assertEquals(441, objects.size());
         assertEquals(way, wrapper.getElement());
     }


### PR DESCRIPTION
This updates the JosmFilterParser to a version that generates a serializable parse tree that can be saved if the console needs to do so.