### PR TITLE
Don't save Context in PresetFilter

### DIFF
--- a/src/main/java/de/blau/android/Main.java
+++ b/src/main/java/de/blau/android/Main.java
@@ -2066,7 +2066,7 @@ public class Main extends ConfigurationChangeAwareActivity
             }
             Filter currentFilter = logic.getFilter();
             if (currentFilter != null) {
-                currentFilter.saveState();
+                currentFilter.saveState(this);
                 currentFilter.hideControls();
                 currentFilter.removeControls();
                 logic.setFilter(null);

--- a/src/main/java/de/blau/android/Mode.java
+++ b/src/main/java/de/blau/android/Mode.java
@@ -87,7 +87,7 @@ public enum Mode {
             Filter filter = logic.getFilter();
             if (filter != null) {
                 if (!(filter instanceof IndoorFilter)) {
-                    filter.saveState();
+                    filter.saveState(main);
                     filter.hideControls();
                     filter.removeControls();
                     IndoorFilter indoor = new IndoorFilter();
@@ -111,7 +111,7 @@ public enum Mode {
             // needs to be removed here and previous filter, if any, restored
             Filter filter = logic.getFilter();
             if (filter instanceof IndoorFilter) {
-                filter.saveState();
+                filter.saveState(main);
                 filter.hideControls();
                 filter.removeControls();
                 filter = filter.getSavedFilter();
@@ -149,7 +149,7 @@ public enum Mode {
             Filter filter = logic.getFilter();
             if (filter != null) {
                 if (!(filter instanceof CorrectFilter)) {
-                    filter.saveState();
+                    filter.saveState(main);
                     filter.hideControls();
                     filter.removeControls();
                     CorrectFilter complete = new CorrectFilter();
@@ -171,7 +171,7 @@ public enum Mode {
             // needs to be removed here and previous filter, if any, restored
             Filter filter = logic.getFilter();
             if (filter instanceof CorrectFilter) {
-                filter.saveState();
+                filter.saveState(main);
                 filter.hideControls();
                 filter.removeControls();
                 filter = filter.getSavedFilter();

--- a/src/main/java/de/blau/android/filter/Filter.java
+++ b/src/main/java/de/blau/android/filter/Filter.java
@@ -166,7 +166,7 @@ public abstract class Filter implements Serializable {
     /**
      * Save the state of this filter
      */
-    public void saveState() {
+    public void saveState(@NonNull Context ctx) {
     }
 
     /**

--- a/src/main/java/de/blau/android/filter/PresetFilter.java
+++ b/src/main/java/de/blau/android/filter/PresetFilter.java
@@ -45,7 +45,6 @@ public class PresetFilter extends CommonFilter {
     private transient SavingHelper<PresetElementPath> savingHelper = new SavingHelper<>();
 
     private transient Preset[]      preset          = null;
-    private transient Context       context;
     private transient PresetElement element         = null;
     private PresetElementPath       path            = null;
     private boolean                 includeWayNodes = false;
@@ -69,13 +68,14 @@ public class PresetFilter extends CommonFilter {
     /**
      * Set the PresetItem or PresetGroup that is used for filtering
      * 
+     * @param ctx an Androic Context
      * @param path the PresetELementPath of the item to use
      */
-    void setPresetElement(@NonNull PresetElementPath path) {
+    void setPresetElement(@NonNull Context ctx, @NonNull PresetElementPath path) {
         clear();
         this.path = path;
-        Preset[] presets = App.getCurrentPresets(context);
-        Preset searchPreset = App.getCurrentRootPreset(context);
+        Preset[] presets = App.getCurrentPresets(ctx);
+        Preset searchPreset = App.getCurrentRootPreset(ctx);
         element = Preset.getElementByPath(searchPreset.getRootGroup(), path);
         if (element == null) {
             if (presetFilterButton != null) {
@@ -96,7 +96,7 @@ public class PresetFilter extends CommonFilter {
         if (update != null) {
             update.execute();
         }
-        setIcon(context);
+        setIcon(ctx);
     }
 
     /**
@@ -112,18 +112,17 @@ public class PresetFilter extends CommonFilter {
     @Override
     public void init(Context context) {
         Log.d(DEBUG_TAG, "init");
-        this.context = context;
         clear();
         if (path != null) {
-            setPresetElement(path);
+            setPresetElement(context, path);
         }
     }
 
     @Override
-    public void saveState() {
+    public void saveState(@NonNull Context ctx) {
         synchronized (this) {
             if (path != null && savingHelper != null) {
-                savingHelper.save(context, FILENAME, path, false);
+                savingHelper.save(ctx, FILENAME, path, false);
             }
         }
     }

--- a/src/main/java/de/blau/android/filter/PresetFilterActivity.java
+++ b/src/main/java/de/blau/android/filter/PresetFilterActivity.java
@@ -239,7 +239,7 @@ public class PresetFilterActivity extends ConfigurationChangeAwareActivity imple
             filter = (PresetFilter) tempFilter;
             final PresetElementPath path = element.getPath(rootGroup);
             if (path != null) {
-                filter.setPresetElement(path);
+                filter.setPresetElement(this, path);
                 currentGroup.getGroupView(this, presetView, this, null, null, element, null);
             }
             presetView.invalidate();


### PR DESCRIPTION
In some situations we might be setting the preset filter icon but the copy of context in the filter is null, and the same for saving state.

This change explicitly passes a current Context object to the relevant methods.