### PR TITLE
Save review state and improve selection logic

### DIFF
--- a/documentation/docs/help/en/Main map display.md
+++ b/documentation/docs/help/en/Main map display.md
@@ -187,7 +187,7 @@ To reposition or remove the "on-map" GPS button use the "Follow position button 
 Select either the transfer icon ![Transfer](../images/menu_transfer.png) or the "Transfer" menu item. This will display seven or eight options:
 
  * **Upload data to OSM server...** - review and upload changes to OpenStreetMap, the entry is disabled if you haven't changed anything yet, or there is no network available. See [Uploading your changes](Uploading%20your%20changes.md) for more information *(requires authentication)* *(requires network connectivity)*
- * **Review changes...** - review current changes, and potentially select them for upload.
+ * **Review changes...** - review current changes, and potentially select them for upload. The selection is persistent, that means you can select an OSM element for upload exit the modal and it will be re-selected. Note: if you select an element that requires other elements to be uploaded with them, they will be selected too, and the same if you de-select such an object the dependent elements will be de-selected too.
  * **Download current view** - download the area visible on the screen and merge it with existing data *(requires network connectivity)*
  * **Clear and download current view** - clear any data in memory and then download the area visible on the screen *(requires network connectivity)*
  * **Query Overpass...** - run a query against a Overpass API server, see [Overpass queries](#overpass_queries). *(requires network connectivity)*

--- a/src/androidTest/java/de/blau/android/dialogs/ReviewChangesTest.java
+++ b/src/androidTest/java/de/blau/android/dialogs/ReviewChangesTest.java
@@ -28,6 +28,7 @@ import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiObject2;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiSelector;
+import androidx.test.uiautomator.Until;
 import de.blau.android.App;
 import de.blau.android.LayerUtils;
 import de.blau.android.Logic;
@@ -184,8 +185,6 @@ public class ReviewChangesTest {
 
         itemCheckBox.click();
         TestUtils.sleep(5000); // hack
-        uploadButton = device.findObject(uiSelector0);
-        assertNotNull(uploadButton);
         try {
             assertTrue(uploadButton.isEnabled());
             uploadButton.click();
@@ -260,5 +259,49 @@ public class ReviewChangesTest {
         } catch (UiObjectNotFoundException e1) {
             fail(e1.getMessage());
         }
+    }
+
+    /**
+     * Select change to upload exit restart and check that it is still there
+     */
+    @Test
+    public void selectChanges3() {
+        Logic logic = App.getLogic();
+        Node bd = (Node) App.getDelegator().getOsmElement(Node.NAME, 101792984L);
+        assertNotNull(bd);
+        Map<String, String> tags = new HashMap<>(bd.getTags());
+        tags.put(Tags.KEY_NAME, "Dietikonberg");
+        tags.put(Tags.KEY_WIKIPEDIA, "en:Bergdietikon");
+
+        logic.setTags(main, bd, tags);
+        assertTrue(TestUtils.clickMenuButton(device, main.getString(R.string.menu_transfer), false, true));
+
+        assertTrue(TestUtils.clickText(device, false, main.getString(R.string.menu_transfer_review), true, false));
+
+        UiObject2 itemText = TestUtils.findObjectWithText(device, false, "Dietikonberg", 1000, false);
+        assertNotNull(itemText);
+        UiObject2 itemCheckBox = itemText.getParent().findObject(By.res(device.getCurrentPackageName() + ":id/checkBox1"));
+
+        itemCheckBox.click();
+        assertTrue(itemCheckBox.isChecked());
+
+        UiSelector uiSelector1 = new UiSelector().className("android.widget.Button").instance(1); //
+
+        UiObject doneButton = device.findObject(uiSelector1);
+        assertNotNull(doneButton);
+        device.performActionAndWait(() -> {
+            try {
+                doneButton.click();
+            } catch (UiObjectNotFoundException e) {
+                fail(e.getMessage());
+            }
+        }, Until.newWindow(), 5000);
+        assertTrue(TestUtils.clickMenuButton(device, main.getString(R.string.menu_transfer), false, true));
+        assertTrue(TestUtils.clickText(device, false, main.getString(R.string.menu_transfer_review), true, false));
+
+        itemText = TestUtils.findObjectWithText(device, false, "Dietikonberg", 1000, false);
+        assertNotNull(itemText);
+        itemCheckBox = itemText.getParent().findObject(By.res(device.getCurrentPackageName() + ":id/checkBox1"));
+        assertTrue(itemCheckBox.isChecked());
     }
 }

--- a/src/main/assets/help/en/Main map display.html
+++ b/src/main/assets/help/en/Main map display.html
@@ -192,7 +192,7 @@
 <p>Select either the transfer icon <img src="../images/menu_transfer.png" alt="Transfer" /> or the &quot;Transfer&quot; menu item. This will display seven or eight options:</p>
 <ul>
 <li><strong>Upload data to OSM server...</strong> - review and upload changes to OpenStreetMap, the entry is disabled if you haven't changed anything yet, or there is no network available. See <a href="Uploading%20your%20changes.md">Uploading your changes</a> for more information <em>(requires authentication)</em> <em>(requires network connectivity)</em></li>
-<li><strong>Review changes...</strong> - review current changes, and potentially select them for upload.</li>
+<li><strong>Review changes...</strong> - review current changes, and potentially select them for upload. The selection is persistent, that means you can select an OSM element for upload exit the modal and it will be re-selected. Note: if you select an element that requires other elements to be uploaded with them, they will be selected too, and the same if you de-select such an object the dependent elements will be de-selected too.</li>
 <li><strong>Download current view</strong> - download the area visible on the screen and merge it with existing data <em>(requires network connectivity)</em></li>
 <li><strong>Clear and download current view</strong> - clear any data in memory and then download the area visible on the screen <em>(requires network connectivity)</em></li>
 <li><strong>Query Overpass...</strong> - run a query against a Overpass API server, see <a href="#overpass_queries">Overpass queries</a>. <em>(requires network connectivity)</em></li>

--- a/src/main/java/de/blau/android/dialogs/ReviewAndUpload.java
+++ b/src/main/java/de/blau/android/dialogs/ReviewAndUpload.java
@@ -150,6 +150,7 @@ public class ReviewAndUpload extends AbstractReviewDialog {
         return f;
     }
 
+    @SuppressWarnings("unchecked")
     @NonNull
     @SuppressLint("InflateParams")
     @Override
@@ -335,7 +336,7 @@ public class ReviewAndUpload extends AbstractReviewDialog {
 
     protected void createChangesView() {
         addChangesToView(getActivity(), (ListView) requireDialog().findViewById(R.id.upload_changes), elements, DEFAULT_COMPARATOR,
-                getArguments().getString(TAG_KEY), R.layout.changes_list_item);
+                getArguments().getString(TAG_KEY), R.layout.changes_list_item, null, null);
     }
 
     /**

--- a/src/main/java/de/blau/android/osm/StorageDelegator.java
+++ b/src/main/java/de/blau/android/osm/StorageDelegator.java
@@ -3379,12 +3379,12 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
     /**
      * Add any required referenced elements to upload
      * 
-     * @param context and Android Context
+     * @param context an Android Context if null no toast will be generated
      * @param elements the List of elements
      * @return the List of elements for convenience
      */
     @NonNull
-    public List<OsmElement> addRequiredElements(@NonNull final Context context, @NonNull final List<OsmElement> elements) {
+    public List<OsmElement> addRequiredElements(@Nullable final Context context, @NonNull final List<OsmElement> elements) {
         Set<OsmElement> additionalElements = new HashSet<>();
         // add parent elements containing new elements that have been selected for upload
         for (OsmElement e : elements) {
@@ -3428,7 +3428,9 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
         if (added > 0) {
             // upload will sort elements correctly
             elements.addAll(additionalElements);
-            ScreenMessage.toastTopWarning(context, context.getResources().getQuantityString(R.plurals.added_required_elements, added, added));
+            if (context != null) {
+                ScreenMessage.toastTopWarning(context, context.getResources().getQuantityString(R.plurals.added_required_elements, added, added));
+            }
         }
         return elements;
     }


### PR DESCRIPTION
This PR makes the reviewed/selection state persistent, that is you can exit the modal and, if the elements are still available, on restarting the modal the changes will still be present, making it substantially more useful.

This further fixes an issue in which it was possible to use the modal to bypass the checks that added dependent elements to ensure referential consistency and adds code to automatically select such elements in the modal as visual feedback.

Partially resolves https://github.com/MarcusWolschon/osmeditor4android/issues/3012