### PR TITLE
Improve way reversing logic

### DIFF
--- a/src/main/java/de/blau/android/osm/MergeAction.java
+++ b/src/main/java/de/blau/android/osm/MergeAction.java
@@ -216,7 +216,7 @@ public class MergeAction {
             Map<String, String> dirTags = Reverse.getDirectionDependentTags(w2);
             if (!dirTags.isEmpty()) {
                 Reverse.reverseDirectionDependentTags(w2, dirTags, true);
-                mergeResult.addIssue(ReverseIssue.TAGSREVERSED);
+                mergeResult.addIssue(ReverseIssue.TAGS_REVERSED);
             }
             if (w2.notReversable()) {
                 mergeResult.addIssue(MergeIssue.NOTREVERSABLE);
@@ -239,7 +239,7 @@ public class MergeAction {
             Map<String, String> dirTags = Reverse.getDirectionDependentTags(w2);
             if (!dirTags.isEmpty()) {
                 Reverse.reverseDirectionDependentTags(w2, dirTags, true);
-                mergeResult.addIssue(ReverseIssue.TAGSREVERSED);
+                mergeResult.addIssue(ReverseIssue.TAGS_REVERSED);
             }
             if (w2.notReversable()) {
                 mergeResult.addIssue(MergeIssue.NOTREVERSABLE);
@@ -396,7 +396,7 @@ public class MergeAction {
             Map<String, String> dirTags = Reverse.getDirectionDependentTags(p2);
             if (!dirTags.isEmpty()) {
                 Reverse.reverseDirectionDependentTags(p2, dirTags, true);
-                mergeResult.addIssue(ReverseIssue.TAGSREVERSED);
+                mergeResult.addIssue(ReverseIssue.TAGS_REVERSED);
             }
             if (p1.notReversable()) {
                 mergeResult.addIssue(MergeIssue.NOTREVERSABLE);

--- a/src/main/java/de/blau/android/osm/ReverseIssue.java
+++ b/src/main/java/de/blau/android/osm/ReverseIssue.java
@@ -4,21 +4,23 @@ import android.content.Context;
 import de.blau.android.R;
 
 public enum ReverseIssue implements Issue {
-    NOTREVERSABLE, SHAREDNODE, TAGSREVERSED, ROLEREVERSED, ONEWAYDIRECTIONREVERSED;
+    NOT_REVERSABLE, SHARED_NODE, TAGS_REVERSED, ROLE_REVERSED, ONEWAY_DIRECTION_REVERSED, ONEWAY_REVERSING_NOT_SUPPORTED;
 
     @Override
     public String toTranslatedString(Context context) {
         switch (this) {
-        case NOTREVERSABLE:
+        case NOT_REVERSABLE:
             return context.getString(R.string.issue_not_reversable);
-        case SHAREDNODE:
+        case SHARED_NODE:
             return context.getString(R.string.issue_shared_node);
-        case TAGSREVERSED:
+        case TAGS_REVERSED:
             return context.getString(R.string.issue_tags_reversed);
-        case ROLEREVERSED:
+        case ROLE_REVERSED:
             return context.getString(R.string.issue_role_reversed);
-        case ONEWAYDIRECTIONREVERSED:
+        case ONEWAY_DIRECTION_REVERSED:
             return context.getString(R.string.issue_oneway_direction_reversed);
+        case ONEWAY_REVERSING_NOT_SUPPORTED:
+            return context.getString(R.string.issue_oneway_reversing_not_supported);
         default:
             return "";
         }
@@ -26,6 +28,6 @@ public enum ReverseIssue implements Issue {
 
     @Override
     public boolean isError() {
-        return this != TAGSREVERSED && this != ROLEREVERSED && this != ONEWAYDIRECTIONREVERSED;
+        return this != TAGS_REVERSED && this != ROLE_REVERSED && this != ONEWAY_DIRECTION_REVERSED;
     }
 }

--- a/src/main/java/de/blau/android/osm/StorageDelegator.java
+++ b/src/main/java/de/blau/android/osm/StorageDelegator.java
@@ -1956,12 +1956,12 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
         if (!dirTags.isEmpty()) {
             Result wayResult = new Result();
             wayResult.setElement(way);
-            final boolean containsOneWay = dirTags.containsKey(Tags.KEY_ONEWAY);
-            if (containsOneWay) {
-                wayResult.addIssue(ReverseIssue.ONEWAYDIRECTIONREVERSED);
+            final Map<String, String> oneWayTags = Reverse.getOnewayTags(dirTags);
+            if (!oneWayTags.isEmpty()) {
+                wayResult.addIssue(ReverseIssue.ONEWAY_DIRECTION_REVERSED);
             }
-            if (dirTags.size() > 1 || !containsOneWay) {
-                wayResult.addIssue(ReverseIssue.TAGSREVERSED);
+            if (dirTags.size() > oneWayTags.size()) {
+                wayResult.addIssue(ReverseIssue.TAGS_REVERSED);
             }
             wayResult.addTags(dirTags);
             result.add(wayResult);
@@ -1975,7 +1975,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
             for (Relation r : dirRelations) {
                 Result relationResult = new Result();
                 relationResult.setElement(r);
-                relationResult.addIssue(ReverseIssue.ROLEREVERSED);
+                relationResult.addIssue(ReverseIssue.ROLE_REVERSED);
                 result.add(relationResult);
                 r.updateState(OsmElement.STATE_MODIFIED);
                 apiStorage.insertElementSafe(r);
@@ -2002,10 +2002,10 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
                 undo.save(n);
                 Result nodeResult = new Result();
                 nodeResult.setElement(n);
-                nodeResult.addIssue(ReverseIssue.TAGSREVERSED);
+                nodeResult.addIssue(ReverseIssue.TAGS_REVERSED);
                 nodeResult.addTags(nodeDirTags);
                 if (getCurrentStorage().getWays(n).size() > 1) {
-                    nodeResult.addIssue(ReverseIssue.SHAREDNODE);
+                    nodeResult.addIssue(ReverseIssue.SHARED_NODE);
                 }
                 result.add(nodeResult);
                 Reverse.reverseDirectionDependentTags(n, nodeDirTags, true);

--- a/src/main/java/de/blau/android/osm/Way.java
+++ b/src/main/java/de/blau/android/osm/Way.java
@@ -429,22 +429,20 @@ public class Way extends StyledOsmElement implements WayInterface, BoundedObject
         }
 
         String barrier = getTagWithKey(Tags.KEY_BARRIER);
-        if (barrier != null) {
-            if (Tags.VALUE_RETAINING_WALL.equals(barrier)) {
-                return true;
-            }
-            if (Tags.VALUE_KERB.equals(barrier)) {
-                return true;
-            }
-            if (Tags.VALUE_GUARD_RAIL.equals(barrier)) {
-                return true;
-            }
-            String twoSided = getTagWithKey(Tags.KEY_TWO_SIDED);
-            if (Tags.VALUE_CITY_WALL.equals(barrier) && (twoSided == null || !Tags.VALUE_YES.equals(twoSided))) {
-                return true;
-            }
+        if (barrier == null) {
+            return false;
         }
-        return false;
+        if (Tags.VALUE_RETAINING_WALL.equals(barrier)) {
+            return true;
+        }
+        if (Tags.VALUE_KERB.equals(barrier)) {
+            return true;
+        }
+        if (Tags.VALUE_GUARD_RAIL.equals(barrier)) {
+            return true;
+        }
+        String twoSided = getTagWithKey(Tags.KEY_TWO_SIDED);
+        return Tags.VALUE_CITY_WALL.equals(barrier) && (twoSided == null || !Tags.VALUE_YES.equals(twoSided));
     }
 
     @Override

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1786,6 +1786,7 @@
     <string name="issue_tags_reversed">Tags reversed</string>
     <string name="issue_role_reversed">Role reversed</string>
     <string name="issue_oneway_direction_reversed">Oneway direction reversed</string>
+    <string name="issue_oneway_reversing_not_supported">Unsupported oneway tag</string>
     <string name="issue_role_conflict">Role conflict</string>
     <string name="issue_merged_tags">Merged tags</string>
     <string name="issue_same_object">Same object</string>

--- a/src/test/java/de/blau/android/osm/ReverseTest.java
+++ b/src/test/java/de/blau/android/osm/ReverseTest.java
@@ -40,6 +40,9 @@ public class ReverseTest {
         reverseTag("oneway", "yes", "-1");
         reverseTag("oneway", "true", "-1");
         reverseTag("oneway", "1", "-1");
+        reverseTag("oneway:bicycle", "yes", "-1");
+        reverseTag("oneway:conditional", "yes @ wet", "-1 @ wet"); 
+        reverseTag("oneway:hgv:conditional", "yes @ 09:00-15:00", "-1 @ 09:00-15:00"); 
         reverseTag("conveying", "forward", "backward");
         reverseTag("conveying", "backward", "forward");
         reverseTag("priority", "forward", "backward");
@@ -55,7 +58,17 @@ public class ReverseTest {
         Map<String, String> dirTags = Reverse.getDirectionDependentTags(e);
         assertFalse(dirTags.containsKey("oneway"));
     }
-
+    
+    @Test
+    public void ignoreNoOneWay2() {
+        Map<String, String> tags = new HashMap<>();
+        tags.put("oneway", "false");
+        Way e = OsmElementFactory.createWay(-1L, 1L, System.currentTimeMillis() / 1000, OsmElement.STATE_CREATED);
+        e.setTags(tags);
+        Map<String, String> dirTags = Reverse.getDirectionDependentTags(e);
+        assertFalse(dirTags.containsKey("oneway"));
+    }
+    
     /**
      * Test that way reversing has the intended effects on a way node
      */

--- a/src/test/java/de/blau/android/osm/StorageDelegatorTest.java
+++ b/src/test/java/de/blau/android/osm/StorageDelegatorTest.java
@@ -241,7 +241,7 @@ public class StorageDelegatorTest {
             assertEquals(originalNodes.get(i).getLon(), dupNodes.get(i).getLon());
         }
     }
-    
+
     /**
      * Test duplication with missing member, should throw an exception
      */
@@ -254,7 +254,7 @@ public class StorageDelegatorTest {
         d.insertElementSafe(r);
         try {
             d.duplicate(Util.wrapInList(r), true);
-        } catch (OsmIllegalOperationException ex ) {
+        } catch (OsmIllegalOperationException ex) {
             // expected
             return;
         }
@@ -808,9 +808,9 @@ public class StorageDelegatorTest {
         assertFalse(result.get(0).hasIssue());
         assertNull(d.getOsmElement(Node.NAME, n1.getOsmId()));
         assertNotNull(d.getOsmElement(Node.NAME, n2.getOsmId()));
-        assertEquals(toE7(0.005),n2.lon); 
+        assertEquals(toE7(0.005), n2.lon);
     }
-    
+
     /**
      * Merge two nodes
      */
@@ -829,7 +829,7 @@ public class StorageDelegatorTest {
         assertFalse(result.get(0).hasIssue());
         assertNull(d.getOsmElement(Node.NAME, n1.getOsmId()));
         assertNotNull(d.getOsmElement(Node.NAME, n2.getOsmId()));
-        assertEquals(toE7(0.006),n2.lon); 
+        assertEquals(toE7(0.006), n2.lon);
     }
 
     /**
@@ -1906,7 +1906,7 @@ public class StorageDelegatorTest {
         assertTrue(toUpload.contains(newNode));
         assertTrue(toUpload.contains(sd.getOsmElement(Way.NAME, 28075087L)));
     }
-    
+
     /**
      * Upload of modified way needs to include newly created node
      */
@@ -1921,7 +1921,7 @@ public class StorageDelegatorTest {
         assertTrue(toUpload.contains(modifiedWay));
         assertTrue(toUpload.contains(sd.getOsmElement(Node.NAME, -1L)));
     }
-    
+
     /**
      * Upload of modified relation needs to include newly created way
      */
@@ -1937,5 +1937,68 @@ public class StorageDelegatorTest {
         assertTrue(toUpload.contains(sd.getOsmElement(Way.NAME, -1L)));
         assertTrue(toUpload.contains(sd.getOsmElement(Node.NAME, -2L)));
         assertTrue(toUpload.contains(sd.getOsmElement(Node.NAME, -3L)));
+    }
+
+    /**
+     * Reverse a way
+     */
+    @Test
+    public void reverseWay1() {
+        StorageDelegator d = new StorageDelegator();
+        Way w = DelegatorUtil.addWayToStorage(d, false);
+        Node firstNode = w.getFirstNode();
+        Node lastNode = w.getLastNode();
+        SortedMap<String, String> tags = new TreeMap<>(w.getTags());
+        tags.put(Tags.KEY_HIGHWAY, "residential");
+        tags.put(Tags.KEY_ONEWAY, Tags.VALUE_YES);
+        w.setTags(tags);
+        List<Result> result = d.reverseWay(w);
+        assertEquals(1, result.size());
+        assertEquals(1, result.get(0).getIssues().size());
+        assertEquals(ReverseIssue.ONEWAY_DIRECTION_REVERSED, new ArrayList<Issue>(result.get(0).getIssues()).get(0));
+        assertTrue(w.hasTag(Tags.KEY_ONEWAY, Tags.VALUE_YES)); // shouldn't change
+        assertEquals(lastNode, w.getFirstNode());
+        assertEquals(firstNode, w.getLastNode());
+    }
+    
+    /**
+     * Reverse a way
+     */
+    @Test
+    public void reverseWay2() {
+        StorageDelegator d = new StorageDelegator();
+        Way w = DelegatorUtil.addWayToStorage(d, false);
+        Node firstNode = w.getFirstNode();
+        Node lastNode = w.getLastNode();
+        SortedMap<String, String> tags = new TreeMap<>(w.getTags());
+        tags.put(Tags.KEY_HIGHWAY, "residential");
+        tags.put(Tags.KEY_SIDEWALK + ":left", Tags.VALUE_YES);
+        w.setTags(tags);
+        List<Result> result = d.reverseWay(w);
+        assertEquals(1, result.size());
+        assertEquals(1, result.get(0).getIssues().size());
+        assertEquals(ReverseIssue.TAGS_REVERSED, new ArrayList<Issue>(result.get(0).getIssues()).get(0));
+        w.hasTag(Tags.KEY_SIDEWALK + ":right", Tags.VALUE_YES);
+        assertEquals(lastNode, w.getFirstNode());
+        assertEquals(firstNode, w.getLastNode());
+    }
+    
+    /**
+     * Reverse a way
+     */
+    @Test
+    public void reverseWay3() {
+        StorageDelegator d = new StorageDelegator();
+        Way w = DelegatorUtil.addWayToStorage(d, false);
+        Node firstNode = w.getFirstNode();
+        Node lastNode = w.getLastNode();
+        SortedMap<String, String> tags = new TreeMap<>(w.getTags());
+        tags.put(Tags.KEY_HIGHWAY, "residential");
+        tags.put(Tags.KEY_ONEWAY, Tags.VALUE_NO);
+        w.setTags(tags);
+        List<Result> result = d.reverseWay(w);
+        assertEquals(0, result.size());
+        assertEquals(lastNode, w.getFirstNode());
+        assertEquals(firstNode, w.getLastNode());
     }
 }


### PR DESCRIPTION
- fix issue that caused a "tags reversed" waring to be added even if just a oneway tag was present.
- support tags prefixed with oneway, not just oneway itself
- support conditional oneway tags

Resolves https://github.com/MarcusWolschon/osmeditor4android/issues/2929