### PR TITLE
Protect properly against relation loops when adding required elements

### DIFF
--- a/src/main/java/de/blau/android/osm/StorageDelegator.java
+++ b/src/main/java/de/blau/android/osm/StorageDelegator.java
@@ -3442,11 +3442,14 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
      */
     private static void addRelationMembersToUpload(@NonNull Set<OsmElement> uploadElements, @NonNull Relation r) {
         for (RelationMember rm : r.getMembers()) {
-            if (rm.getRef() < 0) { // neg id == new element
-                OsmElement member = rm.getElement();
-                if (member instanceof Relation && !uploadElements.contains(member)) {
-                    addRelationMembersToUpload(uploadElements, r);
-                }
+            if (rm.getRef() > 0) { // neg id == new element
+                continue;
+            }
+            OsmElement member = rm.getElement();
+            if (member instanceof Relation && !uploadElements.contains(member)) {
+                uploadElements.add(member); // loop protection
+                addRelationMembersToUpload(uploadElements, r);
+            } else {
                 uploadElements.add(member);
             }
         }

--- a/src/test/java/de/blau/android/osm/StorageDelegatorTest.java
+++ b/src/test/java/de/blau/android/osm/StorageDelegatorTest.java
@@ -1967,6 +1967,28 @@ public class StorageDelegatorTest {
         assertTrue(toUpload.contains(sd.getOsmElement(Node.NAME, -2L)));
         assertTrue(toUpload.contains(sd.getOsmElement(Node.NAME, -3L)));
     }
+    
+    /**
+     * As above but check that we protect against relation loops
+     */
+    @Test
+    public void uploadModifiedRelationTest2() {
+        StorageDelegator sd = UnitTestUtils.loadTestData(getClass(), "selective-upload2.osm");
+        Relation modifiedRelation = (Relation) sd.getOsmElement(Relation.NAME, 29169L);
+        assertNotNull(modifiedRelation);
+        Relation loop = sd.createAndInsertRelation(Util.wrapInList(modifiedRelation));
+        loop.addMember(new RelationMember("", loop));
+        modifiedRelation.addMember(new RelationMember("", loop));
+        
+        List<OsmElement> toUpload = new ArrayList<>();
+        toUpload.add(modifiedRelation);
+        sd.addRequiredElements(ApplicationProvider.getApplicationContext(), toUpload);
+        assertTrue(toUpload.contains(modifiedRelation));
+        assertTrue(toUpload.contains(loop));
+        assertTrue(toUpload.contains(sd.getOsmElement(Way.NAME, -1L)));
+        assertTrue(toUpload.contains(sd.getOsmElement(Node.NAME, -2L)));
+        assertTrue(toUpload.contains(sd.getOsmElement(Node.NAME, -3L)));
+    }
 
     /**
      * Reverse a way


### PR DESCRIPTION
A loop in a relation member could result in adding relation members to upload to infinitely loop.