### PR TITLE
Improve handling of synonyms that refer to "two level" presets

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -687,6 +687,7 @@ dependencies {
     implementation 'ch.poole.android:indeterminate-checkbox:1.1.0@aar'
     implementation 'ch.poole.misc:bentley-ottmann:0.1.1'
     implementation 'ch.poole.geo.pmtiles-reader:Reader:0.3.7'
+    implementation 'ch.poole:preset-utils:0.44.0'
     
     // for temp stuff during dev
     // implementation(name:'alibrary', ext:'jar')

--- a/src/test/java/de/blau/android/presets/SynonymsTest.java
+++ b/src/test/java/de/blau/android/presets/SynonymsTest.java
@@ -63,4 +63,27 @@ public class SynonymsTest {
         }
         fail("petrol station not found");
     }
+
+    /**
+     * Check that 2nd level tag replacements work
+     */
+    @Test
+    public void secondLevelTest() {
+        Locale.setDefault(new Locale("en", "AU"));
+        Synonyms s = new Synonyms(ApplicationProvider.getApplicationContext());
+        List<IndexSearchResult> results = s.search(ApplicationProvider.getApplicationContext(), "petrol", null, 2);
+        boolean found = false;
+        for (IndexSearchResult isr : results) {
+            PresetTagField field = isr.getItem().getField("vending");
+
+            if (field instanceof PresetFixedField) {
+                // we should not have any fixed tags with vending just the regular vending machine preset
+                assertEquals("fuel", ((PresetFixedField) field).getValue().getValue());
+            }
+            if (field instanceof PresetComboField) {
+                found = true;
+            }
+        }
+        assertTrue(found);
+    }
 }


### PR DESCRIPTION
Replace second level tag with mapping from preset utils if necessary.

See https://github.com/simonpoole/beautified-JOSM-preset/issues/509