### PR TITLE
Take a belt and suspenders approach to avoiding runaway alerts

### DIFF
--- a/src/main/java/de/blau/android/dialogs/ErrorAlert.java
+++ b/src/main/java/de/blau/android/dialogs/ErrorAlert.java
@@ -167,6 +167,10 @@ public class ErrorAlert extends CancelableDialogFragment {
         try {
             String tag = getTag(errorCode);
             if (alertDialogFragment != null && tag != null) {
+                if (fm.findFragmentByTag(tag) != null) {
+                    Log.w(DEBUG_TAG, "dialog still being displayed " + tag);
+                    return;
+                }
                 alertDialogFragment.show(fm, tag);
             } else {
                 Log.e(DEBUG_TAG, "Unable to create dialog for value " + errorCode);

--- a/src/main/java/de/blau/android/dialogs/Util.java
+++ b/src/main/java/de/blau/android/dialogs/Util.java
@@ -69,7 +69,7 @@ public final class Util {
             ft.remove(fragment);
         }
         try {
-            ft.commit();
+            ft.commitNowAllowingStateLoss();
         } catch (IllegalStateException isex) {
             Log.e(DEBUG_TAG, "dismissDialog " + tag, isex);
         }


### PR DESCRIPTION
This should fix a rare situation in which errors are being produced faster than the error alerts were being dismissed. Case in hand the alert notifying that auto downloads has been paused when the API is not responding/throwing errors.