### PR TITLE
Try to stop users from misusing the address interpolation tool

### DIFF
--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -798,6 +798,14 @@ public class Logic {
             Log.e(DEBUG_TAG, "Attempted to setTags on a non-existing element");
             throw new OsmIllegalOperationException("Element not in storage");
         }
+        if (tags != null) {
+            for (String v : tags.values()) {
+                if (Util.isEmpty(v) || "".equals(v.trim())) {
+                    Log.e(DEBUG_TAG, "Attempted to set empty value in setTags");
+                    throw new OsmIllegalOperationException("Attempting to set an empty tag value");
+                }
+            }
+        }
         try {
             lock();
             if (createCheckpoint) {
@@ -4551,8 +4559,9 @@ public class Logic {
                         // invalid dimensions or similar error
                         viewBox.setBorders(mainMap, new BoundingBox(-GeoMath.MAX_LON, -GeoMath.MAX_COMPAT_LAT, GeoMath.MAX_LON, GeoMath.MAX_COMPAT_LAT));
                     }
-                    mainMap.getDataStyleManager().updateStrokes(STROKE_FACTOR / viewBox.getWidth()); // safety measure if not
-                                                                                              // done in
+                    mainMap.getDataStyleManager().updateStrokes(STROKE_FACTOR / viewBox.getWidth()); // safety measure
+                                                                                                     // if not
+                    // done in
                     loadEditingState((Main) activity, true);
                 } else {
                     Log.e(DEBUG_TAG, "loadFromFile map is null");

--- a/src/main/java/de/blau/android/easyedit/AddressInterpolationActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/AddressInterpolationActionModeCallback.java
@@ -6,6 +6,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.view.ActionMode;
 import de.blau.android.R;
 import de.blau.android.dialogs.AddressInterpolationDialog;
+import de.blau.android.dialogs.Tip;
 import de.blau.android.osm.Node;
 import de.blau.android.osm.Way;
 import de.blau.android.util.SerializableState;
@@ -35,6 +36,7 @@ public class AddressInterpolationActionModeCallback extends PathCreationActionMo
      */
     public AddressInterpolationActionModeCallback(@NonNull EasyEditManager manager, float x, float y) {
         super(manager, x, y);
+        Tip.showDialog(main, R.string.tip_address_interpolation_key, R.string.tip_address_interpolation);
     }
 
     /**
@@ -46,6 +48,7 @@ public class AddressInterpolationActionModeCallback extends PathCreationActionMo
      */
     public AddressInterpolationActionModeCallback(@NonNull EasyEditManager manager, @NonNull Way way, @NonNull Node node) {
         super(manager, way, node);
+        Tip.showDialog(main, R.string.tip_address_interpolation_key, R.string.tip_address_interpolation);
     }
 
     @Override

--- a/src/main/java/de/blau/android/osm/StorageDelegator.java
+++ b/src/main/java/de/blau/android/osm/StorageDelegator.java
@@ -311,7 +311,6 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
             lock();
             dirty = true;
             undo.save(elem);
-
             if (elem.setTags(tags)) {
                 // OsmElement tags have changed
                 elem.updateState(OsmElement.STATE_MODIFIED);

--- a/src/main/java/de/blau/android/validation/EditTextValidator.java
+++ b/src/main/java/de/blau/android/validation/EditTextValidator.java
@@ -58,7 +58,7 @@ abstract class EditTextValidator implements AfterTextChangedWatcher, FormValidat
     /**
      * Clear any error
      */
-    private void clearError() {
+    public void clearError() {
         editText.setError(null);
     }
 }

--- a/src/main/java/de/blau/android/validation/NotEmptyValidator.java
+++ b/src/main/java/de/blau/android/validation/NotEmptyValidator.java
@@ -21,7 +21,7 @@ public class NotEmptyValidator extends EditTextValidator {
 
     @Override
     protected boolean isValid(@NonNull String text) {
-        return !text.isEmpty();
+        return !text.trim().isEmpty();
     }
 
     @NonNull

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -405,6 +405,9 @@
     <string name="even">Even</string>
     <string name="odd">Odd</string>
     <string name="other">Other</string>
+    <string name="validation_start_is_empty">You must provide a value for the first house number!</string>
+    <string name="validation_end_is_empty">You must provide a value for the last house number!</string>
+    <string name="validation_other_is_empty">If other is selected you must provide a value!</string>
     <!-- Safe split dialog -->
     <string name="split_safe_title">Missing relation members</string>
     <string name="split_safe_message">Neigbour relation member ways are not downloaded. Maintaining relation members ordering may depend on these.</string>
@@ -657,6 +660,7 @@
     <string name="tip_wms_tile_size">WMS servers can support larger tile sizes than 256x256, consider using 512x512 for a more efficient configuration.</string>
     <string name="tip_empty_comment_warning">Vespucci always adds an automatically created summary of what you uploaded.&lt;p&gt;You should still consider adding a few words on why you are making the edits to provide more context for other mappers.</string>
     <string name="tip_wikimedia_filename">Always use a descriptive and unique filename, in particular not a camera generated one or else Wikimedia will reject the upload.</string>
+    <string name="tip_address_interpolation">This tool is intended for adding address interpolations in Address mode. If you want to add a different object, switch to Normal mode and use the Add way tool.</string>
     <!--  NumberPicker -->
     <string name="plus_sign">+</string>
     <string name="minus_sign">-</string>

--- a/src/main/res/values/tipkeys.xml
+++ b/src/main/res/values/tipkeys.xml
@@ -27,4 +27,5 @@
     <string name="tip_wms_tile_size_key">wmsTileSize</string>
     <string name="tip_empty_comment_warning_key">emptyCommentWarning</string>
     <string name="tip_wikimedia_filename_key">wikimediaFilename</string>
+    <string name="tip_address_interpolation_key">addressInterpolation</string>
 </resources>

--- a/src/test/java/de/blau/android/osm/BasicStuffTest.java
+++ b/src/test/java/de/blau/android/osm/BasicStuffTest.java
@@ -161,6 +161,14 @@ public class BasicStuffTest {
         } catch (OsmIllegalOperationException e) {
             // carry on
         }
+        // empty value
+        tags.put(key2, "");
+        try {
+            logic.setTags(null, eInStorage, tags);
+            Assert.fail("should have faile for empty values");
+        } catch (OsmIllegalOperationException e) {
+            // expected
+        }
     }
 
     /**


### PR DESCRIPTION
This adds:

- a tip that the tool is only intended for adding address interpolations,
- validation of the start, end and if necessary "other" EditTexts to ensure they are not empty,
- a check in Logic to assure that no empty tag values are being added (this should have arguably always been the case, but user driven tag changes are as a rule done in the PropertyEditor that already does this check).

Thanks to @lonvia for reporting the issue.