### PR TITLE
Fix regression when de-selecting a row

### DIFF
--- a/src/main/java/de/blau/android/propertyeditor/RelationMemberSelectedActionModeCallback.java
+++ b/src/main/java/de/blau/android/propertyeditor/RelationMemberSelectedActionModeCallback.java
@@ -326,11 +326,10 @@ public class RelationMemberSelectedActionModeCallback extends SelectedRowsAction
     /**
      * Check if all rows have been de-selected
      * 
-     * @param skipHeaderRow if true skip the header row
      * @return true if no rows are selected
      */
     @Override
-    public boolean rowsDeselected(boolean skipHeaderRow) {
+    public boolean rowsDeselected() {
         for (MemberEntry entry : members) {
             if (entry.selected) {
                 // something is still selected

--- a/src/main/java/de/blau/android/propertyeditor/RelationMembersFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/RelationMembersFragment.java
@@ -904,7 +904,7 @@ public class RelationMembersFragment extends SelectableRowsFragment implements P
     public void deselectRow() {
         synchronized (actionModeCallbackLock) {
             if (actionModeCallback != null) {
-                if (actionModeCallback.rowsDeselected(true)) {
+                if (actionModeCallback.rowsDeselected()) {
                     actionModeCallback = null;
                 } else {
                     actionModeCallback.invalidate();

--- a/src/main/java/de/blau/android/propertyeditor/SelectableRowsFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/SelectableRowsFragment.java
@@ -81,17 +81,17 @@ public abstract class SelectableRowsFragment extends BaseFragment implements Pro
     @Override
     public void deselectRow() {
         synchronized (actionModeCallbackLock) {
-            if (actionModeCallback != null && actionModeCallback.rowsDeselected(true)) {
+            if (actionModeCallback != null && actionModeCallback.rowsDeselected()) {
                 actionModeCallback = null;
             }
         }
     }
-    
+
     @Override
     public void selectAllRows() {
         setSelectedRows((boolean current) -> true);
     }
-    
+
     @Override
     public void deselectAllRows() {
         setSelectedRows((boolean current) -> false);
@@ -101,25 +101,25 @@ public abstract class SelectableRowsFragment extends BaseFragment implements Pro
     public void invertSelectedRows() {
         setSelectedRows((boolean current) -> !current);
     }
-    
+
     /**
      * Iterate over all rows and set the selection status
      * 
      * @param change method that sets the selection status
      */
     protected abstract void setSelectedRows(@NonNull final ChangeSelectionStatus change);
-    
+
     @Override
     public void startStopActionModeIfRowSelected() {
         synchronized (actionModeCallbackLock) {
             if (actionModeCallback == null) {
                 actionModeCallback = getActionModeCallback();
-                if (!actionModeCallback.rowsDeselected(true)) {
+                if (!actionModeCallback.rowsDeselected()) {
                     ((AppCompatActivity) getActivity()).startSupportActionMode(actionModeCallback);
                 }
                 return;
             }
-            if (actionModeCallback.rowsDeselected(true)) {
+            if (actionModeCallback.rowsDeselected()) {
                 actionModeCallback = null;
             }
         }

--- a/src/main/java/de/blau/android/propertyeditor/SelectedRowsActionModeCallback.java
+++ b/src/main/java/de/blau/android/propertyeditor/SelectedRowsActionModeCallback.java
@@ -182,13 +182,11 @@ class SelectedRowsActionModeCallback implements Callback {
     /**
      * Check if all rows have been de-selected
      * 
-     * @param skipHeaderRow if true skip the header row
      * @return true if no rows are selected
      */
-    public boolean rowsDeselected(boolean skipHeaderRow) {
+    public boolean rowsDeselected() {
         final int size = rows.getChildCount();
-        int initialRowIndex = skipHeaderRow ? 1 : 0;
-        for (int i = initialRowIndex; i < size; i++) {
+        for (int i = 0; i < size; i++) {
             Row row = (Row) rows.getChildAt(i);
             if (row.isSelected()) {
                 // something is still selected


### PR DESCRIPTION
This is an off by one error originating in when we moved the header out of the row layout for the tag, relation membership and relation members tabs.