### PR TITLE
Fix Logical Errors and Integer Overflow in GeoMath.java

### DIFF
--- a/src/main/java/de/blau/android/util/GeoMath.java
+++ b/src/main/java/de/blau/android/util/GeoMath.java
@@ -250,19 +250,19 @@ public final class GeoMath {
         double top = lat + radiusDegree;
         if (left < -MAX_LON) {
             left = -MAX_LON;
-            right = left + radiusDegree * 2d;
+            right = left + horizontalRadiusDegree * 2d;
         }
         if (right > MAX_LON) {
-            right = MAX_LON_E7;
-            left = right - radiusDegree * 2d;
+            right = MAX_LON;
+            left = right - horizontalRadiusDegree * 2d;
         }
         if (bottom < -MAX_COMPAT_LAT) {
             bottom = -MAX_COMPAT_LAT;
-            top = bottom + horizontalRadiusDegree * 2d;
+            top = bottom + radiusDegree * 2d;
         }
         if (top > MAX_COMPAT_LAT) {
             top = MAX_COMPAT_LAT;
-            bottom = top - horizontalRadiusDegree * 2d;
+            bottom = top - radiusDegree * 2d;
         }
         return new BoundingBox(left, bottom, right, top);
     }

--- a/src/test/java/de/blau/android/util/GeoMathTest.java
+++ b/src/test/java/de/blau/android/util/GeoMathTest.java
@@ -10,6 +10,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import de.blau.android.exception.OsmException;
+import de.blau.android.osm.BoundingBox;
 import de.blau.android.osm.GeoPoint;
 import de.blau.android.osm.ViewBox;
 import de.blau.android.util.collections.FloatPrimitiveList;
@@ -303,5 +304,47 @@ public class GeoMathTest {
         assertEquals(p1, points.get(1));
         assertEquals(p2, points.get(2));
         assertEquals(p3, points.get(3));
+    }
+
+    @Test
+    public void createBoundingBoxForCoordinates() throws OsmException {
+        double lat = 0.0;
+        double lon = 0.0;
+        double radius = 1000.0;
+        BoundingBox bb = GeoMath.createBoundingBoxForCoordinates(lat, lon, radius);
+
+        double radiusDegree = GeoMath.convertMetersToGeoDistance(radius);
+        assertEquals(lon - radiusDegree, bb.getLeft() / 1E7D, 0.0001);
+        assertEquals(lat - radiusDegree, bb.getBottom() / 1E7D, 0.0001);
+        assertEquals(lon + radiusDegree, bb.getRight() / 1E7D, 0.0001);
+        assertEquals(lat + radiusDegree, bb.getTop() / 1E7D, 0.0001);
+
+        lat = 0.0;
+        lon = 180.0;
+        radius = 11000.0;
+        bb = GeoMath.createBoundingBoxForCoordinates(lat, lon, radius);
+        assertEquals(180.0, bb.getRight() / 1E7D, 0.0001);
+        assertEquals(180.0 - (GeoMath.convertMetersToGeoDistance(radius) * 2), bb.getLeft() / 1E7D, 0.0001);
+
+        lat = GeoMath.MAX_COMPAT_LAT;
+        lon = 0.0;
+        radius = 1000.0;
+
+        try {
+            GeoMath.createBoundingBoxForCoordinates(lat, lon, radius);
+            fail("Should have thrown OsmException for latitude out of range");
+        } catch (OsmException e) {
+            assertEquals("Latitude outside of range that can be projected to mercator coordinates", e.getMessage());
+        }
+
+        radiusDegree = GeoMath.convertMetersToGeoDistance(radius);
+        lat = GeoMath.MAX_COMPAT_LAT - radiusDegree + 0.0000001;
+
+        try {
+            GeoMath.createBoundingBoxForCoordinates(lat, lon, radius);
+            fail("Should have thrown OsmException for latitude top out of range");
+        } catch (OsmException e) {
+            assertEquals("Latitude outside of range that can be projected to mercator coordinates", e.getMessage());
+        }
     }
 }


### PR DESCRIPTION
Fixes #3134

### Summary
This PR fixes an issue in GeoMath.createBoundingBoxForCoordinates where:

- Latitude and longitude radius values were applied to the wrong axes.
- A scaled longitude constant caused an overflow during bounding box creation.

The changes correct the bounding box calculation and prevent overflow near extreme coordinates.

### Tests

Added one test case to verify correct bounding box behavior.