### PR TITLE
Fix map expansion in the Southern Hemisphere

### DIFF
--- a/src/main/java/de/blau/android/osm/ViewBox.java
+++ b/src/main/java/de/blau/android/osm/ViewBox.java
@@ -715,7 +715,8 @@ public class ViewBox extends BoundingBox {
         int deltaE7 = (int) (delta * 1E7);
         setTop(Math.min(GeoMath.MAX_COMPAT_LAT_E7, getTop() + deltaE7));
         setBottom(Math.max(-GeoMath.MAX_COMPAT_LAT_E7, getBottom() - deltaE7));
-        int deltaHE7 = (int) ((delta / Math.cos(Math.toRadians(getTop() / 1E7D))) * 1E7D);
+        double maxAbsLat = Math.max(Math.abs(getTop() / 1E7D), Math.abs(getBottom() / 1E7D));
+        int deltaHE7 = (int) ((delta / Math.cos(Math.toRadians(maxAbsLat))) * 1E7D);
         setLeft(Math.max(-GeoMath.MAX_LON_E7, getLeft() - deltaHE7));
         setRight(Math.min(GeoMath.MAX_LON_E7, getRight() + deltaHE7));
         calcDimensions();
@@ -735,7 +736,8 @@ public class ViewBox extends BoundingBox {
             setTop(Math.min(GeoMath.MAX_COMPAT_LAT_E7, getTop() + deltaE7));
             setBottom(Math.max(-GeoMath.MAX_COMPAT_LAT_E7, getBottom() - deltaE7));
         }
-        int minWE7 = (int) ((min / Math.cos(Math.toRadians(getTop() / 1E7D))) * 1E7D);
+        double maxAbsLat = Math.max(Math.abs(getTop() / 1E7D), Math.abs(getBottom() / 1E7D));
+        int minWE7 = (int) ((min / Math.cos(Math.toRadians(maxAbsLat))) * 1E7D);
         if (getWidth() < minWE7) {
             long deltaWE7 = (minWE7 - getWidth()) / 2;
             setLeft((int) Math.max(-GeoMath.MAX_LON_E7, getLeft() - deltaWE7));

--- a/src/test/java/de/blau/android/osm/ViewBoxTest.java
+++ b/src/test/java/de/blau/android/osm/ViewBoxTest.java
@@ -65,4 +65,17 @@ public class ViewBoxTest {
         assertEquals(45, center[1], 0.01);
     }
 
+    @Test
+    public void expansionSouthernHeisphereTest() throws Exception {
+        // Sydney, Australia: Lat -34.0, Lon 151.0
+        ViewBox viewBox = new ViewBox(151.0, -34.0, 151.1, -33.9);
+        viewBox.expand(1000.0);
+
+        // Verification should use the most pole-ward latitude (-34.0)
+        double delta = de.blau.android.util.GeoMath.convertMetersToGeoDistance(1000.0);
+        double expectedDeltaHE7 = (delta / Math.cos(Math.toRadians(34.0))) * 1E7D;
+
+        assertEquals(151.0 * 1E7 - expectedDeltaHE7, viewBox.getLeft(), 100);
+        assertEquals(151.1 * 1E7 + expectedDeltaHE7, viewBox.getRight(), 100);
+    }
 }


### PR DESCRIPTION
Closes #3138.

## What was wrong?
When the app tried to add extra space around the map (like a buffer), it didn't add enough room in places far south (like Australia or South Africa). This happened because the calculation was only looking at the top edge of the map.

## What was fixed?
I changed the code in `ViewBox.java` to look at whichever edge of the map is furthest from the Equator. This makes sure the map always adds enough extra space, no matter where you are in the world.

### The Change:
Instead of just using the top edge, we now check both the top and bottom edges and pick the one that is further from the Equator:
```java
// Find the edge furthest from the Equator
double maxAbsLat = Math.max(Math.abs(getTop() / 1E7D), Math.abs(getBottom() / 1E7D));
// Use that for the expansion calculation
int deltaHE7 = (int) ((delta / Math.cos(Math.toRadians(maxAbsLat))) * 1E7D);
```

### Tests
I added a new test also in viewbox called expansionSouthernHeisphereTest
 which confirms the math is now correct for Southern locations by checking the expansion at Latitude -34.0 (Sydney).