### PR TITLE
Add headers table to configuration export

### DIFF
--- a/src/main/java/de/blau/android/layer/tiles/ImageryLayerInfo.java
+++ b/src/main/java/de/blau/android/layer/tiles/ImageryLayerInfo.java
@@ -3,6 +3,7 @@ package de.blau.android.layer.tiles;
 import static de.blau.android.contract.Constants.LOG_TAG_LEN;
 
 import java.util.Collection;
+import java.util.List;
 
 import android.os.Bundle;
 import android.util.Log;
@@ -20,6 +21,7 @@ import de.blau.android.R;
 import de.blau.android.dialogs.LayerInfo;
 import de.blau.android.dialogs.TableLayoutUtils;
 import de.blau.android.resources.TileLayerSource;
+import de.blau.android.resources.TileLayerSource.Header;
 import de.blau.android.resources.TileLayerSource.Provider;
 import de.blau.android.util.DateFormatter;
 import de.blau.android.util.Util;
@@ -98,6 +100,13 @@ public class ImageryLayerInfo extends LayerInfo {
         }
         addAttribution(activity, tableLayout, tp);
         tableLayout.addView(TableLayoutUtils.createRow(activity, R.string.url, null, layer.getOriginalTileUrl(), false, tp));
+        List<Header> headers = layer.getHeaders();
+        if (!Util.isEmpty(headers)) {
+            tableLayout.addView(TableLayoutUtils.createFullRow(activity, activity.getString(R.string.layer_info_custom_headers), tp));
+            for (Header header : headers) {
+                tableLayout.addView(TableLayoutUtils.createRow(activity, header.getName(), null, header.getValue(), false, tp));
+            }
+        }
         return sv;
     }
 

--- a/src/main/java/de/blau/android/prefs/AdvancedPrefDatabase.java
+++ b/src/main/java/de/blau/android/prefs/AdvancedPrefDatabase.java
@@ -112,7 +112,7 @@ public class AdvancedPrefDatabase extends SQLiteOpenHelper implements AutoClosea
     private static final String WHERE_URL   = "url = ?";
     private static final String WHERE_ROWID = "rowid = ?";
 
-    private static final String TEMP_TABLE = "temp";
+    public static final String TEMP_TABLE = "temp";
 
     private static final String CANNOT_DELETE_DEFAULT = "Cannot delete default";
 
@@ -368,7 +368,7 @@ public class AdvancedPrefDatabase extends SQLiteOpenHelper implements AutoClosea
      */
     public static void migrateTable(@NonNull SQLiteDatabase db, String origTable, String tempTable) {
         db.execSQL("BEGIN TRANSACTION");
-        db.execSQL("INSERT INTO " + tempTable + " SELECT * FROM " + origTable);
+        db.execSQL("INSERT OR IGNORE INTO " + tempTable + " SELECT * FROM " + origTable);
         db.execSQL("DROP TABLE " + origTable);
         db.execSQL("ALTER TABLE " + tempTable + " RENAME TO " + origTable);
         db.execSQL("COMMIT");

--- a/src/main/java/de/blau/android/prefs/ImportExportConfiguration.java
+++ b/src/main/java/de/blau/android/prefs/ImportExportConfiguration.java
@@ -1,6 +1,22 @@
 package de.blau.android.prefs;
 
 import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+import static de.blau.android.prefs.AdvancedPrefDatabase.ACCESSTOKENSECRET_COL;
+import static de.blau.android.prefs.AdvancedPrefDatabase.ACCESSTOKEN_COL;
+import static de.blau.android.prefs.AdvancedPrefDatabase.APIS_TABLE;
+import static de.blau.android.prefs.AdvancedPrefDatabase.DATABASE_NAME;
+import static de.blau.android.prefs.AdvancedPrefDatabase.GEOCODERS_TABLE;
+import static de.blau.android.prefs.AdvancedPrefDatabase.ID_DEFAULT;
+import static de.blau.android.prefs.AdvancedPrefDatabase.ID_OHM;
+import static de.blau.android.prefs.AdvancedPrefDatabase.ID_PANORAMAX_DEV;
+import static de.blau.android.prefs.AdvancedPrefDatabase.ID_SANDBOX;
+import static de.blau.android.prefs.AdvancedPrefDatabase.ID_WIKIMEDIA_COMMONS;
+import static de.blau.android.prefs.AdvancedPrefDatabase.IMAGESTORES_TABLE;
+import static de.blau.android.prefs.AdvancedPrefDatabase.PRESETS_TABLE;
+import static de.blau.android.prefs.AdvancedPrefDatabase.STYLES_TABLE;
+import static de.blau.android.resources.TileLayerDatabase.HEADERS_TABLE;
+import static de.blau.android.resources.TileLayerDatabase.LAYERS_TABLE;
+import static de.blau.android.resources.TileLayerDatabase.SOURCE_MANUAL;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -118,21 +134,19 @@ public final class ImportExportConfiguration {
             serializer.startDocument(OsmXml.UTF_8, null);
             serializer.startTag(null, CONFIGURATION);
             sharedPreferences(ctx, serializer);
-            sqlite(ctx, AdvancedPrefDatabase.DATABASE_NAME, AdvancedPrefDatabase.APIS_TABLE,
-                    " where id not in (" + "'" + AdvancedPrefDatabase.ID_DEFAULT + "'," + "'" + AdvancedPrefDatabase.ID_SANDBOX + "'," + "'"
-                            + AdvancedPrefDatabase.ID_OHM + "')",
-                    Arrays.asList(AdvancedPrefDatabase.ACCESSTOKEN_COL, AdvancedPrefDatabase.ACCESSTOKENSECRET_COL), false, serializer);
-            sqlite(ctx, AdvancedPrefDatabase.DATABASE_NAME, AdvancedPrefDatabase.IMAGESTORES_TABLE,
-                    " where id not in (" + "'" + AdvancedPrefDatabase.ID_WIKIMEDIA_COMMONS + "'," + "'" + AdvancedPrefDatabase.ID_PANORAMAX_DEV + "')", null,
-                    false, serializer);
-            sqlite(ctx, AdvancedPrefDatabase.DATABASE_NAME, AdvancedPrefDatabase.PRESETS_TABLE, " where id != '" + AdvancedPrefDatabase.ID_DEFAULT + "'", null,
-                    false, serializer);
-            sqlite(ctx, AdvancedPrefDatabase.DATABASE_NAME, AdvancedPrefDatabase.GEOCODERS_TABLE, "", null, false, serializer);
-            sqlite(ctx, AdvancedPrefDatabase.DATABASE_NAME, AdvancedPrefDatabase.LAYERS_TABLE, "", null, true, serializer);
-            sqlite(ctx, AdvancedPrefDatabase.DATABASE_NAME, AdvancedPrefDatabase.STYLES_TABLE, " where custom = 1", null, false, serializer);
-            //
-            sqlite(ctx, TileLayerDatabase.DATABASE_NAME, TileLayerDatabase.LAYERS_TABLE, " where source='" + TileLayerDatabase.SOURCE_MANUAL + "'", null, false,
+            sqlite(ctx, DATABASE_NAME, APIS_TABLE, " where id not in (" + "'" + ID_DEFAULT + "'," + "'" + ID_SANDBOX + "'," + "'" + ID_OHM + "')",
+                    Arrays.asList(ACCESSTOKEN_COL, ACCESSTOKENSECRET_COL), false, serializer);
+            sqlite(ctx, DATABASE_NAME, IMAGESTORES_TABLE, " where id not in (" + "'" + ID_WIKIMEDIA_COMMONS + "'," + "'" + ID_PANORAMAX_DEV + "')", null, false,
                     serializer);
+            sqlite(ctx, DATABASE_NAME, PRESETS_TABLE, " where id != '" + ID_DEFAULT + "'", null, false, serializer);
+            sqlite(ctx, DATABASE_NAME, GEOCODERS_TABLE, "", null, false, serializer);
+            sqlite(ctx, DATABASE_NAME, AdvancedPrefDatabase.LAYERS_TABLE, "", null, true, serializer);
+            sqlite(ctx, DATABASE_NAME, STYLES_TABLE, " where custom = 1", null, false, serializer);
+            //
+            sqlite(ctx, TileLayerDatabase.DATABASE_NAME, LAYERS_TABLE, " where source='" + SOURCE_MANUAL + "'", null, false, serializer);
+            sqlite(ctx, TileLayerDatabase.DATABASE_NAME, HEADERS_TABLE,
+                    "," + LAYERS_TABLE + " where " + HEADERS_TABLE + ".id=" + LAYERS_TABLE + ".id AND " + LAYERS_TABLE + ".source='" + SOURCE_MANUAL + "'",
+                    null, false, serializer);
             // filter names need to be set before the entries
             sqlite(ctx, TagFilterDatabaseHelper.DATABASE_NAME, TagFilterDatabaseHelper.FILTER_NAME_TABLE, "", null, false, serializer);
             sqlite(ctx, TagFilterDatabaseHelper.DATABASE_NAME, TagFilterDatabaseHelper.FILTERENTRIES_TABLE, "", null, false, serializer);

--- a/src/main/java/de/blau/android/resources/TileLayerDatabase.java
+++ b/src/main/java/de/blau/android/resources/TileLayerDatabase.java
@@ -20,6 +20,7 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import de.blau.android.osm.BoundingBox;
+import de.blau.android.prefs.AdvancedPrefDatabase;
 import de.blau.android.resources.TileLayerSource.Category;
 import de.blau.android.resources.TileLayerSource.Header;
 import de.blau.android.resources.TileLayerSource.Provider;
@@ -32,7 +33,7 @@ public class TileLayerDatabase extends SQLiteOpenHelper {
     protected static final String DEBUG_TAG = TileLayerDatabase.class.getSimpleName().substring(0, TAG_LEN);
 
     public static final String DATABASE_NAME    = "tilelayers";
-    private static final int   DATABASE_VERSION = 9;
+    private static final int   DATABASE_VERSION = 10;
 
     public static final String SOURCE_ELI          = "eli";    // editor-layer-index
     public static final String SOURCE_JOSM_IMAGERY = "josm";   // josm.openstreetmap.de/wiki/maps
@@ -78,7 +79,7 @@ public class TileLayerDatabase extends SQLiteOpenHelper {
     private static final String RIGHT_FIELD     = "right";
     private static final String TOP_FIELD       = "top";
 
-    private static final String HEADERS_TABLE      = "headers";
+    public static final String  HEADERS_TABLE      = "headers";
     private static final String HEADER_NAME_FIELD  = "name";
     private static final String HEADER_VALUE_FIELD = "value";
 
@@ -115,7 +116,7 @@ public class TileLayerDatabase extends SQLiteOpenHelper {
                     + " left INTEGER DEFAULT NULL, bottom INTEGER DEFAULT NULL, right INTEGER DEFAULT NULL, top INTEGER DEFAULT NULL,"
                     + " FOREIGN KEY(id) REFERENCES layers(id) ON DELETE CASCADE)");
             db.execSQL("CREATE INDEX coverages_idx ON coverages(id)");
-            createHeadersTable(db);
+            createHeadersTable(db, HEADERS_TABLE);
         } catch (SQLException e) {
             Log.w(DEBUG_TAG, "Problem creating database", e);
         }
@@ -148,7 +149,13 @@ public class TileLayerDatabase extends SQLiteOpenHelper {
             db.execSQL("ALTER TABLE layers ADD COLUMN tile_type TEXT DEFAULT NULL");
         }
         if (oldVersion <= 8) {
-            createHeadersTable(db);
+            createHeadersTable(db, HEADERS_TABLE);
+        }
+        if (oldVersion <= 9) {
+            createHeadersTable(db, AdvancedPrefDatabase.TEMP_TABLE);
+            AdvancedPrefDatabase.migrateTable(db, HEADERS_TABLE, AdvancedPrefDatabase.TEMP_TABLE);
+            db.execSQL("DROP INDEX " + AdvancedPrefDatabase.TEMP_TABLE + "_idx");
+            db.execSQL("CREATE INDEX " + HEADERS_TABLE + "_idx ON " + HEADERS_TABLE + "(id)");
         }
     }
 
@@ -157,10 +164,10 @@ public class TileLayerDatabase extends SQLiteOpenHelper {
      * 
      * @param db a writable database instance
      */
-    private void createHeadersTable(SQLiteDatabase db) {
-        db.execSQL("CREATE TABLE headers (id TEXT NOT NULL, name TEXT NOT NULL, value TEXT NOT NULL,"
-                + " FOREIGN KEY(id) REFERENCES layers(id) ON DELETE CASCADE)");
-        db.execSQL("CREATE INDEX headers_idx ON headers(id)");
+    private void createHeadersTable(@NonNull SQLiteDatabase db, @NonNull String table) {
+        db.execSQL("CREATE TABLE " + table + " (id TEXT NOT NULL, name TEXT NOT NULL, value TEXT NOT NULL,"
+                + " FOREIGN KEY(id) REFERENCES layers(id) ON DELETE CASCADE, PRIMARY KEY (id, name))");
+        db.execSQL("CREATE INDEX " + table + "_idx ON " + table + "(id)");
     }
 
     @Override

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -578,6 +578,7 @@
     <string name="errors">Errors</string>
     <string name="layer_info_layer_not_available">Layer information not available</string>
     <string name="layer_info_no_meta_data">Meta data not loaded</string>
+    <string name="layer_info_custom_headers">Custom headers</string>
     <!--  Mapillary layer -->
     <string name="mapillary_image">%1$s</string>
     <!-- Date range dialog -->


### PR DESCRIPTION
Add support for exporting and importing custom headers for tile sources

As we currently don't support adding custom headers manually we didn't
add this in the first cut, but it probably makes sense.

Further this adds a display of the header in the layer info modal.
