### PR TITLE
Replacing the PropertyEditor more than twice caused a crash

### DIFF
--- a/src/main/java/de/blau/android/propertyeditor/PropertyEditorActivity.java
+++ b/src/main/java/de/blau/android/propertyeditor/PropertyEditorActivity.java
@@ -234,10 +234,11 @@ public class PropertyEditorActivity<M extends Map<String, String> & Serializable
         PropertyEditorFragment<M, L, T> existing = peekBackStack(fm);
 
         String tag = java.util.UUID.randomUUID().toString();
-        if (existing != null) {
-            ft.hide(existing);
+        if (existing != null) {           
             if (!existing.hasChanges() && attemptReplace) {
                 fm.popBackStackImmediate();
+            } else {
+                ft.hide(existing);
             }
         }
         PropertyEditorFragment<M, L, T> fragment = PropertyEditorFragment.newInstance(data, predictAddressTags, showPresets, extraTags, presetsToApply,


### PR DESCRIPTION
Only hiding the fragment instance when we really want to retain it seems to avoid the issue. WE should investigate if we could test this is a reasonable fashion automatically.

Resolves: https://github.com/MarcusWolschon/osmeditor4android/issues/3168