### PR TITLE
Add missing setActive when constructing PresetConfiguration from the DB

### DIFF
--- a/src/main/java/de/blau/android/prefs/PresetConfiguration.java
+++ b/src/main/java/de/blau/android/prefs/PresetConfiguration.java
@@ -32,6 +32,7 @@ public class PresetConfiguration extends ResourceConfiguration {
     public PresetConfiguration(@NonNull String id, @NonNull String name, @Nullable String version, @Nullable String shortDescription,
             @Nullable String description, @NonNull String url, @NonNull String lastUpdate, boolean active, boolean useTranslations) {
         super(id, name, description, version, url, lastUpdate);
+        setActive(active);
         this.shortDescription = shortDescription;
         this.useTranslations = useTranslations;
     }


### PR DESCRIPTION
This regression would cause the check boxes not to be checked for active presets, potentially leading to the confusion in related: https://github.com/MarcusWolschon/osmeditor4android/issues/3171