### PR TITLE
Fix typos: commiting -> committing, Seperator -> Separator

### DIFF
--- a/src/main/java/de/blau/android/prefs/ImportExportConfiguration.java
+++ b/src/main/java/de/blau/android/prefs/ImportExportConfiguration.java
@@ -546,7 +546,7 @@ public final class ImportExportConfiguration {
             case SHARED_PREFERENCES:
                 switch (name) {
                 case SECTION:
-                    Log.i(DEBUG_TAG, "commiting edits");
+                    Log.i(DEBUG_TAG, "committing edits");
                     editor.apply();
                     state = State.BASE;
                     return;

--- a/src/main/java/de/blau/android/prefs/VespucciURLActivity.java
+++ b/src/main/java/de/blau/android/prefs/VespucciURLActivity.java
@@ -117,7 +117,7 @@ public class VespucciURLActivity extends AppCompatActivity {
             finish();
             return;
         }
-        String path = stripPathSeperators(data.getPath());
+        String path = stripPathSeparators(data.getPath());
         if (Util.isEmpty(path)) {
             path = fixupPath(data);
         }
@@ -256,7 +256,7 @@ public class VespucciURLActivity extends AppCompatActivity {
      * @param path the String to remove the slashes from
      * @return the String
      */
-    private String stripPathSeperators(@NonNull String path) {
+    private String stripPathSeparators(@NonNull String path) {
         if (path.startsWith("/")) {
             path = path.substring(1);
         }

--- a/src/main/java/de/blau/android/presets/PresetGroup.java
+++ b/src/main/java/de/blau/android/presets/PresetGroup.java
@@ -176,7 +176,7 @@ public class PresetGroup extends PresetElement {
                 } else if (element instanceof PresetGroup) {
                     sortAndAddElements(filteredElements, tempItems);
                     tempGroups.add((PresetGroup) element);
-                } else { // PresetSeperator
+                } else { // PresetSeparator
                     sortAndAddElements(filteredElements, tempGroups);
                     sortAndAddElements(filteredElements, tempItems);
                     filteredElements.add(element);


### PR DESCRIPTION
Fix \"commiting\" -> \"committing\" in log message (ImportExportConfiguration.java)
- Rename private method stripPathSeperators -> stripPathSeparators (VespucciURLActivity.java)
- Fix \"PresetSeperator\" -> \"PresetSeparator\" in comment (PresetGroup.java)