### PR TITLE
Fix various inconsistencies with action modes in split window use

### DIFF
--- a/src/main/java/de/blau/android/propertyeditor/PropertyEditorActivity.java
+++ b/src/main/java/de/blau/android/propertyeditor/PropertyEditorActivity.java
@@ -236,8 +236,9 @@ public class PropertyEditorActivity<M extends Map<String, String> & Serializable
         String tag = java.util.UUID.randomUUID().toString();
         if (existing != null) {           
             if (!existing.hasChanges() && attemptReplace) {
+                existing.finishActionMode();
                 fm.popBackStackImmediate();
-            } else {
+            } else {               
                 ft.hide(existing);
             }
         }

--- a/src/main/java/de/blau/android/propertyeditor/PropertyEditorFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/PropertyEditorFragment.java
@@ -182,16 +182,17 @@ public class PropertyEditorFragment<M extends Map<String, String> & Serializable
     private MultiHashMap<Long, RelationMemberPosition> originalParents;
     private ArrayList<RelationMemberDescription>       originalMembers;
 
-    private Preferences        prefs         = null;
+    private Preferences        prefs           = null;
     private ExtendedViewPager  mViewPager;
-    private boolean            usePaneLayout = false;
-    private boolean            isRelation    = false;
+    private boolean            usePaneLayout   = false;
+    private boolean            isRelation      = false;
     private NetworkStatus      networkStatus;
-    private List<String>       isoCodes      = null;
+    private List<String>       isoCodes        = null;
     private ControlListener    controlListener;
     private PageChangeListener pageChangeListener;
     private Capabilities       capabilities;
     private int                position;
+    private Bundle             actionModeState = new Bundle();
 
     /**
      * Run these actions when we everything is restored
@@ -437,21 +438,27 @@ public class PropertyEditorFragment<M extends Map<String, String> & Serializable
     @Override
     public void onHiddenChanged(boolean hidden) {
         super.onHiddenChanged(hidden);
-        if (!hidden) {
-            Log.d(DEBUG_TAG, "onHiddenChanged");
-            if (elementDeleted()) {
-                ScreenMessage.toastTopWarning(getContext(), R.string.toast_element_has_been_deleted);
-                App.getLogic().getHandler().post(() -> controlListener.finished(this));
-                return;
+        Log.d(DEBUG_TAG, "onHiddenChanged " + hidden);
+        final SelectableRowsFragment[] fragments = new SelectableRowsFragment[] { tagEditorFragment, relationMembershipFragment, relationMembersFragment };
+        if (hidden) {
+            for (SelectableRowsFragment f : fragments) {
+                if (f != null) {
+                    f.saveActionModeState(actionModeState);
+                    f.finishActionMode();
+                }
             }
-            if (tagEditorFragment != null) {
-                tagEditorFragment.onDataUpdate();
-            }
-            if (relationMembersFragment != null) {
-                relationMembersFragment.onDataUpdate();
-            }
-            if (relationMembershipFragment != null) {
-                relationMembershipFragment.onDataUpdate();
+            return;
+        }
+        if (elementDeleted()) {
+            ScreenMessage.toastTopWarning(getContext(), R.string.toast_element_has_been_deleted);
+            App.getLogic().getHandler().post(() -> controlListener.finished(this));
+            return;
+        }
+        for (SelectableRowsFragment f : fragments) {
+            if (f != null) {
+                ((DataUpdate) f).onDataUpdate();
+                f.onViewStateRestored(actionModeState);
+                f.restartActionMode();
             }
         }
     }
@@ -1559,5 +1566,16 @@ public class PropertyEditorFragment<M extends Map<String, String> & Serializable
             capabilities = server.getCachedCapabilities();
         }
         return capabilities;
+    }
+
+    /**
+     * Finish any active action modes
+     */
+    public void finishActionMode() {
+        for (SelectableRowsFragment f : new SelectableRowsFragment[] { tagEditorFragment, relationMembershipFragment, relationMembersFragment }) {
+            if (f != null) {
+                f.finishActionMode();
+            }
+        }
     }
 }

--- a/src/main/java/de/blau/android/propertyeditor/SelectableRowsFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/SelectableRowsFragment.java
@@ -22,6 +22,8 @@ public abstract class SelectableRowsFragment extends BaseFragment implements Pro
     private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, SelectableRowsFragment.class.getSimpleName().length());
     private static final String DEBUG_TAG = SelectableRowsFragment.class.getSimpleName().substring(0, TAG_LEN);
 
+    private static final String FRAGMENT_NAME = "fragmentName";
+
     protected SelectedRowsActionModeCallback actionModeCallback     = null;
     protected final Object                   actionModeCallbackLock = new Object();
 
@@ -30,8 +32,9 @@ public abstract class SelectableRowsFragment extends BaseFragment implements Pro
     @Override
     public void onViewStateRestored(@Nullable Bundle savedInstanceState) {
         super.onViewStateRestored(savedInstanceState);
-        if (savedInstanceState != null && savedInstanceState.getIntegerArrayList(SelectedRowsActionModeCallback.SELECTED_ROWS_KEY) != null
-                && actionModeCallback == null) {
+        Log.d(DEBUG_TAG, "onViewStateRestored");
+        if (savedInstanceState != null && this.getClass().getCanonicalName().equals(savedInstanceState.getString(FRAGMENT_NAME))
+                && savedInstanceState.getIntegerArrayList(SelectedRowsActionModeCallback.SELECTED_ROWS_KEY) != null && actionModeCallback == null) {
             actionModeCallback = getActionModeCallback();
             actionModeCallback.restoreState(savedInstanceState);
             restartActionMode = true;
@@ -49,6 +52,13 @@ public abstract class SelectableRowsFragment extends BaseFragment implements Pro
     public void onResume() {
         super.onResume();
         Log.d(DEBUG_TAG, "onResume");
+        restartActionMode();
+    }
+
+    /**
+     * Restart the action mode if necessary
+     */
+    void restartActionMode() {
         if (restartActionMode) {
             restartActionMode = false;
             ((AppCompatActivity) getActivity()).startSupportActionMode(actionModeCallback);
@@ -58,12 +68,22 @@ public abstract class SelectableRowsFragment extends BaseFragment implements Pro
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
+        saveActionModeState(outState);
+        Log.w(DEBUG_TAG, "onSaveInstanceState bundle size " + Util.getBundleSize(outState));
+    }
+
+    /**
+     * Save only the action mode state to a BUndle
+     * 
+     * @param outState the Bundle to save to
+     */
+    void saveActionModeState(@NonNull Bundle outState) {
         synchronized (actionModeCallbackLock) {
             if (actionModeCallback != null) {
+                outState.putString(FRAGMENT_NAME, this.getClass().getCanonicalName());
                 actionModeCallback.saveState(outState);
             }
         }
-        Log.w(DEBUG_TAG, "onSaveInstanceState bundle size " + Util.getBundleSize(outState));
     }
 
     @Override
@@ -117,6 +137,18 @@ public abstract class SelectableRowsFragment extends BaseFragment implements Pro
     @Override
     public void invertSelectedRows() {
         setSelectedRows((boolean current) -> !current);
+    }
+
+    /**
+     * Finish any action mode
+     */
+    public void finishActionMode() {
+        synchronized (actionModeCallbackLock) {
+            if (actionModeCallback != null) {
+                actionModeCallback.currentAction.finish();
+                actionModeCallback = null;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This stops action modes if the ProppertyEditorFragment instance is replaced and saves and restores action mode state if it is just hidden.

Resolves: https://github.com/MarcusWolschon/osmeditor4android/issues/3189