### PR TITLE
Support the name_template extension to show display_values

### DIFF
--- a/src/main/java/de/blau/android/search/Wrapper.java
+++ b/src/main/java/de/blau/android/search/Wrapper.java
@@ -10,6 +10,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 
+import org.jetbrains.annotations.NotNull;
+
 import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -449,6 +451,16 @@ public class Wrapper implements Meta {
             return true;
         }
         return Meta.super.around(meta, region);
+    }
+
+    @Override
+    public String displayValue(String key, String value) {
+        PresetItem item = Preset.findBestMatch(App.getCurrentPresets(context), getTags(), null, null);
+        if (item == null) {
+            return value;
+        }
+        String displayValue = item.getDescriptionForValue(key, value);
+        return displayValue != null ? displayValue : value;
     }
 
     public class SearchResult {

--- a/src/test/java/de/blau/android/search/WrapperTest.java
+++ b/src/test/java/de/blau/android/search/WrapperTest.java
@@ -33,6 +33,7 @@ import de.blau.android.osm.Node;
 import de.blau.android.osm.PbfTest;
 import de.blau.android.osm.Relation;
 import de.blau.android.osm.StorageDelegator;
+import de.blau.android.osm.Tags;
 import de.blau.android.osm.Way;
 import de.blau.android.presets.PresetGroup;
 import de.blau.android.presets.PresetItem;
@@ -509,5 +510,14 @@ public class WrapperTest {
         wrapper2.setSilent(true);
         assertTrue(wrapper2.around(wrapper2, "Zürich"));
     }
-
+    
+    @Test
+    public void displayValueTest() {
+        Way way = (Way) delegator.getOsmElement(Way.NAME, 571087535L);
+        assertNotNull(way);
+        wrapper.setElement(way);
+        assertEquals("Asphalt", wrapper.displayValue("surface", "asphalt"));
+        assertEquals("asphalt", wrapper.displayValue("no key", "asphalt"));
+        assertEquals("no value", wrapper.displayValue("surface", "no value"));
+    }
 }


### PR DESCRIPTION
This make name_templates more useful as it supports preset display values and by that translations of these too.