### PR TITLE
Run rebuilding of data style structures after import of style

### DIFF
--- a/src/main/java/de/blau/android/dialogs/DownloadMissing.java
+++ b/src/main/java/de/blau/android/dialogs/DownloadMissing.java
@@ -165,7 +165,7 @@ public class DownloadMissing extends CancelableDialogFragment {
 
         @Override
         protected void onPreExecute() {
-            Progress.showDialog(activity, Progress.PROGRESS_RESOURCE);
+            Progress.showDialog(activity, Progress.PROGRESS_RESOURCE_DOWNLOAD);
         }
 
         @Override
@@ -219,7 +219,7 @@ public class DownloadMissing extends CancelableDialogFragment {
 
         @Override
         protected void onPostExecute(Void result) {
-            Progress.dismissDialog(activity, Progress.PROGRESS_RESOURCE);
+            Progress.dismissDialog(activity, Progress.PROGRESS_RESOURCE_DOWNLOAD);
             ScreenMessage.toastTopInfo(activity, activity.getString(R.string.resource_download_successful));
         }
 
@@ -229,7 +229,7 @@ public class DownloadMissing extends CancelableDialogFragment {
             if (activity.isFinishing()) {
                 return;
             }
-            Progress.dismissDialog(activity, Progress.PROGRESS_RESOURCE);
+            Progress.dismissDialog(activity, Progress.PROGRESS_RESOURCE_DOWNLOAD);
             ScreenMessage.toastTopError(activity, activity.getString(R.string.download_missing_error, ex.getMessage()));
         }
     }

--- a/src/main/java/de/blau/android/dialogs/Progress.java
+++ b/src/main/java/de/blau/android/dialogs/Progress.java
@@ -32,18 +32,19 @@ public class Progress extends CancelableDialogFragment {
     public static final int PROGRESS_SAVING                    = 5;
     public static final int PROGRESS_OAUTH                     = 6;
     public static final int PROGRESS_UPLOADING                 = 7;
-    public static final int PROGRESS_RESOURCE                    = 8;
-    public static final int PROGRESS_RUNNING                   = 9;
-    public static final int PROGRESS_BUILDING_IMAGERY_DATABASE = 10;
-    public static final int PROGRESS_QUERY_OAM                 = 11;
-    public static final int PROGRESS_PRUNING                   = 12;
-    public static final int PROGRESS_MIGRATION                 = 13;
-    public static final int PROGRESS_LOADING_PRESET            = 14;
-    public static final int PROGRESS_IMPORTING_FILE            = 15;
-    public static final int PROGRESS_DOWNLOAD_TASKS            = 16;
-    public static final int PROGRESS_DOWNLOAD_SEQUENCE         = 17;
-    public static final int PROGRESS_DETERMINING_STATUS        = 18;
-    public static final int PROGRESS_UPDATING                  = 19;
+    public static final int PROGRESS_RESOURCE_LOAD             = 8;
+    public static final int PROGRESS_RESOURCE_DOWNLOAD         = 9;
+    public static final int PROGRESS_RUNNING                   = 10;
+    public static final int PROGRESS_BUILDING_IMAGERY_DATABASE = 11;
+    public static final int PROGRESS_QUERY_OAM                 = 12;
+    public static final int PROGRESS_PRUNING                   = 13;
+    public static final int PROGRESS_MIGRATION                 = 14;
+    public static final int PROGRESS_LOADING_PRESET            = 15;
+    public static final int PROGRESS_IMPORTING_FILE            = 16;
+    public static final int PROGRESS_DOWNLOAD_TASKS            = 17;
+    public static final int PROGRESS_DOWNLOAD_SEQUENCE         = 18;
+    public static final int PROGRESS_DETERMINING_STATUS        = 19;
+    public static final int PROGRESS_UPDATING                  = 20;
 
     private int    dialogType;
     private String messageArg;
@@ -131,7 +132,8 @@ public class Progress extends CancelableDialogFragment {
         dismissDialog(activity, PROGRESS_SAVING);
         dismissDialog(activity, PROGRESS_OAUTH);
         dismissDialog(activity, PROGRESS_UPLOADING);
-        dismissDialog(activity, PROGRESS_RESOURCE);
+        dismissDialog(activity, PROGRESS_RESOURCE_LOAD);
+        dismissDialog(activity, PROGRESS_RESOURCE_DOWNLOAD);
         dismissDialog(activity, PROGRESS_RUNNING);
         dismissDialog(activity, PROGRESS_BUILDING_IMAGERY_DATABASE);
         dismissDialog(activity, PROGRESS_QUERY_OAM);
@@ -168,8 +170,10 @@ public class Progress extends CancelableDialogFragment {
             return "dialog_progress_oauth";
         case PROGRESS_UPLOADING:
             return "dialog_progress_uploading";
-        case PROGRESS_RESOURCE:
-            return "dialog_progress_preset";
+        case PROGRESS_RESOURCE_LOAD:
+            return "dialog_progress_resource_load";
+        case PROGRESS_RESOURCE_DOWNLOAD:
+            return "dialog_progress_resource_download";
         case PROGRESS_RUNNING:
             return "dialog_progress_running";
         case PROGRESS_BUILDING_IMAGERY_DATABASE:

--- a/src/main/java/de/blau/android/dialogs/ProgressDialog.java
+++ b/src/main/java/de/blau/android/dialogs/ProgressDialog.java
@@ -76,9 +76,13 @@ public final class ProgressDialog {
             titleId = R.string.progress_general_title;
             messageId = R.string.progress_uploading_message;
             break;
-        case Progress.PROGRESS_RESOURCE:
+        case Progress.PROGRESS_RESOURCE_LOAD:
             titleId = R.string.progress_general_title;
-            messageId = R.string.progress_resource_message;
+            messageId = R.string.progress_resource_load_message;
+            break;
+        case Progress.PROGRESS_RESOURCE_DOWNLOAD:
+            titleId = R.string.progress_general_title;
+            messageId = R.string.progress_resource_download_message;
             break;
         case Progress.PROGRESS_RUNNING:
             titleId = R.string.progress_general_title;

--- a/src/main/java/de/blau/android/prefs/PresetConfigurationEditorActivity.java
+++ b/src/main/java/de/blau/android/prefs/PresetConfigurationEditorActivity.java
@@ -131,7 +131,7 @@ public class PresetConfigurationEditorActivity extends AbstractConfigurationEdit
             item.active = getIntent().getExtras().getBoolean(EXTRA_ENABLE);
         }
         db.addPreset(item.id, item.name, item.value, item.active);
-        retrieveData(this, db, item, Preset.PRESETXML, true);
+        retrieveData(this, db, item, Preset.PRESETXML, true, null);
         if (!isAddingViaIntent() || item.active) { // added a new preset and enabled it: need to rebuild presets
             App.resetPresets();
         }
@@ -144,7 +144,7 @@ public class PresetConfigurationEditorActivity extends AbstractConfigurationEdit
         if (preset.url != null && !preset.url.equals(item.value)) {
             // url changed so better recreate everything
             db.removeResourceDirectory(item.id);
-            retrieveData(this, db, item, Preset.PRESETXML, true);
+            retrieveData(this, db, item, Preset.PRESETXML, true, null);
         }
         App.resetPresets();
     }
@@ -182,7 +182,7 @@ public class PresetConfigurationEditorActivity extends AbstractConfigurationEdit
         case MENU_RELOAD:
             PresetConfiguration preset = db.getPreset(clickedItem.id);
             if (preset.url != null) {
-                retrieveData(this, db, clickedItem, Preset.PRESETXML, true);
+                retrieveData(this, db, clickedItem, Preset.PRESETXML, true, null);
             }
             App.resetPresets();
             break;
@@ -224,7 +224,7 @@ public class PresetConfigurationEditorActivity extends AbstractConfigurationEdit
      * @param item the item containing the preset to be downloaded
      */
     static void retrieveData(@NonNull URLListEditActivity activity, @NonNull AdvancedPrefDatabase db, @NonNull final ListEditItem item) {
-        retrieveData(activity, db, item, Preset.PRESETXML, true);
+        retrieveData(activity, db, item, Preset.PRESETXML, true, null);
     }
 
     @Override

--- a/src/main/java/de/blau/android/prefs/StyleConfigurationEditorActivity.java
+++ b/src/main/java/de/blau/android/prefs/StyleConfigurationEditorActivity.java
@@ -152,11 +152,12 @@ public class StyleConfigurationEditorActivity extends AbstractConfigurationEdito
             Log.e(DEBUG_TAG, "Style configuration not found for " + item.id);
             return;
         }
-        retrieveData(this, db, item, STYLE_XML, false);
-        if (!isAddingViaIntent()) { // added a new style and enabled it: need to rebuild styles
-            manager.reset(this, true);
-        }
-        reloadItems();
+        retrieveData(this, db, item, STYLE_XML, false, () -> {
+            if (!isAddingViaIntent()) { // added a new style and enabled it: need to rebuild styles
+                manager.reset(this, true);
+            }
+            reloadItems();
+        });
     }
 
     @Override
@@ -203,9 +204,8 @@ public class StyleConfigurationEditorActivity extends AbstractConfigurationEdito
         if (MENU_RELOAD == menuItemId) {
             StyleConfiguration style = db.getStyle(clickedItem.id);
             if (style.url != null) {
-                retrieveData(this, db, clickedItem, STYLE_XML, true);
+                retrieveData(this, db, clickedItem, STYLE_XML, true, () -> manager.reset(this, true));
             }
-            manager.reset(this, true);
             return;
         }
         Log.e(DEBUG_TAG, "Unknown menu item " + menuItemId);

--- a/src/main/java/de/blau/android/prefs/URLListEditActivity.java
+++ b/src/main/java/de/blau/android/prefs/URLListEditActivity.java
@@ -43,6 +43,7 @@ import androidx.appcompat.widget.ActionMenuView.OnMenuItemClickListener;
 import androidx.core.content.ContextCompat;
 import androidx.core.graphics.BlendModeColorFilterCompat;
 import androidx.core.graphics.BlendModeCompat;
+import de.blau.android.PostAsyncActionHandler;
 import de.blau.android.R;
 import de.blau.android.contract.Schemes;
 import de.blau.android.dialogs.Progress;
@@ -767,23 +768,10 @@ public abstract class URLListEditActivity extends ListActivity
      * @param db an AdvancedPrefDatabase instance
      * @param item the item containing the resource to be downloaded
      * @param defaultFilename default name to use for imported resources
-     */
-    static void retrieveData(@NonNull URLListEditActivity activity, @NonNull AdvancedPrefDatabase db, @NonNull final ListEditItem item,
-            String defaultFilename) {
-        retrieveData(activity, db, item, defaultFilename, true);
-    }
-
-    /**
-     * Download data (XML, icons) for a certain resource or load it from a file
-     * 
-     * @param activity a URLListEditActivity instance
-     * @param db an AdvancedPrefDatabase instance
-     * @param item the item containing the resource to be downloaded
-     * @param defaultFilename default name to use for imported resources
      * @param parseForIcons parser the XML for icons, currently only of use for presets
      */
     static void retrieveData(@NonNull URLListEditActivity activity, @NonNull AdvancedPrefDatabase db, @NonNull final ListEditItem item, String defaultFilename,
-            boolean parseForIcons) {
+            boolean parseForIcons, @Nullable PostAsyncActionHandler handler) {
 
         final File dir = db.getResourceDirectory(item.id);
         // noinspection ResultOfMethodCallIgnored
@@ -794,18 +782,18 @@ public abstract class URLListEditActivity extends ListActivity
         new ExecutorTask<Void, Integer, Integer>() {
 
             private boolean localFile;
+            private Uri     uri;
 
             @Override
             protected void onPreExecute() {
-                Progress.showDialog(activity, Progress.PROGRESS_RESOURCE);
+                uri = Uri.parse(item.value);
+                final String scheme = uri.getScheme();
+                localFile = Schemes.FILE.equals(scheme) || Schemes.CONTENT.equals(scheme);
+                Progress.showDialog(activity, localFile ? Progress.PROGRESS_RESOURCE_LOAD : Progress.PROGRESS_RESOURCE_DOWNLOAD);
             }
 
             @Override
             protected Integer doInBackground(Void args) {
-                Uri uri = Uri.parse(item.value);
-                final String scheme = uri.getScheme();
-
-                localFile = Schemes.FILE.equals(scheme) || Schemes.CONTENT.equals(scheme);
                 int loadResult = localFile ? XmlConfigurationLoader.load(activity, uri, dir, defaultFilename)
                         : XmlConfigurationLoader.download(item.value, dir, defaultFilename);
 
@@ -832,23 +820,31 @@ public abstract class URLListEditActivity extends ListActivity
 
             @Override
             protected void onPostExecute(Integer result) {
-                Progress.dismissDialog(activity, Progress.PROGRESS_RESOURCE);
                 switch (result) {
                 case RESULT_TOTAL_SUCCESS:
-                    ScreenMessage.barInfo(activity, localFile ? R.string.resource_load_successful : R.string.resource_download_successful);
+                case RESULT_IMAGE_FAILURE:
+                    if (result == RESULT_IMAGE_FAILURE) {
+                        msgbox(R.string.preset_download_missing_images);
+                    } else {
+                        ScreenMessage.barInfo(activity, localFile ? R.string.resource_load_successful : R.string.resource_download_successful);
+                    }
+                    if (handler != null) {
+                        handler.onSuccess();
+                    }
                     activity.sendResultIfApplicable(item);
                     break;
                 case RESULT_TOTAL_FAILURE:
-                    msgbox(R.string.resource_download_failed);
-                    break;
-                case RESULT_IMAGE_FAILURE:
-                    msgbox(R.string.preset_download_missing_images);
+                    msgbox(localFile ? R.string.resource_load_failed : R.string.resource_download_failed);
+                    if (handler != null) {
+                        handler.onError(null);
+                    }
                     break;
                 case RESULT_DOWNLOAD_CANCELED:
                     break; // do nothing
                 default:
                     break;
                 }
+                Progress.dismissDialog(activity, localFile ? Progress.PROGRESS_RESOURCE_LOAD : Progress.PROGRESS_RESOURCE_DOWNLOAD);
             }
 
             /**

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -180,7 +180,8 @@
     <string name="progress_searching_message">Searching…</string>
     <string name="progress_saving_message">Saving…</string>
     <string name="progress_uploading_message">Uploading…</string>
-    <string name="progress_resource_message">Downloading resource…</string>
+    <string name="progress_resource_download_message">Downloading resource…</string>
+    <string name="progress_resource_load_message">Loading resource…</string>
     <string name="progress_loading_preset_message">Loading preset…</string>
     <string name="progress_importing_file_message">Importing file…</string>
     <string name="progress_running_message">Running…</string>
@@ -1677,6 +1678,7 @@
     <string name="resource_download_successful">Resource downloaded</string>
     <string name="resource_load_successful">Resource loaded</string>
     <string name="resource_download_failed">Could not download resource file. The resource will not work.</string>
+    <string name="resource_load_failed">Could not load resource file. The resource will not work.</string>
     <string name="preset_download_parse_failed">The resource file is invalid. The resource will not work.</string>
     <string name="preset_download_missing_images">Preset file downloaded. However, some missing icons were not.</string>
     <string name="resource_download_title">Resource downloader</string>


### PR DESCRIPTION
Very large style files would get imported while the rebuild was already running, this moves the rebuilding to an handler run after the import.

Note that this can still cause ANRs if the rebuild is very slow (as that is not run in a thread), that will be adressed if and when we refactor the style management to only hold one style in memory.

Resolves https://github.com/MarcusWolschon/osmeditor4android/issues/3176