### PR TITLE
Catch and report exceptions from running conflict resolution actions

### DIFF
--- a/src/main/java/de/blau/android/dialogs/UploadConflict.java
+++ b/src/main/java/de/blau/android/dialogs/UploadConflict.java
@@ -393,7 +393,7 @@ public class UploadConflict extends CancelableDialogFragment {
                     Entry<String, Runnable> action = resolveActions.entrySet().iterator().next();
                     neutral.setText(action.getKey());
                     neutral.setOnClickListener((View v) -> {
-                        action.getValue().run();
+                        runAction(activity, action);
                         dialog.dismiss();
                     });
                     return;
@@ -404,7 +404,7 @@ public class UploadConflict extends CancelableDialogFragment {
                     for (Entry<String, Runnable> action : resolveActions.entrySet()) {
                         MenuItem item = popup.getMenu().add(action.getKey());
                         item.setOnMenuItemClickListener(unused -> {
-                            action.getValue().run();
+                            runAction(activity, action);
                             dialog.dismiss();
                             return false;
                         });
@@ -421,6 +421,24 @@ public class UploadConflict extends CancelableDialogFragment {
         }
 
         return builder.create();
+    }
+
+    /**
+     * Run the clicked action, catching and reporting any exceptions
+     * 
+     * @param activity the parent activity
+     * @param action the action
+     */
+    private void runAction(@Nullable FragmentActivity activity, @NonNull final Entry<String, Runnable> action) {
+        try {
+            action.getValue().run();
+        } catch (Exception e) {
+            final String key = action.getKey();
+            Log.e(DEBUG_TAG, "Caught exception running action " + key + " " + e);
+            if (activity != null) {
+                ScreenMessage.toastTopError(activity, activity.getString(R.string.error_running_action, key, e.getLocalizedMessage()));
+            }
+        }
     }
 
     /**

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -51,6 +51,7 @@
     <string name="local_reference_inconsistency">Local reference inconsistency, undeleting the referenced element is the safe option, but please report this as a bug.</string>
     <string name="delete_locally">Delete\nlocally</string>
     <string name="undelete_on_server">Undelete\non server</string>
+    <string name="error_running_action">Action %1$s errored with %2$s</string>
     <!-- Upload retry -->
     <string name="upload_retry_title">Upload failed</string>
     <string name="upload_retry_message_no_open_changeset">Opening changeset failed.\n\nIt is safe to retry.</string>


### PR DESCRIPTION
If an exception was thrown in an conflict resolution action it would cause a crash.