### PR TITLE
Improve unjoinWay behaviour 

### DIFF
--- a/src/androidTest/java/de/blau/android/osm/GeometryEditsTest.java
+++ b/src/androidTest/java/de/blau/android/osm/GeometryEditsTest.java
@@ -625,13 +625,17 @@ public class GeometryEditsTest {
             assertTrue(w1.hasCommonNode(w2));
             assertTrue(w2.hasCommonNode(w3));
             assertTrue(w1.hasCommonNode(w3));
-            logic.performUnjoinWay(main, w1, null);
+            // normal mode
+            List<Node> unjoinedNodes = logic.performUnjoinWay(main, w1, null);
+            assertEquals(3, unjoinedNodes.size());
             assertFalse(w1.hasCommonNode(w2));
             assertFalse(w1.hasCommonNode(w3));
             logic.undo();
             assertTrue(w1.hasCommonNode(w2));
             assertTrue(w1.hasCommonNode(w3));
-            logic.performUnjoinWay(main, w1, Tags.KEY_HIGHWAY);
+            // unjoin dissimilar
+            unjoinedNodes = logic.performUnjoinWay(main, w1, Tags.KEY_HIGHWAY);
+            assertEquals(3, unjoinedNodes.size());
             assertFalse(w1.hasCommonNode(w2));
             assertTrue(w1.hasCommonNode(w3));
         } catch (Exception igit) {

--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -2906,13 +2906,19 @@ public class Logic {
      * @param activity activity this was called from, if null no warnings will be displayed
      * @param way the Way to unjoin
      * @param primaryKey don't unjoin from ways with the same primary key, but replace the node in them too
+     * @return a list of the unjoined nodes
      */
-    public void performUnjoinWay(@Nullable FragmentActivity activity, @NonNull Way way, @Nullable String primaryKey) {
+    @NonNull
+    public List<Node> performUnjoinWay(@Nullable FragmentActivity activity, @NonNull Way way, @Nullable String primaryKey) {
         try {
             lock();
+            final StorageDelegator delegator = getDelegator();
+            if (!delegator.isInDownload(way)) {
+                throw new OsmIllegalOperationException(getResources(activity).getString(R.string.toast_all_way_nodes_download));
+            }
             createCheckpoint(activity, R.string.undo_action_unjoin_ways);
             displayAttachedObjectWarning(activity, way); // needs to be done before unjoin
-            getDelegator().unjoinWay(activity, way, primaryKey);
+            return delegator.unjoinWay(activity, way, primaryKey);
         } catch (OsmIllegalOperationException | StorageException ex) {
             handleDelegatorException(activity, ex);
             throw ex; // rethrow

--- a/src/main/java/de/blau/android/easyedit/WaySelectionActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/WaySelectionActionModeCallback.java
@@ -304,7 +304,8 @@ public class WaySelectionActionModeCallback extends ElementSelectionActionModeCa
                 main.startSupportActionMode(new RemoveNodeFromWayActionModeCallback(manager, way));
                 break;
             case MENUITEM_UNJOIN:
-                logic.performUnjoinWay(main, way, null);
+                List<Node> result = logic.performUnjoinWay(main, way, null);
+                toastUnglued(result.size());
                 break;
             case MENUITEM_UNJOIN_DISSIMILAR:
                 unjonDissimilar(main, way);
@@ -349,17 +350,28 @@ public class WaySelectionActionModeCallback extends ElementSelectionActionModeCa
         List<String> primaryKeys = way.getObjectKeys(activity);
         final int keyCount = primaryKeys.size();
         if (keyCount <= 1) {
-            logic.performUnjoinWay(activity, way, keyCount == 1 ? primaryKeys.get(0) : null);
+            List<Node> result = logic.performUnjoinWay(activity, way, keyCount == 1 ? primaryKeys.get(0) : null);
+            toastUnglued(result.size());
             return;
         }
         ThemeUtils.getAlertDialogBuilder(activity).setTitle(R.string.select_primary_key)
                 .setItems(primaryKeys.toArray(new String[0]), (DialogInterface dialog, int which) -> {
                     try {
-                        logic.performUnjoinWay(activity, way, primaryKeys.get(which));
+                        List<Node> result = logic.performUnjoinWay(activity, way, primaryKeys.get(which));
+                        toastUnglued(result.size());
                     } catch (OsmIllegalOperationException | StorageException ex) {
                         // already toasted
                     }
                 }).setNegativeButton(R.string.cancel, null).show();
+    }
+
+    /**
+     * Display a toast with the number of unglued nodes
+     * 
+     * @param count the number of unglued nodes
+     */
+    private void toastUnglued(int count) {
+        ScreenMessage.toastTopInfo(main, main.getResources().getQuantityString(R.plurals.toast_unglued_nodes, count, count));
     }
 
     @Override

--- a/src/main/java/de/blau/android/osm/StorageDelegator.java
+++ b/src/main/java/de/blau/android/osm/StorageDelegator.java
@@ -1793,7 +1793,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
                     first = false;
                 } else {
                     // subsequent ways
-                    replaceWayNode(node, way);
+                    replaceWayNode(node, way, true);
                 }
             }
         }
@@ -1829,7 +1829,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
                 }
             }
             if (similarWays.size() < otherWays.size() - 1) { // if all are the same no need to replace
-                Node newNode = replaceWayNode(nd, way);
+                Node newNode = replaceWayNode(nd, way, false);
                 for (Way similar : similarWays) {
                     replaceNodeInWay(nd, newNode, similar);
                 }
@@ -1842,15 +1842,18 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
      * 
      * @param node the node to replace
      * @param way the Way
+     * @param clone copy tags and relation memberships (with the exception of restrictions)
      * @return the new Node
      */
     @NonNull
-    private Node replaceWayNode(@NonNull final Node node, @NonNull final Way way) {
+    private Node replaceWayNode(@NonNull final Node node, @NonNull final Way way, boolean clone) {
         List<OsmElement> changedElements = new ArrayList<>();
         dirty = true;
         // create a new node that duplicates the given node
         Node newNode = factory.createNodeWithNewId(node.lat, node.lon);
-        newNode.addTags(node.getTags());
+        if (clone) {
+            newNode.addTags(node.getTags());
+        }
         insertElementUnsafe(newNode);
         changedElements.add(newNode);
         // replace the given node in the way with the new node
@@ -1870,8 +1873,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
         changedElements.add(way);
 
         // check if node is in a relation, if yes, add to new node
-        // should probably check for restrictions
-        if (node.hasParentRelations()) {
+        if (clone && node.hasParentRelations()) {
             List<Relation> relations = node.getParentRelations();
             /*
              * iterate through relations, for all except restrictions add the new node to the relation, for now simply

--- a/src/main/java/de/blau/android/osm/StorageDelegator.java
+++ b/src/main/java/de/blau/android/osm/StorageDelegator.java
@@ -1805,9 +1805,12 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
      * @param ctx Android Context
      * @param way the Way to unjoin
      * @param primaryKey don't unjoin from ways with the same primary key if not null, but replace the node in them too
+     * @return List of the original nodes that had to be unglued
      */
-    public void unjoinWay(@Nullable Context ctx, @NonNull final Way way, @Nullable String primaryKey) {
+    @NonNull
+    public List<Node> unjoinWay(@Nullable Context ctx, @NonNull final Way way, @Nullable String primaryKey) {
         Set<Node> wayNodes = new HashSet<>(way.getNodes()); // only do every node once
+        List<Node> ungluedNodes = new ArrayList<>(); // List of the original nodes that had to be unglued
         Map<Long, Boolean> keyMap = new HashMap<>();
         for (Node nd : wayNodes) {
             List<Way> otherWays = getCurrentStorage().getWays(nd);
@@ -1828,13 +1831,16 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
                     }
                 }
             }
-            if (similarWays.size() < otherWays.size() - 1) { // if all are the same no need to replace
-                Node newNode = replaceWayNode(nd, way, false);
-                for (Way similar : similarWays) {
-                    replaceNodeInWay(nd, newNode, similar);
-                }
+            if (similarWays.size() >= otherWays.size() - 1) { // if all are the same no need to replace
+                continue;
+            }
+            Node newNode = replaceWayNode(nd, way, false);
+            ungluedNodes.add(nd);
+            for (Way similar : similarWays) {
+                replaceNodeInWay(nd, newNode, similar);
             }
         }
+        return ungluedNodes;
     }
 
     /**
@@ -1884,14 +1890,11 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
                 undo.save(r);
                 String type = r.getTagWithKey(Tags.KEY_TYPE);
                 if (type != null) {
-                    if (type.equals(Tags.VALUE_RESTRICTION)) {
-                        // doing nothing for now at least gives a chance of being right :-)
-                    } else {
+                    if (!Tags.VALUE_RESTRICTION.equals(type)) {
                         RelationMember newMember = new RelationMember(rm.getRole(), newNode);
                         r.addMemberAfter(rm, newMember);
                         newNode.addParentRelation(r);
                     }
-
                 } else {
                     RelationMember newMember = new RelationMember(rm.getRole(), newNode);
                     r.addMemberAfter(rm, newMember);

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -901,6 +901,10 @@
     <string name="toast_panoramax_instance_list_error">Unable to retrieve panoramax instance list\n%1$s</string>
     <string name="toast_authorisation_successful">Authorisation successful!</string>
     <string name="toast_authorisation_failed">Authorisation failed\n%1$s</string>
+    <plurals name="toast_unglued_nodes">
+        <item quantity="one">Unglued one node</item>
+        <item quantity="other">Unglued %1$d nodes</item>
+    </plurals>
     <!-- Error messages -->
     <string name="error_mapsplit_missing_zoom">MapSplit sources must have min and max zoom set</string>
     <string name="error_pbf_no_version">Version information missing in PBF file</string>

--- a/src/test/java/de/blau/android/osm/StorageDelegatorTest.java
+++ b/src/test/java/de/blau/android/osm/StorageDelegatorTest.java
@@ -1233,12 +1233,6 @@ public class StorageDelegatorTest {
         final Node n2 = w.getNodes().get(2);
         d.addNodeToWay(n2, w2);
 
-        Relation r = d.getFactory().createRelationWithNewId();
-        RelationMember member = new RelationMember("test", n2);
-        r.addMember(member);
-        d.insertElementSafe(r);
-        n2.addParentRelation(r);
-
         assertEquals(2, d.getApiWayCount());
         assertEquals(w.nodeCount(), d.getApiNodeCount());
         d.unjoinWay(null, w2, null);
@@ -1247,8 +1241,6 @@ public class StorageDelegatorTest {
         assertNotEquals(n2, lastNode);
         assertEquals(2, d.getApiWayCount());
         assertEquals(w.nodeCount() + 2, d.getApiNodeCount());
-
-        assertTrue(lastNode.hasParentRelation(r.getOsmId()));
     }
 
     /**
@@ -1312,6 +1304,80 @@ public class StorageDelegatorTest {
 
         assertEquals(2, d.getApiWayCount());
         assertEquals(w.nodeCount() + 3, d.getApiNodeCount());
+    }
+
+    /**
+     * Unjoin two ways one node has tags and is a relation member, check that that doesn't get copied
+     */
+    @Test
+    public void unjoinWayWithTaggedNode() {
+        StorageDelegator d = new StorageDelegator();
+        Way w = DelegatorUtil.addWayToStorage(d, false);
+        final Node n1 = w.getNodes().get(1);
+        Way w2 = d.createAndInsertWay(n1);
+        final Node n2 = w.getNodes().get(2);
+        d.addNodeToWay(n2, w2);
+
+        Map<String, String> tags = new TreeMap<>();
+        tags.put(Tags.KEY_AMENITY, "bench");
+        n2.setTags(tags);
+
+        Relation r = d.getFactory().createRelationWithNewId();
+        RelationMember member = new RelationMember("test", n2);
+        r.addMember(member);
+        d.insertElementSafe(r);
+        n2.addParentRelation(r);
+
+        assertEquals(2, d.getApiWayCount());
+        assertEquals(w.nodeCount(), d.getApiNodeCount());
+        d.unjoinWay(null, w2, null);
+        assertNotEquals(n1, w2.getFirstNode());
+        final Node lastNode = w2.getLastNode();
+        assertNotEquals(n2, lastNode);
+        assertEquals(2, d.getApiWayCount());
+        assertEquals(w.nodeCount() + 2, d.getApiNodeCount());
+
+        assertFalse(lastNode.hasTagWithValue(Tags.KEY_AMENITY, "bench"));
+        assertFalse(lastNode.hasParentRelation(r.getOsmId()));
+    }
+
+    /**
+     * Unjoin two ways at one node that has tags and is a relation member
+     */
+    @Test
+    public void unjoinWaysAtTaggedNode() {
+        StorageDelegator d = new StorageDelegator();
+        Way w = DelegatorUtil.addWayToStorage(d, false);
+        final Node n1 = w.getNodes().get(1);
+        Way w2 = d.createAndInsertWay(n1);
+        final Node n2 = w.getNodes().get(2);
+        d.addNodeToWay(n2, w2);
+
+        Map<String, String> tags = new TreeMap<>();
+        tags.put(Tags.KEY_AMENITY, "bench");
+        n1.setTags(tags);
+
+        Relation r = d.getFactory().createRelationWithNewId();
+        RelationMember member = new RelationMember("test", n1);
+        r.addMember(member);
+        d.insertElementSafe(r);
+        n1.addParentRelation(r);
+
+        assertEquals(2, d.getApiWayCount());
+        assertEquals(w.nodeCount(), d.getApiNodeCount());
+
+        d.unjoinWays(n1);
+
+        final Node firstNode = w2.getFirstNode();
+
+        assertTrue(firstNode.hasTagWithValue(Tags.KEY_AMENITY, "bench"));
+        assertTrue(firstNode.hasParentRelation(r.getOsmId()));
+        
+        final Node oNode =  w.getNodes().get(1);
+        assertTrue(oNode.hasTagWithValue(Tags.KEY_AMENITY, "bench"));
+        assertTrue(oNode.hasParentRelation(r.getOsmId()));
+        
+        assertNotEquals(firstNode, oNode);
     }
 
     /**


### PR DESCRIPTION
- This changes the unjoin behaviour for ways to not duplicate tags and relation memberships as this might be surprising behaviour. It dosen't change this for unjoining multiple ways in one node, though that could arguably be considered problematic too.
- Checks that all Nodes are in downloaded areas
- Improves messaging

Resolved https://github.com/MarcusWolschon/osmeditor4android/issues/3214
Resolves https://github.com/MarcusWolschon/osmeditor4android/issues/3216
