### PR TITLE
Avoid creating tiny bounding boxes

### DIFF
--- a/src/main/java/de/blau/android/layer/data/MapOverlay.java
+++ b/src/main/java/de/blau/android/layer/data/MapOverlay.java
@@ -431,8 +431,8 @@ public class MapOverlay<O extends OsmElement> extends NonSerializeableLayer
             Context ctx = map.getContext();
             List<BoundingBox> bbList = new ArrayList<>(delegator.getBoundingBoxes());
             box.scale(1.2); // make sides 20% larger
-            box.ensureMinumumSize(minDownloadSize); // enforce a minimum size
             List<BoundingBox> bboxes = BoundingBox.newBoxes(bbList, box);
+            BoundingBox.consolidate(bboxes, (int) (GeoMath.convertMetersToGeoDistance(minDownloadSize) * 1E7));
             final Logic logic = App.getLogic();
             for (BoundingBox b : bboxes) {
                 try {

--- a/src/main/java/de/blau/android/layer/tasks/MapOverlay.java
+++ b/src/main/java/de/blau/android/layer/tasks/MapOverlay.java
@@ -155,8 +155,8 @@ public class MapOverlay extends NonSerializeableLayer
             downloadThreadPool.execute(() -> {
                 ViewBox box = new ViewBox(map.getViewBox());
                 box.scale(1.2); // make sides 20% larger
-                box.ensureMinumumSize(minDownloadSize); // enforce a minimum size
                 List<BoundingBox> bboxes = BoundingBox.newBoxes(tasks.getBoundingBoxes(), box);
+                BoundingBox.consolidate(bboxes, (int) (GeoMath.convertMetersToGeoDistance(minDownloadSize) * 1E7));
                 for (BoundingBox b : bboxes) {
                     tasks.addBoundingBox(b);
                     try {

--- a/src/main/java/de/blau/android/osm/BoundingBox.java
+++ b/src/main/java/de/blau/android/osm/BoundingBox.java
@@ -746,6 +746,78 @@ public class BoundingBox implements Serializable, JosmXmlSerializable, BoundedOb
     }
 
     /**
+     * Check if two boxes are adjacent (touching but not overlapping)
+     */
+    public boolean isAdjacent(@NonNull BoundingBox neighbour) {
+        // Horizontally adjacent
+        if ((right == neighbour.left || left == neighbour.right) && bottom < neighbour.top && top > neighbour.bottom) {
+            return true;
+        }
+        // Vertically adjacent
+        return (top == neighbour.bottom || bottom == neighbour.top) && left < neighbour.right && right > neighbour.left;
+    }
+
+    /**
+     * Merge small slivers (boxes with very small width or height) with adjacent boxes.
+     * 
+     * @param boxes list of boxes to consolidate
+     * @param minSize minimum dimension (in 1E7 degrees) to keep as separate box
+     * @return consolidated list
+     */
+    @NonNull
+    public static List<BoundingBox> consolidate(@NonNull List<BoundingBox> boxes, int minSize) {
+        if (boxes.isEmpty()) {
+            return boxes;
+        }
+
+        List<BoundingBox> result = new ArrayList<>(boxes);
+        boolean changed = true;
+
+        // Iteratively merge small boxes with neighbors
+        while (changed) {
+            changed = false;
+            for (int i = 0; i < result.size(); i++) {
+                BoundingBox current = result.get(i);
+
+                // Skip boxes that are reasonably sized in both dimensions
+                if (current.getWidth() >= minSize && current.getHeight() >= minSize) {
+                    continue;
+                }
+
+                // Find best neighbor to merge with (smallest union)
+                int bestNeighbor = -1;
+                long smallestUnion = Long.MAX_VALUE;
+
+                for (int j = 0; j < result.size(); j++) {
+                    if (i == j) {
+                        continue;
+                    }
+                    BoundingBox neighbor = result.get(j);
+                    // Check if adjacent or overlapping
+                    if (current.intersects(neighbor) || current.isAdjacent(neighbor)) {
+                        BoundingBox union = new BoundingBox(current);
+                        union.union(neighbor);
+                        long unionArea = union.approxArea();
+                        if (unionArea < smallestUnion) {
+                            smallestUnion = unionArea;
+                            bestNeighbor = j;
+                        }
+                    }
+                }
+
+                // Merge with best neighbor
+                if (bestNeighbor >= 0) {
+                    current.union(result.get(bestNeighbor));
+                    result.remove(bestNeighbor);
+                    changed = true;
+                    break; // Restart iteration after modification
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
      * Get an approximate size of the BoundingBox
      * 
      * @return the size in squared degrees * 1E7

--- a/src/test/java/de/blau/android/osm/BoundingBoxTest.java
+++ b/src/test/java/de/blau/android/osm/BoundingBoxTest.java
@@ -2,6 +2,7 @@ package de.blau.android.osm;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -89,5 +90,295 @@ public class BoundingBoxTest {
         assertFalse(box.isValidForApi(0.25f));
         box.makeValidForApi(0.25f);
         assertTrue(box.isValidForApi(0.25f));
+    }
+
+    /**
+     * Test consolidating two horizontally adjacent thin boxes into one
+     */
+    @Test
+    public void consolidateAdjacentHorizontalSlivers() {
+        List<BoundingBox> boxes = new ArrayList<>();
+        // Left sliver: narrow in width
+        boxes.add(new BoundingBox(0, 0, 500000, 10000000)); // width: 500000
+        // Right sliver: narrow in width
+        boxes.add(new BoundingBox(500000, 0, 1000000, 10000000)); // width: 500000
+
+        List<BoundingBox> result = BoundingBox.consolidate(boxes, 1000000);
+
+        // Should merge into 1 or 2 boxes (depending on consolidation aggressiveness)
+        assertTrue("Expected 1-2 boxes after consolidation, got " + result.size(), result.size() <= 2);
+
+        // Verify coverage is preserved
+        BoundingBox union = new BoundingBox(0, 0, 1000000, 10000000);
+        for (BoundingBox box : result) {
+            assertTrue("Result box should be within or equal to original union", union.contains(box) || box.contains(union));
+        }
+    }
+
+    /**
+     * Test consolidating two vertically adjacent thin boxes into one
+     */
+    @Test
+    public void consolidateAdjacentVerticalSlivers() {
+        List<BoundingBox> boxes = new ArrayList<>();
+        // Bottom sliver: narrow in height
+        boxes.add(new BoundingBox(0, 0, 10000000, 500000)); // height: 500000
+        // Top sliver: narrow in height
+        boxes.add(new BoundingBox(0, 500000, 10000000, 1000000)); // height: 500000
+
+        List<BoundingBox> result = BoundingBox.consolidate(boxes, 1000000);
+
+        // Should merge into 1 or 2 boxes
+        assertTrue("Expected 1-2 boxes after consolidation, got " + result.size(), result.size() <= 2);
+
+        // Verify coverage
+        BoundingBox union = new BoundingBox(0, 0, 10000000, 1000000);
+        for (BoundingBox box : result) {
+            assertTrue("Result box should be within or equal to original union", union.contains(box) || box.contains(union));
+        }
+    }
+
+    /**
+     * Test consolidating overlapping boxes
+     */
+    @Test
+    public void consolidateOverlappingBoxes() {
+        List<BoundingBox> boxes = new ArrayList<>();
+        boxes.add(new BoundingBox(0, 0, 10000000, 10000000));
+        boxes.add(new BoundingBox(5000000, 5000000, 15000000, 15000000)); // overlaps
+
+        List<BoundingBox> result = BoundingBox.consolidate(boxes, 1000000);
+
+        // Should consolidate significantly
+        assertTrue("Expected 1-2 boxes after consolidation, got " + result.size(), result.size() <= 2);
+    }
+
+    /**
+     * Test realistic pan-and-zoom fragmentation scenario Simulates: download initial area, then pan right and up
+     */
+    @Test
+    public void consolidatePanAndZoomFragmentation() {
+        List<BoundingBox> boxes = new ArrayList<>();
+
+        // Initial download
+        boxes.add(new BoundingBox(0, 0, 20000000, 20000000));
+
+        // After panning right - creates right sliver
+        boxes.add(new BoundingBox(20000000, 5000000, 20500000, 15000000)); // thin right edge
+
+        // After panning up - creates top sliver
+        boxes.add(new BoundingBox(5000000, 20000000, 15000000, 20500000)); // thin top edge
+
+        List<BoundingBox> result = BoundingBox.consolidate(boxes, 1000000);
+
+        // Should reduce from 3 to 1-2 boxes
+        assertTrue("Expected 1-2 boxes after consolidation, got " + result.size(), result.size() <= 2);
+    }
+
+    /**
+     * Test repeated panning creating many small boxes
+     */
+    @Test
+    public void realWorldRepeatedPanning() {
+        List<BoundingBox> boxes = new ArrayList<>();
+
+        // Simulate result of repeated pan operations creating many thin strips
+        boxes.add(new BoundingBox(0, 0, 10000000, 10000000)); // main
+        boxes.add(new BoundingBox(10000000, 0, 10300000, 10000000)); // right strip 1
+        boxes.add(new BoundingBox(10300000, 0, 10600000, 10000000)); // right strip 2
+        boxes.add(new BoundingBox(10600000, 0, 11000000, 10000000)); // right strip 3
+        boxes.add(new BoundingBox(0, 10000000, 10000000, 10300000)); // top strip 1
+        boxes.add(new BoundingBox(0, 10300000, 10000000, 10600000)); // top strip 2
+
+        int originalSize = boxes.size();
+        List<BoundingBox> result = BoundingBox.consolidate(boxes, 500000);
+
+        // Should significantly reduce fragmentation
+        assertTrue("Consolidation should reduce box count. Original: " + originalSize + ", Result: " + result.size(), result.size() < originalSize);
+    }
+
+    /**
+     * Test that large, non-adjacent boxes are not merged
+     */
+    @Test
+    public void largeBoxesShouldNotBeMerged() {
+        List<BoundingBox> boxes = new ArrayList<>();
+        // Two large, non-adjacent boxes
+        boxes.add(new BoundingBox(0, 0, 20000000, 20000000));
+        boxes.add(new BoundingBox(50000000, 50000000, 70000000, 70000000)); // far away
+
+        List<BoundingBox> result = BoundingBox.consolidate(boxes, 1000000);
+
+        // Should remain as 2 separate boxes
+        assertEquals("Large non-adjacent boxes should not be merged", 2, result.size());
+    }
+
+    /**
+     * Test empty list
+     */
+    @Test
+    public void consolidateEmptyList() {
+        List<BoundingBox> boxes = new ArrayList<>();
+        List<BoundingBox> result = BoundingBox.consolidate(boxes, 1000000);
+
+        assertEquals("Empty list should remain empty", 0, result.size());
+    }
+
+    /**
+     * Test single box
+     */
+    @Test
+    public void consolidateSingleBox() {
+        List<BoundingBox> boxes = new ArrayList<>();
+        boxes.add(new BoundingBox(0, 0, 10000000, 10000000));
+
+        List<BoundingBox> result = BoundingBox.consolidate(boxes, 1000000);
+
+        assertEquals("Single box should remain as single box", 1, result.size());
+        assertEquals("Box should be unchanged", boxes.get(0), result.get(0));
+    }
+
+    /**
+     * Test that small boxes contained within large boxes are merged
+     */
+    @Test
+    public void consolidateContainedSmallBox() {
+        List<BoundingBox> boxes = new ArrayList<>();
+        // Large box
+        boxes.add(new BoundingBox(0, 0, 10000000, 10000000));
+        // Small box inside the large one
+        boxes.add(new BoundingBox(4000000, 4000000, 4500000, 4500000));
+
+        List<BoundingBox> result = BoundingBox.consolidate(boxes, 500001);
+
+        // Small box should be absorbed
+        assertTrue("Expected 1 box after consolidation, got " + result.size(), result.size() <= 1);
+    }
+
+    /**
+     * Test that minSize parameter is respected
+     */
+    @Test
+    public void minSizeParameterRespected() {
+        List<BoundingBox> boxes = new ArrayList<>();
+        // Two narrow boxes
+        boxes.add(new BoundingBox(0, 0, 1000000, 10000000)); // width: 1M
+        boxes.add(new BoundingBox(1000000, 0, 2000000, 10000000)); // width: 1M
+
+        // With high minSize threshold, should merge
+        List<BoundingBox> result1 = BoundingBox.consolidate(boxes, 2000000);
+        assertTrue("High minSize should trigger consolidation", result1.size() <= 2);
+
+        // With low minSize threshold, might not merge
+        List<BoundingBox> result2 = BoundingBox.consolidate(boxes, 100000);
+        // Both behaviors are acceptable, just testing that parameter is used
+        assertNotNull("Result should not be null", result2);
+    }
+
+    /**
+     * Test complex fragmentation pattern (multiple strips from different directions)
+     */
+    @Test
+    public void consolidateComplexFragmentationPattern() {
+        List<BoundingBox> boxes = new ArrayList<>();
+
+        // Main coverage
+        boxes.add(new BoundingBox(10000000, 10000000, 30000000, 30000000));
+
+        // Right strips
+        boxes.add(new BoundingBox(30000000, 12000000, 30500000, 28000000));
+        boxes.add(new BoundingBox(30500000, 12000000, 31000000, 28000000));
+
+        // Top strips
+        boxes.add(new BoundingBox(12000000, 30000000, 28000000, 30500000));
+        boxes.add(new BoundingBox(12000000, 30500000, 28000000, 31000000));
+
+        // Bottom strips
+        boxes.add(new BoundingBox(12000000, 9500000, 28000000, 10000000));
+
+        // Left strips
+        boxes.add(new BoundingBox(9500000, 12000000, 10000000, 28000000));
+
+        int originalSize = boxes.size();
+        List<BoundingBox> result = BoundingBox.consolidate(boxes, 1000000);
+
+        // Should consolidate significantly
+        assertTrue("Expected significant reduction. Original: " + originalSize + ", Result: " + result.size(), result.size() < originalSize);
+    }
+
+    /**
+     * This test validates that after consolidation, the union of result boxes covers at least as much area as the union
+     * of original boxes.
+     */
+    @Test
+    public void consolidationPreservesCoverage() {
+        List<BoundingBox> boxes = new ArrayList<>();
+
+        // Create a realistic pan scenario
+        boxes.add(new BoundingBox(0, 0, 20000000, 20000000));
+        boxes.add(new BoundingBox(15000000, 0, 22000000, 20000000)); // overlapping right
+        boxes.add(new BoundingBox(0, 15000000, 20000000, 22000000)); // overlapping top
+        boxes.add(new BoundingBox(20000000, 10000000, 21000000, 20000000)); // thin sliver
+        boxes.add(new BoundingBox(10000000, 20000000, 20000000, 21000000)); // thin sliver
+
+        // Calculate original coverage bounds
+        BoundingBox originalUnion = BoundingBox.union(boxes);
+        assertNotNull("Original union should not be null", originalUnion);
+
+        // Consolidate
+        List<BoundingBox> result = BoundingBox.consolidate(boxes, 1000001);
+
+        // Calculate result coverage bounds
+        BoundingBox resultUnion = BoundingBox.union(result);
+        assertNotNull("Result union should not be null", resultUnion);
+
+        // Verify critical test points
+        // 1. Result should cover at least the core areas
+        assertTrue("Result should cover original bounds or be larger",
+                resultUnion.getLeft() <= originalUnion.getLeft() && resultUnion.getRight() >= originalUnion.getRight()
+                        && resultUnion.getBottom() <= originalUnion.getBottom() && resultUnion.getTop() >= originalUnion.getTop());
+
+        // 2. Result should have fewer boxes
+        assertTrue("Consolidation should reduce box count", result.size() < boxes.size());
+    }
+
+    /**
+     * Test that the algorithm handles boxes touching at edges (not overlapping)
+     */
+    @Test
+    public void adjacentNonOverlappingBoxes() {
+        List<BoundingBox> boxes = new ArrayList<>();
+        // Two boxes that touch but don't overlap
+        boxes.add(new BoundingBox(0, 0, 10000000, 10000000));
+        boxes.add(new BoundingBox(10000000, 0, 20000000, 10000000)); // starts where previous ends
+
+        List<BoundingBox> result = BoundingBox.consolidate(boxes, 1000000);
+
+        // Should be consolidatable since they're adjacent
+        assertTrue("Adjacent boxes should consolidate to 1-2 boxes, got " + result.size(), result.size() <= 2);
+    }
+
+    /**
+     * Test with many tiny boxes (extreme fragmentation)
+     */
+    @Test
+    public void extremeFragmentation() {
+        List<BoundingBox> boxes = new ArrayList<>();
+
+        // Create a 10x10 grid of tiny boxes
+        for (int i = 0; i < 10; i++) {
+            for (int j = 0; j < 10; j++) {
+                int left = i * 1000000;
+                int bottom = j * 1000000;
+                boxes.add(new BoundingBox(left, bottom, left + 1000000, bottom + 1000000));
+            }
+        }
+
+        assertEquals("Starting with 100 tiny boxes", 100, boxes.size());
+
+        List<BoundingBox> result = BoundingBox.consolidate(boxes, 1000001);
+
+        // Should consolidate significantly
+        assertTrue("Extreme fragmentation should consolidate dramatically. Result: " + result.size(), result.size() < 50);
     }
 }


### PR DESCRIPTION
The algorithm to generate bounding boxes for pan and zoom download can in some situations start generating very small bounding boxes. This code merges any boxes that are smaller than the minimum and in general seems to make the problem go away.

As an experiment this code was partly generated by a LLM, though in particular the unit tests didn't actually work originally and the code had some typical artifacts of such code that have mostly been removed.