### PR TITLE
Record the non-expanded tile url for custom entries instead of the name

### DIFF
--- a/src/main/java/de/blau/android/Map.java
+++ b/src/main/java/de/blau/android/Map.java
@@ -1266,20 +1266,20 @@ public class Map extends SurfaceView implements IMapView {
     }
 
     /**
-     * Return a list of the names of the currently used (and visible) layers
+     * Return a list of the source of the currently used (and visible) layers
      * 
-     * @return a List containing the currently in use imagery names
+     * @return a List containing the currently in use imagery sources
      */
     @NonNull
-    public List<String> getImageryNames() {
-        List<String> result = new ArrayList<>();
+    public List<TileLayerSource> getImagerySources() {
+        List<TileLayerSource> result = new ArrayList<>();
         List<MapViewLayer> imageryLayers = getLayers();
         Collections.reverse(imageryLayers);
         for (MapViewLayer osmvo : imageryLayers) {
             if (osmvo instanceof MapTilesLayer && osmvo.isVisible()) {
                 TileLayerSource tileLayerConfiguration = ((MapTilesLayer<?>) osmvo).getTileLayerConfiguration();
                 if (tileLayerConfiguration != null) {
-                    result.add(tileLayerConfiguration.getName());
+                    result.add(tileLayerConfiguration);
                     if (!tileLayerConfiguration.isOverlay()) {
                         // not an overlay -> not transparent so nothing below it is visible
                         break;

--- a/src/main/java/de/blau/android/osm/StorageDelegator.java
+++ b/src/main/java/de/blau/android/osm/StorageDelegator.java
@@ -44,6 +44,8 @@ import de.blau.android.filter.Filter;
 import de.blau.android.osm.OsmChangeParser.MissingNode;
 import de.blau.android.osm.UndoStorage.Checkpoint;
 import de.blau.android.prefs.Preferences;
+import de.blau.android.resources.TileLayerDatabase;
+import de.blau.android.resources.TileLayerSource;
 import de.blau.android.util.ACRAHelper;
 import de.blau.android.util.BentleyOttmannForOsm;
 import de.blau.android.util.Coordinates;
@@ -467,10 +469,11 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
                 if (map == null) { // currently we only modify data when the map exists
                     return;
                 }
-                List<String> currentImagery = map.getImageryNames();
-                for (String i : currentImagery) {
-                    if (!imagery.contains(i) && !"None".equalsIgnoreCase(i)) {
-                        imagery.add(i);
+                List<TileLayerSource> currentImagery = map.getImagerySources();
+                for (TileLayerSource i : currentImagery) {
+                    String toRecord = TileLayerDatabase.SOURCE_MANUAL.equals(i.getSource()) ? i.getOriginalTileUrl() : i.getName();
+                    if (!imagery.contains(toRecord) && !TileLayerSource.LAYER_NONE_NAME.equalsIgnoreCase(i.getName())) {
+                        imagery.add(toRecord);
                     }
                 }
                 imageryRecorded = true;

--- a/src/main/java/de/blau/android/resources/TileLayerSource.java
+++ b/src/main/java/de/blau/android/resources/TileLayerSource.java
@@ -132,6 +132,8 @@ public class TileLayerSource implements Serializable {
     public static final String LAYER_NOOVERLAY = "NOOVERLAY";
     public static final String LAYER_BING      = "Bing";
 
+    public static final String LAYER_NONE_NAME = "None";
+
     private static final String SWITCH_START = "{switch:";
 
     // supported URL placeholders

--- a/src/test/java/de/blau/android/MapTest.java
+++ b/src/test/java/de/blau/android/MapTest.java
@@ -66,19 +66,19 @@ public class MapTest {
         db.close();
         Map map = new Map(ApplicationProvider.getApplicationContext());
         map.setPrefs(ApplicationProvider.getApplicationContext(), prefs);
-        List<String> names = map.getImageryNames();
+        List<TileLayerSource> names = map.getImagerySources();
         assertEquals(1, names.size());
         TileLayerSource mapnik = TileLayerSource.get(ApplicationProvider.getApplicationContext(), TileLayerSource.LAYER_MAPNIK, false);
         assertNotNull(mapnik);
-        assertEquals(mapnik.getName(), map.getImageryNames().get(0));
+        assertEquals(mapnik.getName(), map.getImagerySources().get(0).getName());
         TileLayerSource mapillary = TileLayerSource.get(ApplicationProvider.getApplicationContext(),
                 de.blau.android.layer.streetlevel.mapillary.MapillaryOverlay.MAPILLARY_TILES_ID, false);
         assertNotNull(mapillary);
         de.blau.android.layer.Util.addLayer(ApplicationProvider.getApplicationContext(), LayerType.MAPILLARY);
         map.setUpLayers(ApplicationProvider.getApplicationContext());
-        names = map.getImageryNames();
+        names = map.getImagerySources();
         assertEquals(2, names.size());
-        assertEquals(mapillary.getName(), map.getImageryNames().get(0));
-        assertEquals(mapnik.getName(), map.getImageryNames().get(1));
+        assertEquals(mapillary.getName(), map.getImagerySources().get(0).getName());
+        assertEquals(mapnik.getName(), map.getImagerySources().get(1).getName());
     }
 }


### PR DESCRIPTION
Record the non-expanded tile url for custom entries instead of the name for storing in the changeset _imagery_used_ tag.

This is somewhat problematic as the url might contain private api keys etc.