### PR TITLE
Support squaring individual corners of a selected way

### DIFF
--- a/documentation/docs/help/en/Multiselect.md
+++ b/documentation/docs/help/en/Multiselect.md
@@ -36,6 +36,10 @@ Remove the objects from the data.
 
 Merge multiple selected ways resulting in a single way. Ways will be reversed if necessary. This option will only be available if only ways with common start/end nodes are selected, or the selection is two closed ways (polygons), in the later case if the polygons do not have common nodes a multi-polygon relation will be created and the ways added as members. If post-merge tag conflicts are detected you will be alerted. 
 
+### ![Orthogonalize](../images/menu_ortho.png) Square
+
+Available for closed ways (polygons), individual non-end way nodes and specific selected ways with selected nodes. Change angles that are near 90° or 180° to 90° or 180° respectively. The threshold over which angles are not changed can be set in the [Advanced preferences](Advanced%20preferences.md).
+
 ### Extract segment
 
 If you have selected exactly two nodes on the same way, you can extract the segment of the way between the two nodes. If the way is closed the segment extracted will between the first and 2nd node selected in the winding direction (clockwise or counterclockwise) of the way.

--- a/documentation/docs/help/en/Node selected.md
+++ b/documentation/docs/help/en/Node selected.md
@@ -61,6 +61,10 @@ Start creating a turn restriction with this node as "via" member. This action is
 
 If the node has a direction tag with a degree value, rotate the node by dragging the display roughly in a circle.
 
+### ![Orthogonalize](../images/menu_ortho.png) Square
+
+Available for non-end nodes of ways. Change angles that are near 90° or 180° to 90° or 180° respectively. The threshold over which angles are not changed can be set in the [Advanced preferences](Advanced%20preferences.md).
+
 ### ![Copy](../images/ic_menu_copy_holo_light.png) Copy
 
 Copy the node to the internal copy and paste buffer.

--- a/src/androidTest/java/de/blau/android/easyedit/ExtendedSelectionTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/ExtendedSelectionTest.java
@@ -19,7 +19,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.ActivityTestRule;
+import androidx.test.uiautomator.By;
 import androidx.test.uiautomator.UiDevice;
+import androidx.test.uiautomator.Until;
 import de.blau.android.App;
 import de.blau.android.LayerUtils;
 import de.blau.android.Logic;
@@ -34,6 +36,7 @@ import de.blau.android.osm.Tags;
 import de.blau.android.osm.Way;
 import de.blau.android.prefs.AdvancedPrefDatabase;
 import de.blau.android.prefs.Preferences;
+import de.blau.android.util.Coordinates;
 
 @RunWith(AndroidJUnit4.class)
 @LargeTest
@@ -350,4 +353,55 @@ public class ExtendedSelectionTest {
         assertTrue(wayNodes.contains(nodes.get(1)));
     }
 
+    /**
+     * Create a new way from menu and clicks at two more locations and finishing via home button, then square
+     */
+    // @SdkSuppress(minSdkVersion = 26)
+    @Test
+    public void square() {
+        map.getDataLayer().setVisible(true);
+        TestUtils.zoomToLevel(device, main, 22);
+        TestUtils.unlock(device);
+        TestUtils.clickButton(device, device.getCurrentPackageName() + ":id/simpleButton", true);
+        assertTrue(TestUtils.clickText(device, false, context.getString(R.string.menu_add_way), true, false));
+        assertTrue(TestUtils.findText(device, false, context.getString(R.string.add_way_start_instruction)));
+        TestUtils.clickAtCoordinates(device, map, 8.3886384, 47.3892752, true);
+        assertTrue(TestUtils.findText(device, false, context.getString(R.string.add_way_node_instruction), 1000));
+
+        TestUtils.clickAtCoordinates(device, map, 8.3887655, 47.3892752, true);
+        TestUtils.sleep();
+        TestUtils.clickAtCoordinates(device, map, 8.38877, 47.389202, true);
+        TestUtils.clickButton(device, device.getCurrentPackageName() + ":id/simpleButton", true);
+        assertTrue(TestUtils.findText(device, false, context.getString(R.string.tag_form_untagged_element)));
+        TestUtils.clickHome(device, true);
+        Way way = App.getLogic().getSelectedWay();
+        assertNotNull(way);
+        assertTrue(way.getOsmId() < 0);
+        assertEquals(3, way.nodeCount());
+        Coordinates[] coords = Coordinates.nodeListToCoordinateArray(map.getWidth(), map.getHeight(), map.getViewBox(), way.getNodes());
+        Coordinates v1 = coords[0].subtract(coords[1]);
+        Coordinates v2 = coords[2].subtract(coords[1]);
+        double theta = Math.toDegrees(Math.acos(Coordinates.dotproduct(v1, v2) / (v1.length() * v2.length())));
+        System.out.println("Original angle " + theta);
+        assertEquals(92.33, theta, 0.25);
+        assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_wayselect)));
+        TestUtils.clickOverflowButton(device);
+        TestUtils.clickText(device, false, context.getString(R.string.menu_select_way_nodes), false, false);
+        assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_multiselect)));
+        
+        if (!TestUtils.clickMenuButton(device, context.getString(R.string.menu_orthogonalize), false, true)) {
+            assertTrue(TestUtils.clickOverflowButton(device));
+            assertTrue(TestUtils.clickText(device, false, context.getString(R.string.menu_orthogonalize), true, false));
+        }
+      
+        device.wait(Until.findObject(By.res(device.getCurrentPackageName() + ":string/Done")), 1000);
+        coords = Coordinates.nodeListToCoordinateArray(map.getWidth(), map.getHeight(), map.getViewBox(), way.getNodes());
+        v1 = coords[0].subtract(coords[1]);
+        v2 = coords[2].subtract(coords[1]);
+        theta = Math.toDegrees(Math.acos(Coordinates.dotproduct(v1, v2) / (v1.length() * v2.length())));
+        System.out.println("New angle " + theta);
+        assertEquals(90.00, theta, 0.05);
+        device.waitForIdle(1000);
+        TestUtils.clickUp(device);
+    }
 }

--- a/src/androidTest/java/de/blau/android/easyedit/WayActionsTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/WayActionsTest.java
@@ -108,7 +108,7 @@ public class WayActionsTest {
     @Test
     public void square() {
         map.getDataLayer().setVisible(true);
-        TestUtils.zoomToLevel(device, main, 21);
+        TestUtils.zoomToLevel(device, main, 22);
         TestUtils.unlock(device);
         TestUtils.clickButton(device, device.getCurrentPackageName() + ":id/simpleButton", true);
         assertTrue(TestUtils.clickText(device, false, context.getString(R.string.menu_add_way), true, false));

--- a/src/main/assets/help/en/Multiselect.html
+++ b/src/main/assets/help/en/Multiselect.html
@@ -24,6 +24,8 @@
 <p>Remove the objects from the data.</p>
 <h3 id="merge-merge-ways"><img src="../images/tag_menu_merge.png" alt="Merge" /> Merge ways</h3>
 <p>Merge multiple selected ways resulting in a single way. Ways will be reversed if necessary. This option will only be available if only ways with common start/end nodes are selected, or the selection is two closed ways (polygons), in the later case if the polygons do not have common nodes a multi-polygon relation will be created and the ways added as members. If post-merge tag conflicts are detected you will be alerted.</p>
+<h3 id="orthogonalize-square"><img src="../images/menu_ortho.png" alt="Orthogonalize" /> Square</h3>
+<p>Available for closed ways (polygons), individual non-end way nodes and specific selected ways with selected nodes. Change angles that are near 90° or 180° to 90° or 180° respectively. The threshold over which angles are not changed can be set in the <a href="Advanced%20preferences.md">Advanced preferences</a>.</p>
 <h3 id="extract-segment">Extract segment</h3>
 <p>If you have selected exactly two nodes on the same way, you can extract the segment of the way between the two nodes. If the way is closed the segment extracted will between the first and 2nd node selected in the winding direction (clockwise or counterclockwise) of the way.</p>
 <p>If the way has <em>highway</em> or <em>waterway</em> tagging a number of shortcuts will be displayed, for example to change a <em>footway</em> in to <em>steps</em>.</p>

--- a/src/main/assets/help/en/Node selected.html
+++ b/src/main/assets/help/en/Node selected.html
@@ -36,6 +36,8 @@
 <p>Start creating a turn restriction with this node as &quot;via&quot; member. This action is only available if the node in question is a potential via member, that is it is a member of at least two ways that have a &quot;highway&quot; tag. Ways will be split automatically during the process.</p>
 <h3 id="rotate-rotate"><img src="../images/ic_menu_rotate.png" alt="Rotate" /> Rotate</h3>
 <p>If the node has a direction tag with a degree value, rotate the node by dragging the display roughly in a circle.</p>
+<h3 id="orthogonalize-square"><img src="../images/menu_ortho.png" alt="Orthogonalize" /> Square</h3>
+<p>Available for non-end nodes of ways. Change angles that are near 90° or 180° to 90° or 180° respectively. The threshold over which angles are not changed can be set in the <a href="Advanced%20preferences.md">Advanced preferences</a>.</p>
 <h3 id="copy-copy"><img src="../images/ic_menu_copy_holo_light.png" alt="Copy" /> Copy</h3>
 <p>Copy the node to the internal copy and paste buffer.</p>
 <h3 id="duplicate-duplicate"><img src="../images/content_duplicate_light.png" alt="Duplicate" /> Duplicate</h3>

--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -119,6 +119,7 @@ import de.blau.android.osm.UndoStorage.Checkpoint;
 import de.blau.android.osm.UserDetails;
 import de.blau.android.osm.ViewBox;
 import de.blau.android.osm.Way;
+import de.blau.android.osm.WayInterface;
 import de.blau.android.prefs.Preferences;
 import de.blau.android.presets.Preset;
 import de.blau.android.resources.DataStyle;
@@ -2590,12 +2591,12 @@ public class Logic {
     }
 
     /**
-     * Orthogonalize a way (aka make angles 90°)
+     * Orthogonalize a way (aka make angles a integer multiple of 90°)
      * 
      * @param activity activity this was called from, if null no warnings will be displayed
      * @param way way to square
      */
-    public void performOrthogonalize(@Nullable FragmentActivity activity, @Nullable Way way) {
+    public <W extends WayInterface> void performOrthogonalize(@Nullable FragmentActivity activity, @Nullable W way) {
         if (way == null || way.getNodes().size() < 3) {
             Log.e(DEBUG_TAG, "performOrthogonalize way " + (way == null ? "is null" : " has " + way.nodeCount()) + " nodes");
             return;
@@ -2604,14 +2605,14 @@ public class Logic {
     }
 
     /**
-     * Orthogonalize multiple ways at once (aka make angles 90°)
+     * Orthogonalize multiple ways at once (aka make angles a integer multiple of 90°)
      * 
      * As this can take a noticeable amount of time, we execute async and display a toast when finished
      * 
      * @param activity activity this was called from, if null no warnings will be displayed
      * @param ways ways to square
      */
-    public void performOrthogonalize(@Nullable FragmentActivity activity, @Nullable List<Way> ways) {
+    public <W extends WayInterface> void performOrthogonalize(@Nullable FragmentActivity activity, @Nullable List<W> ways) {
         if (ways == null || ways.isEmpty()) {
             Log.e(DEBUG_TAG, "performOrthogonalize no ways");
             return;
@@ -2643,7 +2644,7 @@ public class Logic {
                 }
                 if (getFilter() != null && showAttachedObjectWarning()) {
                     Set<Node> nodes = new HashSet<>();
-                    for (Way w : ways) {
+                    for (W w : ways) {
                         nodes.addAll(w.getNodes());
                     }
                     displayAttachedObjectWarning(activity, nodes);

--- a/src/main/java/de/blau/android/easyedit/EasyEditActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/EasyEditActionModeCallback.java
@@ -41,11 +41,14 @@ import de.blau.android.osm.RelationUtils;
 import de.blau.android.osm.Result;
 import de.blau.android.osm.Tags;
 import de.blau.android.osm.Way;
+import de.blau.android.osm.WaySegment;
 import de.blau.android.prefs.keyboard.Shortcuts;
+import de.blau.android.util.MathUtil;
 import de.blau.android.util.MenuUtil;
 import de.blau.android.util.ScreenMessage;
 import de.blau.android.util.SerializableState;
 import de.blau.android.util.ThemeUtils;
+import de.blau.android.util.Util;
 
 /**
  * Base class for ActionMode callbacks inside {@link EasyEditManager}. Derived classes should call
@@ -607,6 +610,85 @@ public abstract class EasyEditActionModeCallback implements ActionMode.Callback 
                 manager.finish();
             }
         };
+    }
+
+    /**
+     * From a List of candidate nodes get Nodes that could be squared and the associated Ways
+     * 
+     * @param logic Logic instance
+     * @param candidateNodes the candidate nodes
+     * @param ways the container for ways, can be null is not used
+     * @param nodes the squarable nodes
+     */
+    protected static void getSquarableNodes(@NonNull Logic logic, @Nullable List<Node> candidateNodes, @Nullable Set<Way> ways, @NonNull Set<Node> nodes) {
+        if (Util.isEmpty(candidateNodes)) {
+            return;
+        }
+        for (Node n : candidateNodes) {
+            List<Way> parents = logic.getWaysForNode(n);
+            for (Way parent : parents) {
+                if (!parent.isEndNode(n) || parent.isClosed()) {
+                    if (ways != null) {
+                        ways.add(parent);
+                    }
+                    nodes.add(n);
+                }
+            }
+        }
+    }
+
+    /**
+     * Given one or more ways and corner nodes, square the corners
+     * 
+     * @param main Main instance
+     * @param logic Logic instance
+     * @param ways the relevant Ways
+     * @param cornerNodes the corners
+     */
+    protected static void orthogonalize(@Nullable Main main, @NonNull Logic logic, @NonNull List<Way> ways, @NonNull List<Node> cornerNodes) {
+        // generate way segments and orthogonalize those
+        List<WaySegment> segments = new ArrayList<>();
+        for (Way w : ways) {
+            // sort the corners as they are in the way
+            List<Node> cornersToSquare = new ArrayList<>();
+            final List<Node> nodes = w.getNodes();
+            final int nodeCount = uniqueNodeCount(w);
+            for (int i = 0; i < nodeCount; i++) {
+                Node n = nodes.get(i);
+                if (cornerNodes.contains(n)) {
+                    cornersToSquare.add(n);
+                }
+            }
+            if (cornersToSquare.isEmpty()) {
+                continue;
+            }
+
+            int cornerCount = cornersToSquare.size();
+            for (int i = 0; i < cornerCount; i++) {
+                Node n = cornersToSquare.get(i);
+                int start = nodes.indexOf(n);
+                // check the next nodes
+                int end = start;
+                while (i < cornerCount - 1 && nodes.get(end + 1).equals(cornersToSquare.get(i + 1))) {
+                    end++;
+                    i++; // NOSONAR
+                }
+                segments.add(new WaySegment(w, MathUtil.mod(start - 1, nodeCount), (end + 1) % nodeCount));
+            }
+        }
+        if (!segments.isEmpty()) {
+            logic.performOrthogonalize(main, segments);
+        }
+    }
+
+    /**
+     * Get the node count of a way without any closing node
+     * 
+     * @param w the way
+     * @return the node count of a way without any closing node
+     */
+    private static int uniqueNodeCount(@NonNull Way w) {
+        return w.nodeCount() - (w.isClosed() ? 1 : 0);
     }
 
     /**

--- a/src/main/java/de/blau/android/easyedit/MultiSelectWithGeometryActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/MultiSelectWithGeometryActionModeCallback.java
@@ -3,7 +3,9 @@ package de.blau.android.easyedit;
 import static de.blau.android.contract.Constants.LOG_TAG_LEN;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import android.annotation.SuppressLint;
 import android.util.Log;
@@ -93,7 +95,7 @@ public class MultiSelectWithGeometryActionModeCallback extends MultiSelectAction
         }));
         actionMap.put(main.getString(R.string.ACTION_UNDO), new Shortcuts.Action(R.string.action_undo, () -> undoListener.onClick(null)));
         actionMap.put(main.getString(R.string.ACTION_DELETE), new Shortcuts.Action(R.string.action_delete, () -> menuDelete(false)));
-        actionMap.put(main.getString(R.string.ACTION_SQUARE), new Shortcuts.Action(R.string.action_square, this::orthogonalizeWays));
+        actionMap.put(main.getString(R.string.ACTION_SQUARE), new Shortcuts.Action(R.string.action_square, this::orthogonalize));
         actionMap.put(main.getString(R.string.ACTION_MERGE), new Shortcuts.Action(R.string.action_merge, () -> {
             if (sortedWays != null) {
                 mergeWays();
@@ -149,7 +151,11 @@ public class MultiSelectWithGeometryActionModeCallback extends MultiSelectAction
                 .setItemVisibility((count > 1 && sortedWays != null && !canMergePolygons) || (count == 2 && canMergePolygons), mergeItem, false);
 
         List<Way> selectedWays = logic.getSelectedWays();
-        updated |= ElementSelectionActionModeCallback.setItemVisibility(selectedWays != null && !selectedWays.isEmpty(), orthogonalizeItem, false);
+        List<Node> selectedNodes = logic.getSelectedNodes();
+
+        Set<Node> squarableNodes = new HashSet<>();
+        getSquarableNodes(logic, selectedNodes, null, squarableNodes);
+        updated |= ElementSelectionActionModeCallback.setItemVisibility(!Util.isEmpty(selectedWays) || !Util.isEmpty(squarableNodes), orthogonalizeItem, false);
 
         updated |= ElementSelectionActionModeCallback.setItemVisibility(intersect(selectedWays), intersectItem, false);
 
@@ -244,7 +250,7 @@ public class MultiSelectWithGeometryActionModeCallback extends MultiSelectAction
             }, -1, R.string.select_relation_title, null, null, selection).show();
             break;
         case MENUITEM_ORTHOGONALIZE:
-            orthogonalizeWays();
+            orthogonalize();
             break;
         case MENUITEM_MERGE:
             if (canMergePolygons(selection)) {
@@ -364,13 +370,24 @@ public class MultiSelectWithGeometryActionModeCallback extends MultiSelectAction
     }
 
     /**
-     * Orthogonalize any selected Ways
+     * Orthogonalize / square / straighten
      */
-    private void orthogonalizeWays() {
+    private void orthogonalize() {
         List<Way> selectedWays = logic.getSelectedWays();
-        if (selectedWays != null && !selectedWays.isEmpty()) {
-            logic.performOrthogonalize(main, selectedWays);
+        List<Node> selectedNodes = logic.getSelectedNodes();
+        if (Util.isEmpty(selectedWays) && !Util.isEmpty(selectedNodes)) {
+            Set<Way> ways = new HashSet<>();
+            Set<Node> nodes = new HashSet<>();
+            getSquarableNodes(logic, selectedNodes, ways, nodes);
+            orthogonalize(main, logic, new ArrayList<>(ways), new ArrayList<>(nodes));
+            return;
         }
+
+        if (Util.isEmpty(selectedNodes)) {
+            logic.performOrthogonalize(main, selectedWays);
+            return;
+        }
+        orthogonalize(main, logic, selectedWays, selectedNodes);
     }
 
     /**

--- a/src/main/java/de/blau/android/easyedit/NodeSelectionActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/NodeSelectionActionModeCallback.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.SortedMap;
 
 import android.annotation.SuppressLint;
@@ -51,15 +52,16 @@ public class NodeSelectionActionModeCallback extends ElementSelectionActionModeC
     private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, NodeSelectionActionModeCallback.class.getSimpleName().length());
     private static final String DEBUG_TAG = NodeSelectionActionModeCallback.class.getSimpleName().substring(0, TAG_LEN);
 
-    private static final int MENUITEM_APPEND       = LAST_REGULAR_MENUITEM + 1;
-    private static final int MENUITEM_JOIN         = LAST_REGULAR_MENUITEM + 2;
-    private static final int MENUITEM_UNJOIN       = LAST_REGULAR_MENUITEM + 3;
-    private static final int MENUITEM_EXTRACT      = LAST_REGULAR_MENUITEM + 4;
-    private static final int MENUITEM_RESTRICTION  = LAST_REGULAR_MENUITEM + 5;
+    private static final int MENUITEM_APPEND        = LAST_REGULAR_MENUITEM + 1;
+    private static final int MENUITEM_JOIN          = LAST_REGULAR_MENUITEM + 2;
+    private static final int MENUITEM_UNJOIN        = LAST_REGULAR_MENUITEM + 3;
+    private static final int MENUITEM_EXTRACT       = LAST_REGULAR_MENUITEM + 4;
+    private static final int MENUITEM_RESTRICTION   = LAST_REGULAR_MENUITEM + 5;
     /** */
-    private static final int MENUITEM_SET_POSITION = LAST_REGULAR_MENUITEM + 6;
-    private static final int MENUITEM_ADDRESS      = LAST_REGULAR_MENUITEM + 7;
-    private static final int MENUITEM_ROTATE       = LAST_REGULAR_MENUITEM + 8;
+    private static final int MENUITEM_SET_POSITION  = LAST_REGULAR_MENUITEM + 6;
+    private static final int MENUITEM_ADDRESS       = LAST_REGULAR_MENUITEM + 7;
+    private static final int MENUITEM_ROTATE        = LAST_REGULAR_MENUITEM + 8;
+    private static final int MENUITEM_ORTHOGONALIZE = LAST_REGULAR_MENUITEM + 9;
 
     private final GeoContext geoContext;
     private List<OsmElement> joinableElements = null;
@@ -71,6 +73,7 @@ public class NodeSelectionActionModeCallback extends ElementSelectionActionModeC
     private MenuItem         extractItem;
     private MenuItem         restrictionItem;
     private MenuItem         rotateItem;
+    private MenuItem         orthogonalizeItem;
     private int              action;
     private Preset[]         presets;
 
@@ -133,6 +136,10 @@ public class NodeSelectionActionModeCallback extends ElementSelectionActionModeC
                 .setIcon(ThemeUtils.getResIdFromAttribute(main, R.attr.menu_gps));
 
         rotateItem = menu.add(Menu.NONE, MENUITEM_ROTATE, Menu.NONE, R.string.menu_rotate).setIcon(ThemeUtils.getResIdFromAttribute(main, R.attr.menu_rotate));
+
+        orthogonalizeItem = menu.add(Menu.NONE, MENUITEM_ORTHOGONALIZE, Menu.NONE, R.string.menu_orthogonalize)
+                .setIcon(ThemeUtils.getResIdFromAttribute(main, R.attr.menu_ortho));
+
         return true;
     }
 
@@ -162,6 +169,10 @@ public class NodeSelectionActionModeCallback extends ElementSelectionActionModeC
         updated |= setItemVisibility(Tags.getDirectionKey(
                 Preset.findBestMatch(main, presets, element.getTags(), geoContext != null ? geoContext.getIsoCodes(element) : null, element, false),
                 element) != null, rotateItem, false);
+
+        Set<Node> squarableNodes = new HashSet<>();
+        getSquarableNodes(logic, Util.wrapInList((Node) element), null, squarableNodes);
+        updated |= ElementSelectionActionModeCallback.setItemVisibility(!Util.isEmpty(squarableNodes), orthogonalizeItem, false);
 
         if (updated) {
             arrangeMenu(menu);
@@ -229,6 +240,12 @@ public class NodeSelectionActionModeCallback extends ElementSelectionActionModeC
             case MENUITEM_ROTATE:
                 deselect = false;
                 main.startSupportActionMode(new RotationActionModeCallback(manager));
+                break;
+            case MENUITEM_ORTHOGONALIZE:
+                Set<Way> ways = new HashSet<>();
+                Set<Node> nodes = new HashSet<>();
+                getSquarableNodes(logic, Util.wrapInList((Node) element), ways, nodes);
+                orthogonalize(main, logic, new ArrayList<>(ways), new ArrayList<>(nodes));
                 break;
             case MENUITEM_SHARE_POSITION:
                 double[] lonLat = new double[2];

--- a/src/main/java/de/blau/android/osm/StorageDelegator.java
+++ b/src/main/java/de/blau/android/osm/StorageDelegator.java
@@ -1024,35 +1024,35 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
      * @return a list of list of ways with common nodes
      */
     @NonNull
-    private List<List<Way>> groupWays(@NonNull List<Way> ways) {
-        List<List<Way>> groups = new ArrayList<>();
+    private <W extends WayInterface> List<List<W>> groupWays(@NonNull List<W> ways) {
+        List<List<W>> groups = new ArrayList<>();
         int group = 0;
         int index = 0;
         int groupIndex = 1;
         groups.add(new ArrayList<>());
-        Way startWay = ways.get(index);
+        W startWay = ways.get(index);
         groups.get(group).add(startWay);
         do {
+            List<W> currentGroup = groups.get(group);
             do {
                 for (Node nd : startWay.getNodes()) {
-                    for (Way w : ways) {
-                        if (w.getNodes().contains(nd) && !groups.get(group).contains(w)) {
-                            groups.get(group).add(w);
+                    for (W w : ways) {
+                        if (w.getNodes().contains(nd) && !currentGroup.contains(w)) {
+                            currentGroup.add(w);
                         }
                     }
                 }
-                if (groupIndex < groups.get(group).size()) {
-                    startWay = groups.get(group).get(groupIndex);
+                if (groupIndex < currentGroup.size()) {
+                    startWay = currentGroup.get(groupIndex);
                     groupIndex++;
                 }
-            } while (groupIndex < groups.get(group).size());
+            } while (groupIndex < currentGroup.size());
             // repeat until no new ways are added in the loop
-
             // find the next way that is not in a group and start a new one
             for (; index < ways.size(); index++) {
-                Way w = ways.get(index);
+                W w = ways.get(index);
                 boolean found = false;
-                for (List<Way> list : groups) {
+                for (List<W> list : groups) {
                     found = found || list.contains(w);
                 }
                 if (!found) {
@@ -1079,7 +1079,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
      * @param ways List of Way to square
      * @param threshold maximum difference to 90°/180° to process
      */
-    public void orthogonalizeWay(@NonNull List<Way> ways, final int threshold) {
+    public <W extends WayInterface> void orthogonalizeWay(@NonNull List<W> ways, final int threshold) {
         final double lowerThreshold = Math.cos((90 - threshold) * Math.PI / 180);
         final double upperThreshold = Math.cos(threshold * Math.PI / 180);
         final double epsilon = 1e-5;
@@ -1088,7 +1088,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
         // save nodes for undo
         // adding to a Set first removes duplication
         Set<Node> save = new HashSet<>();
-        for (Way way : ways) {
+        for (W way : ways) {
             if (way.getNodes() != null) {
                 save.addAll(way.getNodes());
             }
@@ -1097,21 +1097,23 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
             undo.save(nd);
         }
         invalidateWayBoundingBox(save);
-        List<List<Way>> groups = groupWays(ways);
+        List<List<W>> groups = groupWays(ways);
 
         List<Coordinates[]> coordsArray = new ArrayList<>();
 
-        for (List<Way> wayList : groups) {
+        for (List<W> wayList : groups) {
             coordsArray.clear();
 
             int totalNodes = 0;
-            for (Way w : wayList) {
+            for (W w : wayList) {
                 coordsArray.add(Coordinates.nodeListToMercatorCoordinateArray(w.getNodes()));
                 totalNodes += w.getNodes().size();
             }
-            int coordsArraySize = coordsArray.size();
+
             double lonOffset = coordsArray.get(0)[0].x;
             double latOffset = coordsArray.get(0)[0].y;
+
+            int coordsArraySize = coordsArray.size();
             for (int coordIndex = 0; coordIndex < coordsArraySize; coordIndex++) {
                 Coordinates[] coords = coordsArray.get(coordIndex);
                 for (Coordinates c : coords) {

--- a/src/main/java/de/blau/android/osm/WaySegment.java
+++ b/src/main/java/de/blau/android/osm/WaySegment.java
@@ -1,0 +1,67 @@
+package de.blau.android.osm;
+
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import android.util.Log;
+import androidx.annotation.NonNull;
+
+public class WaySegment implements WayInterface, Serializable {
+
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, WaySegment.class.getSimpleName().length());
+    private static final String DEBUG_TAG = WaySegment.class.getSimpleName().substring(0, TAG_LEN);
+
+    private static final long serialVersionUID = 1L;
+
+    private final Way way;
+    private final int start;
+    private final int end;
+
+    /**
+     * Create a way segment from an existing way
+     * 
+     * Essentially this is a "view" of the way, note that it makes no representations as to if the List returned from
+     * getNodes is a subList or a newly constructed one.
+     * 
+     * @param way the original Way
+     * @param start the start of the segment
+     * @param end the end of the segment
+     */
+    public WaySegment(@NonNull Way way, int start, int end) {
+        Log.d(DEBUG_TAG, way.getDescription() + " start:" + start + " end:" + end);
+        this.way = way;
+        this.start = start;
+        this.end = end;
+    }
+
+    @Override
+    public List<Node> getNodes() {
+        final List<Node> nodes = way.getNodes();
+        if (end >= start) {
+            return nodes.subList(start, end + 1);
+        }
+        // wraps over the end of the way, allocate a new List
+        List<Node> result = new ArrayList<>(nodes.subList(start, way.nodeCount()));
+        result.addAll(nodes.subList(0, end + 1));
+        return result;
+    }
+
+    @Override
+    public int nodeCount() {
+        return end >= start ? end - start + 1 : way.nodeCount() - start + end;
+    }
+
+    @Override
+    public boolean isClosed() {
+        final List<Node> nodes = way.getNodes();
+        return nodes.get(start).equals(nodes.get(end));
+    }
+
+    @Override
+    public double length() {
+        return Way.length(getNodes());
+    }
+}

--- a/src/main/java/de/blau/android/util/MathUtil.java
+++ b/src/main/java/de/blau/android/util/MathUtil.java
@@ -11,13 +11,13 @@ public final class MathUtil {
     private MathUtil() {
         // empty
     }
-    
+
     /**
-     * Floor modulus 
+     * Floor modulus
      * 
      * See Math.floorMod
      * 
-     * @param x dividend 
+     * @param x dividend
      * @param y dividor
      * @return the floor modulus of x and y
      */
@@ -27,5 +27,16 @@ public final class MathUtil {
             r--;
         }
         return x - r * y;
-    }    
+    }
+
+    /**
+     * Modulus that handles negative args properly
+     * 
+     * @param x the argument
+     * @param mod the modulus
+     * @return a mathematical correct modulus of x
+     */
+    public static int mod(int x, int mod) {
+        return ((x % mod) + mod) % mod;
+    }
 }

--- a/src/test/java/de/blau/android/easyedit/SquarableNodesTest.java
+++ b/src/test/java/de/blau/android/easyedit/SquarableNodesTest.java
@@ -1,0 +1,279 @@
+package de.blau.android.easyedit;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import androidx.test.filters.LargeTest;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import de.blau.android.App;
+import de.blau.android.Logic;
+import de.blau.android.osm.Node;
+import de.blau.android.osm.OsmElement;
+import de.blau.android.osm.OsmElementFactory;
+import de.blau.android.osm.StorageDelegator;
+import de.blau.android.osm.Way;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for EasyEditActionModeCallback
+ */
+@RunWith(RobolectricTestRunner.class)
+@LargeTest
+public class SquarableNodesTest {
+
+    private Node             node1, node2, node3, node4;
+    private Logic            testLogic;
+    private StorageDelegator delegator;
+
+    @Before
+    public void setUp() {
+        testLogic = App.newLogic();
+        delegator = App.getDelegator();
+
+        // Create test nodes with WGS84 coordinates * 1E7
+        node1 = OsmElementFactory.createNode(1, 1, System.currentTimeMillis() / 1000, OsmElement.STATE_CREATED, 525000000, 134000000);
+        delegator.insertElementSafe(node1);
+        node2 = OsmElementFactory.createNode(2, 1, System.currentTimeMillis() / 1000, OsmElement.STATE_CREATED, 525000000, 135000000);
+        delegator.insertElementSafe(node2);
+        node3 = OsmElementFactory.createNode(3, 1, System.currentTimeMillis() / 1000, OsmElement.STATE_CREATED, 526000000, 135000000);
+        delegator.insertElementSafe(node3);
+        node4 = OsmElementFactory.createNode(4, 1, System.currentTimeMillis() / 1000, OsmElement.STATE_CREATED, 526000000, 134000000);
+        delegator.insertElementSafe(node4);
+    }
+
+    /**
+     * 
+     */
+    private Way createTestWay1() {
+        // Create test ways
+        Way way1 = OsmElementFactory.createWay(1, 1, System.currentTimeMillis() / 1000, OsmElement.STATE_CREATED);
+        delegator.insertElementSafe(way1);
+        delegator.addNodeToWay(node1, way1);
+        delegator.addNodeToWay(node2, way1);
+        delegator.addNodeToWay(node3, way1);
+        return way1;
+    }
+
+    private Way createTestWay2() {
+        Way way2 = OsmElementFactory.createWay(2, 1, System.currentTimeMillis() / 1000, OsmElement.STATE_CREATED);
+        delegator.insertElementSafe(way2);
+        delegator.addNodeToWay(node2, way2);
+        delegator.addNodeToWay(node3, way2);
+        delegator.addNodeToWay(node4, way2);
+        return way2;
+    }
+
+    /**
+     * 
+     */
+    private Way createClosedWay() {
+        // Create a closed way
+        Way closedWay = OsmElementFactory.createWay(3, 1, System.currentTimeMillis() / 1000, OsmElement.STATE_CREATED);
+        delegator.insertElementSafe(closedWay);
+        delegator.addNodeToWay(node1, closedWay);
+        delegator.addNodeToWay(node2, closedWay);
+        delegator.addNodeToWay(node3, closedWay);
+        delegator.addNodeToWay(node1, closedWay); // Close the way
+        return closedWay;
+    }
+
+    @After
+    public void cleanUp() {
+        delegator.reset(true);
+    }
+
+    /**
+     * Test that a single squarable node (not an end node) is correctly identified
+     */
+    @Test
+    public void testGetSquarableNodesSingleNode() {
+        createTestWay1();
+        List<Node> candidateNodes = new ArrayList<>();
+        candidateNodes.add(node2); // node2 is in middle of way1
+
+        Set<Node> squarableNodes = new HashSet<>();
+        EasyEditActionModeCallback.getSquarableNodes(testLogic, candidateNodes, null, squarableNodes);
+
+        assertEquals("Should identify node2 as squarable", 1, squarableNodes.size());
+        assertTrue("node2 should be in squarable nodes", squarableNodes.contains(node2));
+    }
+
+    /**
+     * Test that end nodes on non-closed ways are not squarable
+     */
+    @Test
+    public void testGetSquarableNodesEndNodeNonClosed() {
+        createTestWay1();
+        List<Node> candidateNodes = new ArrayList<>();
+        candidateNodes.add(node1); // node1 is an end node of way1
+
+        Set<Node> squarableNodes = new HashSet<>();
+        EasyEditActionModeCallback.getSquarableNodes(testLogic, candidateNodes, null, squarableNodes);
+
+        assertEquals("End node on non-closed way should not be squarable", 0, squarableNodes.size());
+    }
+
+    /**
+     * Test that end nodes on closed ways ARE squarable
+     */
+    @Test
+    public void testGetSquarableNodesEndNodeClosed() {
+        createClosedWay();
+
+        List<Node> candidateNodes = new ArrayList<>();
+        candidateNodes.add(node1);
+
+        Set<Node> squarableNodes = new HashSet<>();
+        EasyEditActionModeCallback.getSquarableNodes(testLogic, candidateNodes, null, squarableNodes);
+
+        assertEquals("End node on closed way should be squarable", 1, squarableNodes.size());
+        assertTrue("node1 should be in squarable nodes", squarableNodes.contains(node1));
+    }
+
+    /**
+     * Test with empty candidate nodes list
+     */
+    @Test
+    public void testGetSquarableNodesEmptyList() {
+        List<Node> candidateNodes = new ArrayList<>();
+        Set<Node> squarableNodes = new HashSet<>();
+
+        EasyEditActionModeCallback.getSquarableNodes(testLogic, candidateNodes, null, squarableNodes);
+
+        assertEquals("Empty candidate list should result in empty squarable nodes", 0, squarableNodes.size());
+    }
+
+    /**
+     * Test with null candidate nodes list
+     */
+    @Test
+    public void testGetSquarableNodesNullList() {
+        Set<Node> squarableNodes = new HashSet<>();
+
+        EasyEditActionModeCallback.getSquarableNodes(testLogic, null, null, squarableNodes);
+
+        assertEquals("Null candidate list should result in empty squarable nodes", 0, squarableNodes.size());
+    }
+
+    /**
+     * Test with multiple candidate nodes
+     */
+    @Test
+    public void testGetSquarableNodesMultipleNodes() {
+        Way way1 = createTestWay1();
+        Way way2 = createTestWay2();
+        List<Node> candidateNodes = new ArrayList<>();
+        candidateNodes.add(node2);
+        candidateNodes.add(node3);
+
+        Set<Node> squarableNodes = new HashSet<>();
+        Set<Way> waysSet = new HashSet<>();
+
+        EasyEditActionModeCallback.getSquarableNodes(testLogic, candidateNodes, waysSet, squarableNodes);
+
+        assertEquals("Both nodes should be squarable", 2, squarableNodes.size());
+        assertTrue("node2 should be in squarable nodes", squarableNodes.contains(node2));
+        assertTrue("node3 should be in squarable nodes", squarableNodes.contains(node3));
+        assertTrue("way1 should be collected", waysSet.contains(way1));
+        assertTrue("way2 should be collected", waysSet.contains(way2));
+    }
+
+    /**
+     * Test that ways are collected in the provided set
+     */
+    @Test
+    public void testGetSquarableNodesCollectsWays() {
+        Way way1 = createTestWay1();
+        Way closedWay = createClosedWay();
+
+        List<Node> candidateNodes = new ArrayList<>();
+        candidateNodes.add(node2); // node2 is in both way1 and closedWay
+
+        Set<Way> waysSet = new HashSet<>();
+        Set<Node> squarableNodes = new HashSet<>();
+
+        EasyEditActionModeCallback.getSquarableNodes(testLogic, candidateNodes, waysSet, squarableNodes);
+
+        assertEquals("Both ways should be collected", 2, waysSet.size());
+        assertTrue("way1 should be in ways set", waysSet.contains(way1));
+        assertTrue("closedWay should be in ways set", waysSet.contains(closedWay));
+    }
+
+    /**
+     * Test that ways parameter is optional (can be null)
+     */
+    @Test
+    public void testGetSquarableNodesNullWaysSet() {
+        createTestWay1();
+        List<Node> candidateNodes = new ArrayList<>();
+        candidateNodes.add(node2);
+
+        Set<Node> squarableNodes = new HashSet<>();
+
+        // Should not throw exception when ways is null
+        EasyEditActionModeCallback.getSquarableNodes(testLogic, candidateNodes, null, squarableNodes);
+
+        assertEquals("Should identify squarable nodes even with null ways set", 1, squarableNodes.size());
+    }
+
+    /**
+     * Test node that is an orphan (not in any way)
+     */
+    @Test
+    public void testGetSquarableNodesOrphanNode() {
+        Node orphanNode = OsmElementFactory.createNode(99, 1, System.currentTimeMillis() / 1000, OsmElement.STATE_CREATED, 527000000, 136000000);
+        delegator.insertElementSafe(orphanNode);
+
+        List<Node> candidateNodes = new ArrayList<>();
+        candidateNodes.add(orphanNode);
+
+        Set<Node> squarableNodes = new HashSet<>();
+        EasyEditActionModeCallback.getSquarableNodes(testLogic, candidateNodes, null, squarableNodes);
+
+        assertEquals("Orphan node should not be squarable", 0, squarableNodes.size());
+    }
+
+    /**
+     * Test with duplicate candidates
+     */
+    @Test
+    public void testGetSquarableNodesDuplicateCandidates() {
+        createTestWay1();
+        List<Node> candidateNodes = new ArrayList<>();
+        candidateNodes.add(node2);
+        candidateNodes.add(node2); // Add same node twice
+
+        Set<Node> squarableNodes = new HashSet<>();
+        EasyEditActionModeCallback.getSquarableNodes(testLogic, candidateNodes, null, squarableNodes);
+
+        assertEquals("Duplicates in candidates may result in duplicates in squarable nodes", 1, squarableNodes.size());
+    }
+
+    /**
+     * Test node shared between multiple ways
+     */
+    @Test
+    public void testGetSquarableNodesSharedBetweenWays() {
+        createTestWay2();
+        createClosedWay();
+        List<Node> candidateNodes = new ArrayList<>();
+        candidateNodes.add(node3); // node3 is in both way2 and closedWay, but not at end of either
+
+        Set<Node> squarableNodes = new HashSet<>();
+        Set<Way> waysSet = new HashSet<>();
+
+        EasyEditActionModeCallback.getSquarableNodes(testLogic, candidateNodes, waysSet, squarableNodes);
+
+        assertEquals("Shared node should be squarable", 1, squarableNodes.size());
+        assertEquals("Both ways containing the node should be collected", 2, waysSet.size());
+    }
+}

--- a/src/test/java/de/blau/android/osm/WaySegmentTest.java
+++ b/src/test/java/de/blau/android/osm/WaySegmentTest.java
@@ -1,0 +1,190 @@
+package de.blau.android.osm;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import androidx.test.filters.LargeTest;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for the WaySegment class
+ */
+@RunWith(RobolectricTestRunner.class)
+@LargeTest
+public class WaySegmentTest {
+
+    private Way way;
+    private Node node1, node2, node3, node4, node5;
+
+    @Before
+    public void setUp() {
+        // Create test nodes with WGS84 coordinates * 1E7
+        node1 = OsmElementFactory.createNode(1, 1, System.currentTimeMillis() / 1000, OsmElement.STATE_CREATED, 525000000, 134000000);
+        node2 = OsmElementFactory.createNode(2, 1, System.currentTimeMillis() / 1000, OsmElement.STATE_CREATED, 525000000, 135000000);
+        node3 = OsmElementFactory.createNode(3, 1, System.currentTimeMillis() / 1000, OsmElement.STATE_CREATED, 526000000, 135000000);
+        node4 = OsmElementFactory.createNode(4, 1, System.currentTimeMillis() / 1000, OsmElement.STATE_CREATED, 526000000, 134000000);
+        node5 = OsmElementFactory.createNode(5, 1, System.currentTimeMillis() / 1000, OsmElement.STATE_CREATED, 525000000, 133000000);
+
+        // Create a way with 5 nodes
+        way = OsmElementFactory.createWay(1, 1, System.currentTimeMillis() / 1000, OsmElement.STATE_CREATED);
+        way.addNode(node1);
+        way.addNode(node2);
+        way.addNode(node3);
+        way.addNode(node4);
+        way.addNode(node5);
+    }
+
+    /**
+     * Test basic segment creation and getNodes for a forward segment
+     */
+    @Test
+    public void testGetNodesForwardSegment() {
+        WaySegment segment = new WaySegment(way, 1, 3);
+        List<Node> nodes = segment.getNodes();
+
+        assertEquals("Segment should contain 3 nodes (indices 1, 2, 3)", 3, nodes.size());
+        assertEquals("First node should be node2", node2, nodes.get(0));
+        assertEquals("Second node should be node3", node3, nodes.get(1));
+        assertEquals("Third node should be node4", node4, nodes.get(2));
+    }
+
+    /**
+     * Test segment with wrap-around (when end < start)
+     */
+    @Test
+    public void testGetNodesWrappedSegment() {
+        // Create a closed way for proper wrap-around testing
+        Node closingNode = node1; // closed way has first and last node the same
+        way.addNode(closingNode);
+
+        WaySegment segment = new WaySegment(way, 4, 1);
+        List<Node> nodes = segment.getNodes();
+
+        // Should include nodes 4, 5, 0 (wrap), 1
+        assertEquals("Segment should contain 4 nodes", 4, nodes.size());
+        assertEquals("Should start with node5", node5, nodes.get(0));
+        assertTrue("Should contain node1", nodes.contains(node1));
+        assertTrue("Should contain node2", nodes.contains(node2));
+    }
+
+    /**
+     * Test nodeCount for forward segment
+     */
+    @Test
+    public void testNodeCountForwardSegment() {
+        WaySegment segment = new WaySegment(way, 0, 2);
+        assertEquals("Forward segment node count", 3, segment.nodeCount());
+    }
+
+    /**
+     * Test nodeCount for single node segment
+     */
+    @Test
+    public void testNodeCountSingleNode() {
+        WaySegment segment = new WaySegment(way, 2, 2);
+        assertEquals("Single node segment should have count 1", 1, segment.nodeCount());
+    }
+
+    /**
+     * Test nodeCount for wrapped segment
+     */
+    @Test
+    public void testNodeCountWrappedSegment() {
+        way.addNode(node1); // make it closed
+        WaySegment segment = new WaySegment(way, 4, 1);
+        // nodeCount = way.nodeCount() - start + end = 6 - 4 + 1 = 3
+        assertEquals("Wrapped segment node count", 3, segment.nodeCount());
+    }
+
+    /**
+     * Test isClosed for non-closed segment
+     */
+    @Test
+    public void testIsClosedFalse() {
+        WaySegment segment = new WaySegment(way, 0, 3);
+        assertFalse("Segment should not be closed", segment.isClosed());
+    }
+
+    /**
+     * Test isClosed for closed segment
+     */
+    @Test
+    public void testIsClosedTrue() {
+        // Make way closed
+        way.addNode(node1);
+        WaySegment segment = new WaySegment(way, 0, 5); // starts and ends at node1
+        assertTrue("Segment should be closed", segment.isClosed());
+    }
+
+    /**
+     * Test length calculation
+     */
+    @Test
+    public void testLength() {
+        WaySegment segment = new WaySegment(way, 0, 2);
+        double length = segment.length();
+        assertTrue("Length should be positive", length > 0);
+    }
+
+    /**
+     * Test that getNodes returns consistent results on multiple calls
+     */
+    @Test
+    public void testGetNodesConsistency() {
+        WaySegment segment = new WaySegment(way, 1, 3);
+        List<Node> nodes1 = segment.getNodes();
+        List<Node> nodes2 = segment.getNodes();
+
+        assertEquals("Multiple calls to getNodes should return same content", nodes1, nodes2);
+    }
+
+    /**
+     * Test segment at the beginning of way
+     */
+    @Test
+    public void testSegmentAtBeginning() {
+        WaySegment segment = new WaySegment(way, 0, 1);
+        List<Node> nodes = segment.getNodes();
+
+        assertEquals("Should contain 2 nodes", 2, nodes.size());
+        assertEquals("First node should be node1", node1, nodes.get(0));
+        assertEquals("Second node should be node2", node2, nodes.get(1));
+    }
+
+    /**
+     * Test segment at the end of way
+     */
+    @Test
+    public void testSegmentAtEnd() {
+        WaySegment segment = new WaySegment(way, 3, 4);
+        List<Node> nodes = segment.getNodes();
+
+        assertEquals("Should contain 2 nodes", 2, nodes.size());
+        assertEquals("First node should be node4", node4, nodes.get(0));
+        assertEquals("Second node should be node5", node5, nodes.get(1));
+    }
+
+    /**
+     * Test WaySegment implements WayInterface
+     */
+    @Test
+    public void testImplementsWayInterface() {
+        WaySegment segment = new WaySegment(way, 0, 2);
+        assertTrue("WaySegment should implement WayInterface", segment instanceof WayInterface);
+    }
+
+    /**
+     * Test WaySegment is Serializable
+     */
+    @Test
+    public void testIsSerializable() {
+        WaySegment segment = new WaySegment(way, 0, 2);
+        assertTrue("WaySegment should implement Serializable", segment instanceof java.io.Serializable);
+    }
+}
+

--- a/src/test/java/de/blau/android/util/MathUtilTest.java
+++ b/src/test/java/de/blau/android/util/MathUtilTest.java
@@ -1,6 +1,7 @@
 package de.blau.android.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -38,5 +39,85 @@ public class MathUtilTest {
     @Test
     public void zeroDividend() {
         assertEquals(0, MathUtil.floorMod(0, 5));
+    }
+
+    /**
+     * Test mod with positive arguments
+     */
+    @Test
+    public void testModPositive() {
+        assertEquals("5 mod 3 should be 2", 2, MathUtil.mod(5, 3));
+        assertEquals("7 mod 4 should be 3", 3, MathUtil.mod(7, 4));
+        assertEquals("10 mod 10 should be 0", 0, MathUtil.mod(10, 10));
+    }
+
+    /**
+     * Test mod with negative dividend
+     */
+    @Test
+    public void testModNegativeDividend() {
+        assertEquals("-1 mod 5 should be 4", 4, MathUtil.mod(-1, 5));
+        assertEquals("-2 mod 5 should be 3", 3, MathUtil.mod(-2, 5));
+        assertEquals("-5 mod 3 should be 1", 1, MathUtil.mod(-5, 3));
+    }
+
+    /**
+     * Test mod with zero dividend
+     */
+    @Test
+    public void testModZeroDividend() {
+        assertEquals("0 mod 5 should be 0", 0, MathUtil.mod(0, 5));
+        assertEquals("0 mod 1 should be 0", 0, MathUtil.mod(0, 1));
+    }
+
+    /**
+     * Test mod with modulus of 1
+     */
+    @Test
+    public void testModModulusOne() {
+        assertEquals("5 mod 1 should be 0", 0, MathUtil.mod(5, 1));
+        assertEquals("-3 mod 1 should be 0", 0, MathUtil.mod(-3, 1));
+    }
+
+    /**
+     * Test mod wrapping around for way node indices This is the primary use case in the PR: cycling through way nodes
+     */
+    @Test
+    public void testModForWayNodeCycling() {
+        // 5 nodes in a way: indices 0-4
+        int wayNodeCount = 5;
+
+        // Forward cycling
+        assertEquals("Index 0 mod 5 should be 0", 0, MathUtil.mod(0, wayNodeCount));
+        assertEquals("Index 4 mod 5 should be 4", 4, MathUtil.mod(4, wayNodeCount));
+        assertEquals("Index 5 mod 5 should be 0 (wrap around)", 0, MathUtil.mod(5, wayNodeCount));
+
+        // Backward cycling (negative indices)
+        assertEquals("Index -1 mod 5 should be 4", 4, MathUtil.mod(-1, wayNodeCount));
+        assertEquals("Index -2 mod 5 should be 3", 3, MathUtil.mod(-2, wayNodeCount));
+        assertEquals("Index -5 mod 5 should be 0", 0, MathUtil.mod(-5, wayNodeCount));
+        assertEquals("Index -6 mod 5 should be 4", 4, MathUtil.mod(-6, wayNodeCount));
+    }
+
+    /**
+     * Test mod with larger values
+     */
+    @Test
+    public void testModLargeValues() {
+        assertEquals("100 mod 7 should be 2", 2, MathUtil.mod(100, 7));
+        assertEquals("1000 mod 13 should be 12", 12, MathUtil.mod(1000, 13));
+        assertEquals("-100 mod 7 should be 5", 5, MathUtil.mod(-100, 7));
+    }
+
+    /**
+     * Test that mod always returns non-negative results
+     */
+    @Test
+    public void testModAlwaysNonNegative() {
+        for (int i = -20; i <= 20; i++) {
+            int result = MathUtil.mod(i, 10);
+            assertTrue("Result should be non-negative for mod(" + i + ", 10)", result >= 0);
+            assertTrue("Result should be less than modulus for mod(" + i + ", 10)", result < 10);
+        }
     }
 }


### PR DESCRIPTION
In multi-select mode selecting a way (or multiple) and individual nodes on those ways and then the squaring function will just square the selected corners.

Resolves https://github.com/MarcusWolschon/osmeditor4android/issues/3202

WIP currently, needs tests and docs.