### PR TITLE
Add support for authenticated reads

### DIFF
--- a/documentation/docs/help/en/Advanced preferences.md
+++ b/documentation/docs/help/en/Advanced preferences.md
@@ -333,6 +333,9 @@ This lists all the configured OSM API instances, allows adding further ones and 
 
 Select _Edit_ from the overflow menu to configure the URLs including read-only sources and authentication method for a specific entry. Basic Authentication, OAuth 1.0a and OAuth 2 are supported, however the API instance on openstreetmap.org only supports OAuth 2 since June 2024. Additional entries can be added with the "+" button.
 
+Checking _Use authenticated reads_ will authenticate all read operations if the app on your device has been authorised. This will at least reduce the probability
+of issues with rate limiting on the standard OpenStreetMap API (code 509 errors).
+
 For API instances that support uploading compressed bodies in POST requests, _Support compressed uploads_ can be set. By default this is only enabled for the openstreetmap.org API instance. Note that OAuth support for entries that are not pre-configured requires adding corresponding client keys,  
 
 These preferences can also be accessed by selecting _Configure_ for the OpenStreetMap Data layer in the layers modal.

--- a/src/androidTest/java/de/blau/android/AuthorizationTest.java
+++ b/src/androidTest/java/de/blau/android/AuthorizationTest.java
@@ -68,7 +68,7 @@ public class AuthorizationTest {
 
         prefDB = new AdvancedPrefDatabase(context);
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", mockApiBaseUrl.toString(), null, null, new AuthParams(API.Auth.OAUTH2, "user", "pass", null, null), false);
+        prefDB.addAPI("Test", "Test", mockApiBaseUrl.toString(), null, null, new AuthParams(API.Auth.OAUTH2, "user", "pass", null, null), false, false);
         prefDB.selectAPI("Test");
         prefDB.resetCurrentServer();
         Preferences prefs = new Preferences(context);

--- a/src/androidTest/java/de/blau/android/FeedbackTest.java
+++ b/src/androidTest/java/de/blau/android/FeedbackTest.java
@@ -57,7 +57,7 @@ public class FeedbackTest {
         HttpUrl mockBaseUrl = mockServer.server().url("/api/0.6/");
         prefDB = new AdvancedPrefDatabase(context);
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
         prefDB.selectAPI("Test");
         prefDB.resetCurrentServer();
         Preferences prefs = new Preferences(context);

--- a/src/androidTest/java/de/blau/android/IntentsTest.java
+++ b/src/androidTest/java/de/blau/android/IntentsTest.java
@@ -90,7 +90,7 @@ public class IntentsTest {
         //
         prefDB = new AdvancedPrefDatabase(context);
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, mockNotesUrl.toString(), new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, mockNotesUrl.toString(), new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
         prefDB.selectAPI("Test");
         mockServerOsmose = new MockWebServerPlus();
         mockBaseUrl = mockServerOsmose.server().url("/en/api/0.2/");

--- a/src/androidTest/java/de/blau/android/IntentsTest2.java
+++ b/src/androidTest/java/de/blau/android/IntentsTest2.java
@@ -77,7 +77,7 @@ public class IntentsTest2 {
         //
         prefDB = new AdvancedPrefDatabase(context);
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, mockNotesUrl.toString(), new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, mockNotesUrl.toString(), new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
         prefDB.selectAPI("Test");
         mockServerOsmose = new MockWebServerPlus();
         mockBaseUrl = mockServerOsmose.server().url("/en/api/0.2/");

--- a/src/androidTest/java/de/blau/android/SelectionTest.java
+++ b/src/androidTest/java/de/blau/android/SelectionTest.java
@@ -48,7 +48,7 @@ public class SelectionTest {
         main = mActivityRule.getActivity();
         prefDB = new AdvancedPrefDatabase(context);
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", "", null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+        prefDB.addAPI("Test", "Test", "", null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
         prefDB.selectAPI("Test");
         prefs = new Preferences(context);
         prefs.setAutolockDelay(300000L);

--- a/src/androidTest/java/de/blau/android/easyedit/ElementHistoryTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/ElementHistoryTest.java
@@ -67,7 +67,7 @@ public class ElementHistoryTest {
         HttpUrl mockBaseUrl = mockServer.server().url("/api/0.6/");
         prefDB = new AdvancedPrefDatabase(context);
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
         prefDB.selectAPI("Test");
         Preferences prefs = new Preferences(context);
         LayerUtils.removeImageryLayers(context);

--- a/src/androidTest/java/de/blau/android/easyedit/WayActionsTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/WayActionsTest.java
@@ -487,7 +487,7 @@ public class WayActionsTest {
         AdvancedPrefDatabase prefDB = new AdvancedPrefDatabase(context);
         try {
             prefDB.deleteAPI("Test");
-            prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+            prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
             prefDB.selectAPI("Test");
             Preferences prefs = new Preferences(context);
             LayerUtils.removeImageryLayers(context);
@@ -556,7 +556,7 @@ public class WayActionsTest {
         AdvancedPrefDatabase prefDB = new AdvancedPrefDatabase(context);
         try {
             prefDB.deleteAPI("Test");
-            prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+            prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
             prefDB.selectAPI("Test");
             Preferences prefs = new Preferences(context);
             LayerUtils.removeImageryLayers(context);

--- a/src/androidTest/java/de/blau/android/easyedit/WayTest.java
+++ b/src/androidTest/java/de/blau/android/easyedit/WayTest.java
@@ -67,7 +67,7 @@ public class WayTest {
         main = mActivityRule.getActivity();
         prefDB = new AdvancedPrefDatabase(context);
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", "", null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+        prefDB.addAPI("Test", "Test", "", null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
         prefDB.selectAPI("Test");
         Preferences prefs = new Preferences(context);
         prefs.setAutolockDelay(300000L);

--- a/src/androidTest/java/de/blau/android/gpx/GpxUploadTest.java
+++ b/src/androidTest/java/de/blau/android/gpx/GpxUploadTest.java
@@ -73,7 +73,7 @@ public class GpxUploadTest {
         HttpUrl mockBaseUrl = mockServer.server().url("/api/0.6/");
         prefDB = new AdvancedPrefDatabase(main);
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
         prefDB.selectAPI("Test");
         tileServer = MockTileServer.setupTileServer(main, "ersatz_background.mbt", true);
         prefs = new Preferences(main);

--- a/src/androidTest/java/de/blau/android/measure/streetmeasure/MeasureTest.java
+++ b/src/androidTest/java/de/blau/android/measure/streetmeasure/MeasureTest.java
@@ -84,7 +84,7 @@ public class MeasureTest {
         System.out.println("mock api url " + mockBaseUrl.toString());
         prefDB = new AdvancedPrefDatabase(context);
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
         prefDB.selectAPI("Test");
         prefDB.resetCurrentServer();
         prefs = new Preferences(context);

--- a/src/androidTest/java/de/blau/android/osm/TransferMenuTest.java
+++ b/src/androidTest/java/de/blau/android/osm/TransferMenuTest.java
@@ -102,7 +102,7 @@ public class TransferMenuTest {
         HttpUrl mockBaseUrl = mockServer.server().url("/api/0.6/");
         prefDB = new AdvancedPrefDatabase(context);
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
         prefDB.selectAPI("Test");
         prefDB.deleteLayer(LayerType.TASKS, null);
         prefs = new Preferences(context);

--- a/src/androidTest/java/de/blau/android/osm/UploadConflictTest.java
+++ b/src/androidTest/java/de/blau/android/osm/UploadConflictTest.java
@@ -84,7 +84,7 @@ public class UploadConflictTest {
         HttpUrl mockBaseUrl = mockServer.server().url("/api/0.6/");
         prefDB = new AdvancedPrefDatabase(context);
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
         prefDB.selectAPI("Test");
         Preferences prefs = new Preferences(context);
         LayerUtils.removeImageryLayers(context);

--- a/src/androidTest/java/de/blau/android/prefs/keyboard/KeyboardTest.java
+++ b/src/androidTest/java/de/blau/android/prefs/keyboard/KeyboardTest.java
@@ -75,7 +75,7 @@ public class KeyboardTest {
         main = mActivityRule.getActivity();
         prefDB = new AdvancedPrefDatabase(context);
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", "", null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+        prefDB.addAPI("Test", "Test", "", null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
         prefDB.selectAPI("Test");
         prefs = new Preferences(context);
         LayerUtils.removeImageryLayers(context);

--- a/src/androidTest/java/de/blau/android/presets/AutoPresetTest.java
+++ b/src/androidTest/java/de/blau/android/presets/AutoPresetTest.java
@@ -97,7 +97,7 @@ public class AutoPresetTest {
         System.out.println("mock api url " + mockBaseUrl.toString());
         prefDB = new AdvancedPrefDatabase(context);
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
         prefDB.selectAPI("Test");
         prefDB.resetCurrentServer();
         prefs = new Preferences(context);

--- a/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
+++ b/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
@@ -114,7 +114,7 @@ public class PropertyEditorTest {
         System.out.println("mock api url " + mockBaseUrl.toString());
         prefDB = new AdvancedPrefDatabase(context);
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
         prefDB.selectAPI("Test");
         prefDB.resetCurrentServer();
         prefs = new Preferences(context);

--- a/src/androidTest/java/de/blau/android/resources/OAMTest.java
+++ b/src/androidTest/java/de/blau/android/resources/OAMTest.java
@@ -61,7 +61,7 @@ public class OAMTest {
         mockServerString = mockBaseUrl.scheme() + "://" + mockBaseUrl.host() + ":" + mockBaseUrl.port() + "/";
         prefDB = new AdvancedPrefDatabase(context);
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
         prefDB.selectAPI("Test");
         prefDB.resetCurrentServer();
         prefs = new Preferences(context);

--- a/src/androidTest/java/de/blau/android/tasks/MapRouletteTest.java
+++ b/src/androidTest/java/de/blau/android/tasks/MapRouletteTest.java
@@ -93,7 +93,7 @@ public class MapRouletteTest {
         System.out.println("mock api url " + mockBaseUrl.toString());
         prefDB = new AdvancedPrefDatabase(context);
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
         prefDB.selectAPI("Test");
         prefDB.resetCurrentServer();
         prefs = new Preferences(context);

--- a/src/androidTest/java/de/blau/android/tasks/NotesTest.java
+++ b/src/androidTest/java/de/blau/android/tasks/NotesTest.java
@@ -81,7 +81,7 @@ public class NotesTest {
         HttpUrl mockBaseUrl = mockServer.server().url("/api/0.6/");
         prefDB = new AdvancedPrefDatabase(context);
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
         prefDB.selectAPI("Test");
         prefs = new Preferences(context);
         LayerUtils.removeImageryLayers(context);

--- a/src/androidTest/java/de/blau/android/tasks/OsmoseTest.java
+++ b/src/androidTest/java/de/blau/android/tasks/OsmoseTest.java
@@ -80,7 +80,7 @@ public class OsmoseTest {
         prefs.putString(R.string.config_osmoseServer_key, mockBaseUrl.scheme() + "://" + mockBaseUrl.host() + ":" + mockBaseUrl.port() + "/");
         prefDB = new AdvancedPrefDatabase(context);
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
         prefDB.selectAPI("Test");
         prefDB.resetCurrentServer();
         prefs = new Preferences(context);

--- a/src/androidTest/java/de/blau/android/tasks/ReadSaveTasksTest.java
+++ b/src/androidTest/java/de/blau/android/tasks/ReadSaveTasksTest.java
@@ -162,7 +162,7 @@ public class ReadSaveTasksTest {
         HttpUrl mockBaseUrl = mockServer.server().url("/api/0.6/");
         System.out.println("mock api url " + mockBaseUrl.toString());
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
         prefDB.selectAPI("Test");
         final CountDownLatch signal = new CountDownLatch(1);
         mockServer.enqueue("notesDownload1");

--- a/src/androidTest/java/de/blau/android/tasks/TodoTest.java
+++ b/src/androidTest/java/de/blau/android/tasks/TodoTest.java
@@ -217,7 +217,7 @@ public class TodoTest {
             mockServer = new MockWebServerPlus();
             HttpUrl mockBaseUrl = mockServer.server().url("/api/0.6/");
             prefDB.deleteAPI("Test");
-            prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+            prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
             prefDB.selectAPI("Test");
             Preferences prefs = new Preferences(context);
             main.getMap().setPrefs(main, prefs);
@@ -258,7 +258,7 @@ public class TodoTest {
             mockServer = new MockWebServerPlus();
             HttpUrl mockBaseUrl = mockServer.server().url("/api/0.6/");
             prefDB.deleteAPI("Test");
-            prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+            prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
             prefDB.selectAPI("Test");
             Preferences prefs = new Preferences(context);
             main.getMap().setPrefs(main, prefs);

--- a/src/main/assets/help/en/Advanced preferences.html
+++ b/src/main/assets/help/en/Advanced preferences.html
@@ -172,6 +172,7 @@
 <h3 id="osm-api-url">OSM API URL</h3>
 <p>This lists all the configured OSM API instances, allows adding further ones and editing the configuration of existing entries. The default configuration contains an entry for the regular openstreetmap.org API, the sandbox API for development and experimentation and (since 21.1.2) one for OpenHistoricalMap.</p>
 <p>Select <em>Edit</em> from the overflow menu to configure the URLs including read-only sources and authentication method for a specific entry. Basic Authentication, OAuth 1.0a and OAuth 2 are supported, however the API instance on openstreetmap.org only supports OAuth 2 since June 2024. Additional entries can be added with the &quot;+&quot; button.</p>
+<p>Checking <em>Use authenticated reads</em> will authenticate all read operations if the app on your device has been authorised. This will at least reduce the probability of issues with rate limiting on the standard OpenStreetMap API (code 509 errors).</p>
 <p>For API instances that support uploading compressed bodies in POST requests, <em>Support compressed uploads</em> can be set. By default this is only enabled for the openstreetmap.org API instance. Note that OAuth support for entries that are not pre-configured requires adding corresponding client keys,</p>
 <p>These preferences can also be accessed by selecting <em>Configure</em> for the OpenStreetMap Data layer in the layers modal.</p>
 <h3 id="user-account">User account</h3>

--- a/src/main/java/de/blau/android/osm/Server.java
+++ b/src/main/java/de/blau/android/osm/Server.java
@@ -1,5 +1,7 @@
 package de.blau.android.osm;
 
+import static de.blau.android.contract.Constants.LOG_TAG_LEN;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -78,8 +80,8 @@ import se.akerfeldt.okhttp.signpost.SigningInterceptor;
  * @author Simon
  */
 public class Server {
-
-    private static final String DEBUG_TAG = Server.class.getSimpleName().substring(0, Math.min(23, Server.class.getSimpleName().length()));
+    private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, Server.class.getSimpleName().length());
+    private static final String DEBUG_TAG = Server.class.getSimpleName().substring(0, TAG_LEN);
 
     /**
      * <a href="http://wiki.openstreetmap.org/wiki/API">API</a>-Version.
@@ -177,6 +179,11 @@ public class Server {
     private final boolean compressedUploads;
 
     /**
+     * Use authenticated reads
+     */
+    private final boolean authenticatedReads;
+
+    /**
      * display name of the user and other stuff
      */
     private UserDetails cachedUserDetails;
@@ -216,6 +223,33 @@ public class Server {
      */
     private static final String SERVER_NOTES_PATH = "notes/";
 
+    private interface AddInterceptor {
+        void add(@NonNull OkHttpClient.Builder builder);
+    }
+
+    /**
+     * Add an appropriate Interceptor for authentication
+     * 
+     * @param builder an OkHttpClient.Builder instance
+     */
+    private class AddAuthentication implements AddInterceptor {
+        public void add(@NonNull OkHttpClient.Builder builder) {
+            Log.d(DEBUG_TAG, "Adding interceptor for " + authentication);
+            switch (authentication) {
+            case OAUTH1A:
+                builder.addInterceptor(new SigningInterceptor(oAuthConsumer));
+                break;
+            case OAUTH2:
+                builder.addInterceptor(new OAuth2Interceptor(accesstoken));
+                break;
+            case BASIC:
+                builder.addInterceptor(new BasicAuthInterceptor(username, password));
+            }
+        }
+    }
+
+    private final AddAuthentication addAuthentication;
+
     /**
      * Constructor. Sets {@link #rootOpen} and {@link #createdByTag}.
      * 
@@ -241,6 +275,7 @@ public class Server {
         this.accesstokensecret = api.accesstokensecret;
         this.timeout = api.timeout;
         this.compressedUploads = api.compressedUploads;
+        this.authenticatedReads = api.authenticatedReads;
 
         if (authentication == Auth.OAUTH1A) {
             oAuthConsumer = new OAuth1aHelper().getOkHttpConsumer(context, name);
@@ -250,6 +285,8 @@ public class Server {
         } else {
             oAuthConsumer = null;
         }
+
+        addAuthentication = new AddAuthentication();
 
         Log.d(DEBUG_TAG, "API entry " + name + " with " + this.serverURL);
 
@@ -465,7 +502,7 @@ public class Server {
      */
     private Capabilities getCapabilities(@NonNull URL capabilitiesURL) {
         //
-        try (InputStream is = openConnection(null, capabilitiesURL, timeout, timeout)) {
+        try (InputStream is = openConnection(null, capabilitiesURL, useAuthenticatedReads(), timeout, timeout)) {
             Log.d(DEBUG_TAG, "getCapabilities using " + capabilitiesURL.toString());
             return Capabilities.parse(xmlParserFactory.newPullParser(), is);
         } catch (XmlPullParserException e) {
@@ -524,7 +561,17 @@ public class Server {
     public InputStream getStreamForBox(@Nullable final Context context, @NonNull final BoundingBox box) throws IOException {
         Log.d(DEBUG_TAG, "getStreamForBox");
         URL url = new URL(getReadOnlyUrl() + "map?bbox=" + box.toApiString());
-        return openConnection(context, url, timeout, timeout);
+        return openConnection(context, url, useAuthenticatedReads(), timeout, timeout);
+    }
+
+    /**
+     * Check if we need to and can use authenticated reads and return an AddInterceptor class if so
+     * 
+     * @return an AddInterceptor that will add an appropriate Interceptor
+     */
+    @Nullable
+    private AddInterceptor useAuthenticatedReads() {
+        return authenticatedReads && (isLoginSet() || !needOAuthHandshake()) ? addAuthentication : null;
     }
 
     /**
@@ -542,7 +589,7 @@ public class Server {
             throws IOException {
         Log.d(DEBUG_TAG, "getStreamForElement");
         URL url = new URL((hasMapSplitSource() ? getReadWriteUrl() : getReadOnlyUrl()) + type + "/" + id + (mode != null ? "/" + mode : ""));
-        return openConnection(context, url, timeout, timeout);
+        return openConnection(context, url, useAuthenticatedReads(), timeout, timeout);
     }
 
     /**
@@ -572,7 +619,7 @@ public class Server {
             }
         }
         URL url = new URL(urlString.toString());
-        return openConnection(context, url, timeout, timeout);
+        return openConnection(context, url, useAuthenticatedReads(), timeout, timeout);
     }
 
     /**
@@ -587,7 +634,7 @@ public class Server {
      */
     @NonNull
     public static InputStream openConnection(@Nullable final Context context, @NonNull URL url) throws IOException {
-        return openConnection(context, url, Server.DEFAULT_TIMEOUT, Server.DEFAULT_TIMEOUT);
+        return openConnection(context, url, null, Server.DEFAULT_TIMEOUT, Server.DEFAULT_TIMEOUT);
     }
 
     /**
@@ -595,6 +642,7 @@ public class Server {
      * 
      * @param context Android context
      * @param url the URL
+     * @param addInterceptor adds an interceptor if necessary
      * @param connectTimeout connection timeout in ms
      * @param readTimeout read timeout in ms
      * @return the InputStream
@@ -602,12 +650,16 @@ public class Server {
      * 
      */
     @NonNull
-    public static InputStream openConnection(@Nullable final Context context, @NonNull URL url, int connectTimeout, int readTimeout) throws IOException {
+    public static InputStream openConnection(@Nullable final Context context, @NonNull URL url, @Nullable AddInterceptor addInterceptor, int connectTimeout,
+            int readTimeout) throws IOException {
         Log.d(DEBUG_TAG, "get input stream for  " + url.toString());
         try {
             Request request = new Request.Builder().url(url).build();
             OkHttpClient.Builder builder = App.getHttpClient().newBuilder().connectTimeout(connectTimeout, TimeUnit.MILLISECONDS).readTimeout(readTimeout,
                     TimeUnit.MILLISECONDS);
+            if (addInterceptor != null) {
+                addInterceptor.add(builder);
+            }
             OkHttpClient client = builder.build();
             Call readCall = client.newCall(request);
             Response readCallResponse = readCall.execute();
@@ -710,16 +762,7 @@ public class Server {
 
         OkHttpClient.Builder builder = App.getHttpClient().newBuilder().connectTimeout(timeout, TimeUnit.MILLISECONDS).readTimeout(timeout,
                 TimeUnit.MILLISECONDS);
-        switch (authentication) {
-        case OAUTH1A:
-            builder.addInterceptor(new SigningInterceptor(oAuthConsumer));
-            break;
-        case OAUTH2:
-            builder.addInterceptor(new OAuth2Interceptor(accesstoken));
-            break;
-        case BASIC:
-            builder.addInterceptor(new BasicAuthInterceptor(username, password));
-        }
+        addAuthentication.add(builder);
         // if compressed uploads are supported and compression interceptor
         if ((HTTP_POST.equals(requestMethod) || HTTP_PUT.equals(requestMethod)) && compressedUploads) {
             builder.addInterceptor(new GzipRequestInterceptor());
@@ -1437,7 +1480,7 @@ public class Server {
     public Note getNote(long id) throws NumberFormatException, XmlPullParserException, IOException {
         // http://openstreetbugs.schokokeks.org/api/0.1/getGPX?b=48&t=49&l=11&r=12&limit=100
         Log.d(DEBUG_TAG, "getNote");
-        try (InputStream is = openConnection(null, getNoteUrl(Long.toString(id)), timeout, timeout)) {
+        try (InputStream is = openConnection(null, getNoteUrl(Long.toString(id)), useAuthenticatedReads(), timeout, timeout)) {
             XmlPullParser parser = xmlParserFactory.newPullParser();
             parser.setInput(new BufferedInputStream(is, StreamUtils.IO_BUFFER_SIZE), null);
             List<Note> result = Note.parseNotes(parser, null);
@@ -1457,7 +1500,7 @@ public class Server {
     public Collection<Note> getNotesForBox(@NonNull BoundingBox area, long limit) {
         // http://openstreetbugs.schokokeks.org/api/0.1/getGPX?b=48&t=49&l=11&r=12&limit=100
         Log.d(DEBUG_TAG, "getNotesForBox");
-        try (InputStream is = openConnection(null, getNotesForBox(limit, area), timeout, timeout)) {
+        try (InputStream is = openConnection(null, getNotesForBox(limit, area), useAuthenticatedReads(), timeout, timeout)) {
             XmlPullParser parser = xmlParserFactory.newPullParser();
             parser.setInput(new BufferedInputStream(is, StreamUtils.IO_BUFFER_SIZE), null);
             return Note.parseNotes(parser, null);

--- a/src/main/java/de/blau/android/prefs/API.java
+++ b/src/main/java/de/blau/android/prefs/API.java
@@ -52,6 +52,7 @@ public class API {
     public final String  accesstokensecret;
     public final int     timeout;
     public final boolean compressedUploads;
+    public final boolean authenticatedReads;
 
     /**
      * Construct an new API instance
@@ -64,9 +65,10 @@ public class API {
      * @param authParams authentication params
      * @param timeout timeout in seconds
      * @param compressedUploads if true compress uploads
+     * @param authenticatedReads authenticate reads
      */
     public API(@NonNull String id, @NonNull String name, @NonNull String url, @Nullable String readonlyurl, @Nullable String notesurl,
-            @NonNull AuthParams authParams, int timeout, boolean compressedUploads) {
+            @NonNull AuthParams authParams, int timeout, boolean compressedUploads, boolean authenticatedReads) {
         this.id = id;
         this.name = name;
         this.url = url;
@@ -79,5 +81,6 @@ public class API {
         this.accesstokensecret = authParams.accesstokensecret;
         this.timeout = timeout;
         this.compressedUploads = compressedUploads;
+        this.authenticatedReads = authenticatedReads;
     }
 }

--- a/src/main/java/de/blau/android/prefs/APIEditorActivity.java
+++ b/src/main/java/de/blau/android/prefs/APIEditorActivity.java
@@ -109,7 +109,8 @@ public class APIEditorActivity extends URLListEditActivity {
         API[] apis = db.getAPIs();
         API current = db.getCurrentAPI();
         for (API api : apis) {
-            items.add(new ListEditItem(api.id, api.name, api.url, api.readonlyurl, api.notesurl, api.auth, api.compressedUploads, current.id.equals(api.id)));
+            items.add(new ListEditItem(api.id, api.name, api.url, api.readonlyurl, api.notesurl, api.auth, api.compressedUploads, api.authenticatedReads,
+                    current.id.equals(api.id)));
         }
     }
 
@@ -130,13 +131,15 @@ public class APIEditorActivity extends URLListEditActivity {
 
     @Override
     protected void onItemCreated(ListEditItem item) {
-        db.addAPI(item.id, item.name, item.value, item.value2, item.value3, new AuthParams((Auth) item.object0, "", "", null, null), item.boolean0);
+        db.addAPI(item.id, item.name, item.value, item.value2, item.value3, new AuthParams((Auth) item.object0, "", "", null, null), item.boolean0,
+                item.boolean1);
     }
 
     @Override
     protected void onItemEdited(ListEditItem item) {
         db.setAPIDescriptors(item.id, item.name, item.value, item.value2, item.value3, (Auth) item.object0);
         db.setAPICompressedUploads(item.id, item.boolean0);
+        db.setAPIAuthenticatedReads(item.id, item.boolean1);
     }
 
     @Override
@@ -164,8 +167,9 @@ public class APIEditorActivity extends URLListEditActivity {
     public void onAdditionalMenuItemClick(int menuItemId, ListEditItem clickedItem) {
         if (menuItemId == MENU_COPY) {
             ListEditItem item = new ListEditItem(getString(R.string.copy_of, clickedItem.name), clickedItem.value, clickedItem.value2, clickedItem.value3,
-                    clickedItem.boolean0, Auth.BASIC);
-            db.addAPI(item.id, item.name, item.value, item.value2, item.value3, new AuthParams((Auth) item.object0, "", "", null, null), item.boolean0);
+                    clickedItem.boolean0, clickedItem.boolean1, Auth.BASIC);
+            db.addAPI(item.id, item.name, item.value, item.value2, item.value3, new AuthParams((Auth) item.object0, "", "", null, null), item.boolean0,
+                    clickedItem.boolean1);
             items.clear();
             onLoadList(items);
             updateAdapter();
@@ -210,7 +214,8 @@ public class APIEditorActivity extends URLListEditActivity {
             AuthenticationAdapter adapter = new AuthenticationAdapter(getContext(), android.R.layout.simple_spinner_item, Auth.values(),
                     getResources().getStringArray(R.array.authentication_entries));
             auth.setAdapter(adapter);
-            final CheckBox checkbox = (CheckBox) mainView.findViewById(R.id.listedit_compressed_uploads);
+            final CheckBox authenticatedReadsCheck = (CheckBox) mainView.findViewById(R.id.listedit_authenticated_reads);
+            final CheckBox compressedUploadsCheck = (CheckBox) mainView.findViewById(R.id.listedit_compressed_uploads);
 
             final ImageButton fileButton = (ImageButton) mainView.findViewById(R.id.listedit_file_button);
 
@@ -221,14 +226,16 @@ public class APIEditorActivity extends URLListEditActivity {
                 editValue2.setText(item.value2);
                 editValue3.setText(item.value3);
                 auth.setSelection(((Auth) item.object0).ordinal());
-                checkbox.setChecked(item.boolean0);
+                compressedUploadsCheck.setChecked(item.boolean0);
+                authenticatedReadsCheck.setChecked(item.boolean1);
             } else if (activity.isAddingViaIntent()) {
                 String tmpName = activity.getIntent().getExtras().getString(EXTRA_NAME);
                 String tmpValue = activity.getIntent().getExtras().getString(EXTRA_VALUE);
                 editName.setText(tmpName == null ? "" : tmpName);
                 editValue.setText(tmpValue == null ? "" : tmpValue);
                 auth.setSelection(Auth.BASIC.ordinal());
-                checkbox.setChecked(false);
+                compressedUploadsCheck.setChecked(false);
+                authenticatedReadsCheck.setChecked(false);
             }
             if (item != null && item.id.equals(LISTITEM_ID_DEFAULT)) {
                 // name and value are not editable
@@ -238,7 +245,8 @@ public class APIEditorActivity extends URLListEditActivity {
                 editValue.setInputType(InputType.TYPE_NULL);
                 editValue2.setEnabled(true);
                 editValue3.setEnabled(false);
-                checkbox.setEnabled(true);
+                compressedUploadsCheck.setChecked(item.boolean0);
+                authenticatedReadsCheck.setChecked(item.boolean1);
             }
 
             activity.setViewAndButtons(builder, mainView);
@@ -318,7 +326,8 @@ public class APIEditorActivity extends URLListEditActivity {
                     String readOnlyAPIURL = editValue2.getText().toString().trim();
                     String notesAPIURL = editValue3.getText().toString().trim();
                     Auth authentication = Auth.values()[auth.getSelectedItemPosition()];
-                    boolean compressedUploads = checkbox.isChecked();
+                    boolean compressedUploads = compressedUploadsCheck.isChecked();
+                    boolean authenticatedReads = authenticatedReadsCheck.isChecked();
 
                     // (re-)set to black
                     changeBackgroundColor(editValue, VALID_COLOR);
@@ -344,7 +353,8 @@ public class APIEditorActivity extends URLListEditActivity {
                         if (!"".equals(apiURL)) {
                             if (item == null) {
                                 // new item
-                                activity.finishCreateItem(new ListEditItem(name, apiURL, readOnlyAPIURL, notesAPIURL, compressedUploads, authentication));
+                                activity.finishCreateItem(
+                                        new ListEditItem(name, apiURL, readOnlyAPIURL, notesAPIURL, compressedUploads, authenticatedReads, authentication));
                             } else {
                                 item.name = name;
                                 item.value = apiURL;
@@ -352,6 +362,7 @@ public class APIEditorActivity extends URLListEditActivity {
                                 item.value3 = notesAPIURL;
                                 item.object0 = authentication;
                                 item.boolean0 = compressedUploads;
+                                item.boolean1 = authenticatedReads;
                                 activity.finishEditItem(item);
                             }
                         }

--- a/src/main/java/de/blau/android/prefs/AdvancedPrefDatabase.java
+++ b/src/main/java/de/blau/android/prefs/AdvancedPrefDatabase.java
@@ -56,7 +56,7 @@ public class AdvancedPrefDatabase extends SQLiteOpenHelper implements AutoClosea
     private final SharedPreferences sharedPrefs;
     private final String            selectedApi;
 
-    private static final int DATA_VERSION = 23;
+    private static final int DATA_VERSION = 24;
 
     static final String DATABASE_NAME = "AdvancedPrefs";
 
@@ -85,16 +85,17 @@ public class AdvancedPrefDatabase extends SQLiteOpenHelper implements AutoClosea
     private static final String SHORTDESCRIPTION_COL = "shortdescription";
     private static final String DESCRIPTION_COL      = "description";
 
-    static final String         APIS_TABLE            = "apis";
-    static final String         ACCESSTOKENSECRET_COL = "accesstokensecret";
-    static final String         ACCESSTOKEN_COL       = "accesstoken";
-    private static final String AUTH_COL              = "oauth";
-    private static final String NOTESURL_COL          = "notesurl";
-    private static final String READONLYURL_COL       = "readonlyurl";
-    private static final String PASS_COL              = "pass";
-    private static final String USER_COL              = "user";
-    private static final String TIMEOUT_COL           = "timeout";
-    private static final String COMPRESSEDUPLOADS_COL = "compresseduploads";
+    static final String         APIS_TABLE             = "apis";
+    static final String         ACCESSTOKENSECRET_COL  = "accesstokensecret";
+    static final String         ACCESSTOKEN_COL        = "accesstoken";
+    private static final String AUTH_COL               = "oauth";
+    private static final String NOTESURL_COL           = "notesurl";
+    private static final String READONLYURL_COL        = "readonlyurl";
+    private static final String PASS_COL               = "pass";
+    private static final String USER_COL               = "user";
+    private static final String TIMEOUT_COL            = "timeout";
+    private static final String COMPRESSEDUPLOADS_COL  = "compresseduploads";
+    private static final String AUTHENTICATEDREADS_COL = "authenticatedreads";
 
     static final String         LAYERS_TABLE   = "layers";
     private static final String VISIBLE_COL    = "visible";
@@ -215,7 +216,7 @@ public class AdvancedPrefDatabase extends SQLiteOpenHelper implements AutoClosea
     private void createApisTable(@NonNull SQLiteDatabase db, @NonNull String table) {
         db.execSQL(CREATE_TABLE + table
                 + " (id TEXT PRIMARY KEY, name TEXT, url TEXT, readonlyurl TEXT, notesurl TEXT, user TEXT, pass TEXT, preset TEXT, showicon INTEGER DEFAULT 1, oauth INTEGER DEFAULT 0, accesstoken TEXT, accesstokensecret TEXT, timeout INTEGER DEFAULT "
-                + Server.DEFAULT_TIMEOUT + ", compresseduploads INTEGER DEFAULT 0)");
+                + Server.DEFAULT_TIMEOUT + ", compresseduploads INTEGER DEFAULT 0, authenticatedreads INTEGER DEFAULT 0)");
     }
 
     /**
@@ -356,6 +357,9 @@ public class AdvancedPrefDatabase extends SQLiteOpenHelper implements AutoClosea
         if (oldVersion <= 22) {
             createStylesTable(db, STYLES_TABLE);
             addDefaultStyleEntries(db);
+        }
+        if (oldVersion <= 23) {
+            db.execSQL("ALTER TABLE apis ADD COLUMN authenticatedreads INTEGER DEFAULT 0");
         }
     }
 
@@ -575,8 +579,43 @@ public class AdvancedPrefDatabase extends SQLiteOpenHelper implements AutoClosea
      * @param compressedUploads if true API supports compressed uploads
      */
     public synchronized void setAPICompressedUploads(@NonNull SQLiteDatabase db, @NonNull String id, boolean compressedUploads) {
+        setAPIBoolean(db, id, COMPRESSEDUPLOADS_COL, compressedUploads);
+    }
+
+    /**
+     * Sets name and URLs for a OSM API entry id
+     * 
+     * @param id the internal id for this entry
+     * @param compressedUploads if true API supports compressed uploads
+     */
+    public synchronized void setAPIAuthenticatedReads(@NonNull String id, boolean authenticatedReads) {
+        SQLiteDatabase db = getWritableDatabase();
+        setAPIAuthenticatedReads(db, id, authenticatedReads);
+        db.close();
+    }
+
+    /**
+     * Sets name and URLs for a OSM API entry id
+     * 
+     * @param db a writable SQLiteDatabase
+     * @param id the internal id for this entry
+     * @param compressedUploads if true API supports compressed uploads
+     */
+    public synchronized void setAPIAuthenticatedReads(@NonNull SQLiteDatabase db, @NonNull String id, boolean authenticatedReads) {
+        setAPIBoolean(db, id, AUTHENTICATEDREADS_COL, authenticatedReads);
+    }
+
+    /**
+     * Set a boolean value in the API table
+     * 
+     * @param db a writable SQLiteDatabase
+     * @param id the internal id for this entry
+     * @param col the column to set
+     * @param bool the boolean value
+     */
+    private void setAPIBoolean(SQLiteDatabase db, String id, String col, boolean bool) {
         ContentValues values = new ContentValues();
-        values.put(COMPRESSEDUPLOADS_COL, compressedUploads ? 1 : 0);
+        values.put(col, bool ? 1 : 0);
         db.update(APIS_TABLE, values, WHERE_ID, new String[] { id });
         resetCurrentServer();
     }
@@ -642,12 +681,14 @@ public class AdvancedPrefDatabase extends SQLiteOpenHelper implements AutoClosea
      * @param notesurl a note url or null
      * @param authParams authentication parameters
      * @param compressedUploads true if compressed uploads are supported
+     * @param authenticatedReads true if we should authenticate reads
      */
     public synchronized void addAPI(@NonNull String id, @NonNull String name, @NonNull String url, @Nullable String readonlyurl, @Nullable String notesurl,
-            @NonNull AuthParams authParams, boolean compressedUploads) {
+            @NonNull AuthParams authParams, boolean compressedUploads, boolean authenticatedReads) {
         SQLiteDatabase db = getWritableDatabase();
         addAPI(db, id, name, url, readonlyurl, notesurl, authParams);
         setAPICompressedUploads(db, id, compressedUploads);
+        setAPIAuthenticatedReads(db, id, authenticatedReads);
         db.close();
     }
 
@@ -718,7 +759,7 @@ public class AdvancedPrefDatabase extends SQLiteOpenHelper implements AutoClosea
     private synchronized API[] getAPIs(@NonNull SQLiteDatabase db, @Nullable String id) {
         Cursor dbresult = db.query(APIS_TABLE,
                 new String[] { ID_COL, NAME_COL, URL_COL, READONLYURL_COL, NOTESURL_COL, USER_COL, PASS_COL, "preset", "showicon", AUTH_COL, ACCESSTOKEN_COL,
-                        ACCESSTOKENSECRET_COL, TIMEOUT_COL, COMPRESSEDUPLOADS_COL },
+                        ACCESSTOKENSECRET_COL, TIMEOUT_COL, COMPRESSEDUPLOADS_COL, AUTHENTICATEDREADS_COL },
                 id == null ? null : WHERE_ID, id == null ? null : new String[] { id }, null, null, null, null);
         API[] result = new API[dbresult.getCount()];
         dbresult.moveToFirst();
@@ -731,7 +772,7 @@ public class AdvancedPrefDatabase extends SQLiteOpenHelper implements AutoClosea
             }
             AuthParams authParams = new AuthParams(auth, dbresult.getString(5), dbresult.getString(6), dbresult.getString(10), dbresult.getString(11));
             result[i] = new API(dbresult.getString(0), dbresult.getString(1), dbresult.getString(2), dbresult.getString(3), dbresult.getString(4), authParams,
-                    dbresult.getInt(12), dbresult.getInt(13) == 1);
+                    dbresult.getInt(12), dbresult.getInt(13) == 1, dbresult.getInt(14) == 1);
             dbresult.moveToNext();
         }
         dbresult.close();
@@ -889,7 +930,7 @@ public class AdvancedPrefDatabase extends SQLiteOpenHelper implements AutoClosea
             db = getReadableDatabase(); // setPresetState closed the db
             dbresult = queryActivePresets(db);
             count = dbresult.getCount();
-        }     
+        }
         PresetConfiguration[] result = new PresetConfiguration[count];
         dbresult.moveToFirst();
         for (int i = 0; i < result.length; i++) {
@@ -904,7 +945,7 @@ public class AdvancedPrefDatabase extends SQLiteOpenHelper implements AutoClosea
     }
 
     /**
-     * Query all active presets 
+     * Query all active presets
      * 
      * @param db the Database
      * @return a Cursor
@@ -1669,7 +1710,8 @@ public class AdvancedPrefDatabase extends SQLiteOpenHelper implements AutoClosea
      * @param url image store API url
      * @param active use this image store if true
      */
-    private synchronized void addImageStore(@NonNull SQLiteDatabase db, @NonNull String id, @NonNull String name, @NonNull ImageStorageType type, @NonNull String url, boolean active) {
+    private synchronized void addImageStore(@NonNull SQLiteDatabase db, @NonNull String id, @NonNull String name, @NonNull ImageStorageType type,
+            @NonNull String url, boolean active) {
         Log.d(DEBUG_TAG, "Adding image store entry " + id + " " + name + " " + type + " " + url + " " + active);
         ContentValues values = new ContentValues();
         values.put(ID_COL, id);

--- a/src/main/java/de/blau/android/prefs/ImageStorageEditorActivity.java
+++ b/src/main/java/de/blau/android/prefs/ImageStorageEditorActivity.java
@@ -133,7 +133,7 @@ public class ImageStorageEditorActivity extends URLListEditActivity {
                 ThemeUtils.getAlertDialogBuilder(ImageStorageEditorActivity.this).setItems(names, (DialogInterface d, int which) -> {
                     ImageStorageConfiguration imagestore = instances.get(which);
                     // hack we test for null id in itemEditDialog
-                    ListEditItem item = new ListEditItem(null, imagestore.name, imagestore.type.toString(), imagestore.url, null, null, false, false); // NOSONAR
+                    ListEditItem item = new ListEditItem(null, imagestore.name, imagestore.type.toString(), imagestore.url, null, null, false, false, false); // NOSONAR
                     itemEditDialog(item);
                 }).show();
             }

--- a/src/main/java/de/blau/android/prefs/PresetConfigurationEditorActivity.java
+++ b/src/main/java/de/blau/android/prefs/PresetConfigurationEditorActivity.java
@@ -266,7 +266,7 @@ public class PresetConfigurationEditorActivity extends AbstractConfigurationEdit
             boolean useTranslationsEnabled = useTranslations.isChecked();
             if (item == null) {
                 // new item
-                activity.finishCreateItem(new ListEditItem(name, url, null, null, useTranslationsEnabled, null));
+                activity.finishCreateItem(new ListEditItem(name, url, null, null, useTranslationsEnabled, false, null));
             } else {
                 item.name = name;
                 item.value = url;

--- a/src/main/java/de/blau/android/prefs/StyleConfigurationEditorActivity.java
+++ b/src/main/java/de/blau/android/prefs/StyleConfigurationEditorActivity.java
@@ -251,7 +251,7 @@ public class StyleConfigurationEditorActivity extends AbstractConfigurationEdito
         void finishItem(@NonNull URLListEditActivity activity, @Nullable ListEditItem item, @NonNull String name, @NonNull String url) {
             if (item == null) {
                 // new item
-                activity.finishCreateItem(new ListEditItem(name, url, null, null, true, null));
+                activity.finishCreateItem(new ListEditItem(name, url, null, null, true, false, null));
             } else {
                 item.name = name;
                 item.value = url;

--- a/src/main/java/de/blau/android/prefs/URLListEditActivity.java
+++ b/src/main/java/de/blau/android/prefs/URLListEditActivity.java
@@ -410,15 +410,17 @@ public abstract class URLListEditActivity extends ListActivity
     /**
      * 
      * @author Jan
+     * @author Simon
      */
     public static class ListEditItem implements Serializable {
-        private static final long serialVersionUID = 7574708515164503468L;
+        private static final long serialVersionUID = 7574708515164503469L;
         final String              id;
         String                    name;
         String                    value;
         String                    value2;
         String                    value3;
         boolean                   boolean0;
+        boolean                   boolean1;
         boolean                   active;
         Serializable              object0;
 
@@ -429,7 +431,7 @@ public abstract class URLListEditActivity extends ListActivity
          * @param value the value
          */
         public ListEditItem(@NonNull String name, @NonNull String value) {
-            this(name, value, null, null, false, null);
+            this(name, value, null, null, false, false, null);
         }
 
         /**
@@ -440,9 +442,10 @@ public abstract class URLListEditActivity extends ListActivity
          * @param value2 further value 2
          * @param value3 further value 3
          * @param boolean0 a boolean
+         * @param boolean1 a 2nd boolean
          * @param object0 a Serializable object
          */
-        public ListEditItem(@NonNull String name, @NonNull String value, @Nullable String value2, @Nullable String value3, boolean boolean0,
+        public ListEditItem(@NonNull String name, @NonNull String value, @Nullable String value2, @Nullable String value3, boolean boolean0, boolean boolean1,
                 Serializable object0) {
             id = java.util.UUID.randomUUID().toString();
             this.value = value;
@@ -450,6 +453,7 @@ public abstract class URLListEditActivity extends ListActivity
             this.value3 = value3;
             this.name = name;
             this.boolean0 = boolean0;
+            this.boolean1 = boolean1;
             this.object0 = object0;
             this.active = false;
         }
@@ -500,13 +504,14 @@ public abstract class URLListEditActivity extends ListActivity
          * @param value3 further value 3
          * @param object0 a Serializable object
          * @param boolean0 a boolean
+         * @param boolean1 a 2nd boolean
          * @param active true if this entry should be active
          */
         public ListEditItem(@NonNull String id, @NonNull String name, @NonNull String value, @Nullable String value2, @Nullable String value3,
-                @NonNull Serializable object0, boolean boolean0, boolean active) {
+                @NonNull Serializable object0, boolean boolean0, boolean boolean1, boolean active) {
             this(id, name, value, value2, value3, boolean0, active);
             this.object0 = object0;
-
+            this.boolean1 = boolean1;
         }
 
         /**
@@ -528,6 +533,7 @@ public abstract class URLListEditActivity extends ListActivity
             this.value3 = value3;
             this.name = name;
             this.boolean0 = boolean0;
+            this.boolean1 = false;
             this.object0 = null;
             this.active = active;
         }
@@ -747,7 +753,7 @@ public abstract class URLListEditActivity extends ListActivity
             if (item == null || item.id == null) {
                 // new item
                 if (!"".equals(value)) {
-                    finishCreateItem(new ListEditItem(name, value, !"".equals(value2) ? value2 : null, null, false, null));
+                    finishCreateItem(new ListEditItem(name, value, !"".equals(value2) ? value2 : null, null, false, false, null));
                 }
             } else {
                 item.name = name;

--- a/src/main/java/de/blau/android/taginfo/TaginfoServer.java
+++ b/src/main/java/de/blau/android/taginfo/TaginfoServer.java
@@ -691,7 +691,7 @@ public final class TaginfoServer {
             @Nullable final PostAsyncActionHandler handler) {
         Log.d(DEBUG_TAG, "querying server for " + url);
         Object result = null;
-        try (InputStream is = Server.openConnection(context, new URL(url), 1000, 1000); JsonReader reader = new JsonReader(new InputStreamReader(is));) {
+        try (InputStream is = Server.openConnection(context, new URL(url), null, 1000, 1000); JsonReader reader = new JsonReader(new InputStreamReader(is));) {
             result = resultReader.read(reader);
             if (result != null && handler != null) {
                 handler.onSuccess();

--- a/src/main/java/de/blau/android/util/DownloadBroadcastReceiver.java
+++ b/src/main/java/de/blau/android/util/DownloadBroadcastReceiver.java
@@ -115,7 +115,7 @@ public class DownloadBroadcastReceiver extends BroadcastReceiver {
             if (db.getReadOnlyApiId(filename) == null) {
                 API current = db.getCurrentAPI();
                 db.addAPI(java.util.UUID.randomUUID().toString(), filename, current.url, uri.toString(), current.notesurl,
-                        new AuthParams(current.auth, "", "", null, null), false);
+                        new AuthParams(current.auth, "", "", null, null), false, false);
                 ScreenMessage.toastTopInfo(ctxt, ctxt.getString(R.string.toast_added_api_entry_for, filename));
             } else {
                 ScreenMessage.toastTopInfo(ctxt, ctxt.getString(R.string.toast_updated, filename));

--- a/src/main/res/layout/listedit_apiedit.xml
+++ b/src/main/res/layout/listedit_apiedit.xml
@@ -90,11 +90,27 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp">
         <TextView
+            android:id="@+id/listedit_label_authenticated_reads"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
+            android:text="@string/listedit_authenticated_reads" />
+        <CheckBox
+            android:id="@+id/listedit_authenticated_reads"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentRight="true"
+            android:layout_alignParentEnd="true"
+            android:layout_alignBaseline="@id/listedit_label_authenticated_reads" />
+        <TextView
             android:id="@+id/listedit_label_compressed_uploads"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentLeft="true"
             android:layout_alignParentStart="true"
+            android:layout_below="@id/listedit_label_authenticated_reads"
+            android:layout_marginTop="16dp"
             android:text="@string/listedit_supports_compressed_uploads" />
         <CheckBox
             android:id="@+id/listedit_compressed_uploads"

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1675,6 +1675,7 @@
     <string name="listedit_use_translations">Use translations</string>
     <string name="manage_geocoders">Manage geocoders</string>
     <string name="listedit_supports_compressed_uploads">Supports compressed uploads</string>
+    <string name="listedit_authenticated_reads">Use authenticated reads</string>
     <string name="geocoder_type">Geocoder type</string>
     <string name="manage_image_stores">Manage image storage</string>
     <string name="imagestore_type">Image storage type</string>

--- a/src/test/java/de/blau/android/net/CompressionTest.java
+++ b/src/test/java/de/blau/android/net/CompressionTest.java
@@ -71,7 +71,7 @@ public class CompressionTest {
         main = Robolectric.buildActivity(Main.class).create().resume().get();
         prefDB = new AdvancedPrefDatabase(main);
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, null, null, null, null), true);
+        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, null, null, null, null), true, false);
         prefDB.selectAPI("Test");
         System.out.println("mock api url " + mockBaseUrl.toString()); // NOSONAR
         Logic logic = App.getLogic();

--- a/src/test/java/de/blau/android/net/OAuth2Test.java
+++ b/src/test/java/de/blau/android/net/OAuth2Test.java
@@ -60,7 +60,7 @@ public class OAuth2Test {
         main = Robolectric.buildActivity(Main.class).create().resume().get();
         prefDB = new AdvancedPrefDatabase(main);
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null,  new AuthParams(API.Auth.OAUTH2, null, null, null, null), false);
+        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null,  new AuthParams(API.Auth.OAUTH2, null, null, null, null), false, false);
         prefDB.selectAPI("Test");
         System.out.println("mock api url " + mockBaseUrl.toString()); // NOSONAR
         ClassLoader loader = Thread.currentThread().getContextClassLoader();

--- a/src/test/java/de/blau/android/osm/ApiErrorTest.java
+++ b/src/test/java/de/blau/android/osm/ApiErrorTest.java
@@ -111,7 +111,7 @@ public class ApiErrorTest {
         main = Robolectric.buildActivity(Main.class).create().resume().get();
         prefDB = new AdvancedPrefDatabase(main);
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
         prefDB.selectAPI("Test");
         System.out.println("mock api url " + mockBaseUrl.toString()); // NOSONAR
         prefs = new Preferences(main);

--- a/src/test/java/de/blau/android/osm/ApiTest.java
+++ b/src/test/java/de/blau/android/osm/ApiTest.java
@@ -121,7 +121,7 @@ public class ApiTest {
         main = Robolectric.buildActivity(Main.class).create().resume().get();
         prefDB = new AdvancedPrefDatabase(main);
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
         prefDB.selectAPI("Test");
         System.out.println("mock api url " + mockBaseUrl.toString()); // NOSONAR
         Logic logic = App.getLogic();

--- a/src/test/java/de/blau/android/osm/GpxApiTest.java
+++ b/src/test/java/de/blau/android/osm/GpxApiTest.java
@@ -53,7 +53,7 @@ public class GpxApiTest {
         HttpUrl mockBaseUrl = mockServer.server().url("/api/0.6/");
         prefDB = new AdvancedPrefDatabase(ApplicationProvider.getApplicationContext());
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
         prefDB.selectAPI("Test");
         System.out.println("mock api url " + mockBaseUrl.toString()); // NOSONAR
         Logic logic = App.newLogic();

--- a/src/test/java/de/blau/android/osm/MiscApiTest.java
+++ b/src/test/java/de/blau/android/osm/MiscApiTest.java
@@ -53,7 +53,7 @@ public class MiscApiTest {
         main = Robolectric.buildActivity(Main.class).create().resume().get();
         prefDB = new AdvancedPrefDatabase(main);
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
         prefDB.selectAPI("Test");
         System.out.println("mock api url " + mockBaseUrl.toString()); // NOSONAR
         Logic logic = App.getLogic();

--- a/src/test/java/de/blau/android/osm/NotesApiTest.java
+++ b/src/test/java/de/blau/android/osm/NotesApiTest.java
@@ -70,7 +70,7 @@ public class NotesApiTest {
         main = Robolectric.buildActivity(Main.class).create().resume().get();
         prefDB = new AdvancedPrefDatabase(main);
         prefDB.deleteAPI("Test");
-        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false);
+        prefDB.addAPI("Test", "Test", mockBaseUrl.toString(), null, null, new AuthParams(API.Auth.BASIC, "user", "pass", null, null), false, false);
         prefDB.selectAPI("Test");
         System.out.println("mock api url " + mockBaseUrl.toString()); // NOSONAR
         Logic logic = App.getLogic();

--- a/src/test/java/de/blau/android/prefs/AdvancedPrefDatabaseTest.java
+++ b/src/test/java/de/blau/android/prefs/AdvancedPrefDatabaseTest.java
@@ -32,8 +32,8 @@ public class AdvancedPrefDatabaseTest {
             assertEquals(AdvancedPrefDatabase.ID_DEFAULT, current.id);
             assertEquals("OpenStreetMap", current.name);
             assertEquals(Auth.OAUTH2, current.auth);
-            db.addAPI("test_1", "test_1", current.url, null, null, new AuthParams(current.auth, null, null, null, null), false);
-            db.addAPI("test_2", "test_2", current.url, null, null, new AuthParams(Auth.OAUTH1A, null, null, null, null), false);
+            db.addAPI("test_1", "test_1", current.url, null, null, new AuthParams(current.auth, null, null, null, null), false, false);
+            db.addAPI("test_2", "test_2", current.url, null, null, new AuthParams(Auth.OAUTH1A, null, null, null, null), false, false);
             db.setAPIAccessToken("12345", "67890");
             API[] test1 = db.getAPIs("test_1");
             assertEquals(1, test1.length);
@@ -61,7 +61,7 @@ public class AdvancedPrefDatabaseTest {
             assertEquals(AdvancedPrefDatabase.ID_DEFAULT, current.id);
             assertEquals("OpenStreetMap", current.name);
             assertEquals(Auth.OAUTH2, current.auth);
-            db.addAPI("test_1", "test_1", current.url, null, null, new AuthParams(current.auth, null, null, null, null), false);
+            db.addAPI("test_1", "test_1", current.url, null, null, new AuthParams(current.auth, null, null, null, null), false, false);
             db.setAPIAccessToken("12345", "67890");
 
             API[] test1 = db.getAPIs("test_1");

--- a/src/test/java/de/blau/android/prefs/ImportExportConfigurationTest.java
+++ b/src/test/java/de/blau/android/prefs/ImportExportConfigurationTest.java
@@ -46,8 +46,8 @@ public class ImportExportConfigurationTest {
         final Context ctx = ApplicationProvider.getApplicationContext();
         try (AdvancedPrefDatabase db = new AdvancedPrefDatabase(ctx)) {
             API current = db.getCurrentAPI();
-            db.addAPI("test_1", "test_1", current.url, null, null, new AuthParams(current.auth, null, null, null, null), false);
-            db.addAPI("test_2", "test_2", current.url, null, null, new AuthParams(Auth.OAUTH1A, null, null, null, null), false);
+            db.addAPI("test_1", "test_1", current.url, null, null, new AuthParams(current.auth, null, null, null, null), false, false);
+            db.addAPI("test_2", "test_2", current.url, null, null, new AuthParams(Auth.OAUTH1A, null, null, null, null), false, false);
             db.selectAPI("test_2");
             db.setAPIAccessToken("12345", "67890");
         }


### PR DESCRIPTION
The standard APIs download rate limits are now so low that some areas are very difficult to download. This is particularly an issue when the bulk of the data are large relations and downloading a smaller area has no effect. Example: motorway A1/A3 in Switzerland.

This adds support for authenticated reads from the API. Default is off as this has both a privacy impact and higher friction for initial use.

Resolves https://github.com/MarcusWolschon/osmeditor4android/issues/668