### PR TITLE
Improve ReplaceGeometry abort behaviour

### DIFF
--- a/src/main/java/de/blau/android/easyedit/ReplaceGeometryActionModeCallback.java
+++ b/src/main/java/de/blau/android/easyedit/ReplaceGeometryActionModeCallback.java
@@ -36,7 +36,7 @@ import de.blau.android.util.ThemeUtils;
  * @author simon
  *
  */
-public class ReplaceGeometryActionModeCallback extends NonSimpleActionModeCallback {
+public class ReplaceGeometryActionModeCallback extends AbortableWayActionModeCallback {
 
     private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, ReplaceGeometryActionModeCallback.class.getSimpleName().length());
     private static final String DEBUG_TAG = ReplaceGeometryActionModeCallback.class.getSimpleName().substring(0, TAG_LEN);


### PR DESCRIPTION
Aborting a replace geometry action was leaving elements selected but no active selection mode. Fix by inheriting functionality from AbortableWayActionModeCallback.