### PR TITLE
Re-factor applicationId and app name handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:8.13.0'
         classpath 'ch.poole.gradle:markdown-gradle-plugin:0.2.6'
         classpath 'org.jacoco:org.jacoco.core:0.8.13'    
-        classpath "ch.poole:preset-utils:0.26.0"
+        classpath "ch.poole:preset-utils:0.44.0"
         classpath 'ch.poole.misc:gradle-eclipse-aar-plugin:0.1.0'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:3.0.1'
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.9.1'
@@ -261,8 +261,9 @@ android {
  
     defaultConfig {
         applicationId "de.blau.android"
-        versionCode project.getVersionCode()
-        versionName "${project.getVersionName()}"
+        versionCode 3401
+        versionName "22.0.0.0"
+        resValue "string", "app_version", versionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     
@@ -272,7 +273,6 @@ android {
         }
         release {
             minifyEnabled true       
-            // proguardFiles getDefaultProguardFile('proguard-android.txt'),'proguard-rules.pro'
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'),'proguard-rules.pro'
         }
         fakeRelease {
@@ -286,16 +286,28 @@ android {
     compileSdkVersion 35
 
     // Specifies one flavor dimension.
-    flavorDimensions "api"
+    flavorDimensions = ['applicationId'] 
     productFlavors {
         current {
-            dimension "api"
+            dimension "applicationId"
             multiDexEnabled true
             minSdkVersion 21
             targetSdkVersion 35
             applicationIdSuffix ""
             versionNameSuffix ""
+            resValue "string", "app_name", "Vespucci"
             resValue "string", "content_provider", "de.blau.android.provider"
+        }
+        vespucciIo {
+            applicationId "io.vespucci"
+            dimension "applicationId"
+            multiDexEnabled true
+            minSdkVersion 21
+            targetSdkVersion 35
+            applicationIdSuffix ""
+            versionNameSuffix ""
+            resValue "string", "app_name", "vespucci.io"
+            resValue "string", "content_provider", "io.vespucci.provider"
         }
     }
 
@@ -354,6 +366,10 @@ android {
     androidResources {
         generateLocaleConfig false
     }
+}
+
+base {
+    archivesName = "${android.defaultConfig.applicationId}-${android.defaultConfig.versionName}"
 }
 
 ext {
@@ -717,28 +733,6 @@ dependencies {
     }
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.3.0'
     androidTestImplementation "androidx.work:work-testing:$work_version"
-}
-
-int getVersionCode() {
-    def xml = getXmlFromFile("${android.sourceSets.main.manifest.srcFile}")
-    return xml.@'android:versionCode'.toInteger()
-}
-
-String getVersionName() {
-    def xml = getXmlFromFile("${android.sourceSets.main.res.srcDirs[0]}/values/appname.xml")
-    def versionName = xml.string.find { it.@name == 'app_version' }.toString()
-    if (versionName == null || versionName.length() == 0) {
-        throw new NullPointerException("Failure extracting version name.")
-    }
-    return versionName
-}
-
-def getXmlFromFile(String xmlFilePath) {
-    def xml = new XmlSlurper().parse(new File(xmlFilePath))
-    if (xml == null) {
-        throw new NullPointerException("Failure reading from " + xmlFilePath)
-    }
-    return xml;
 }
 
 def coverageSourceDirs = ['src/main/java']

--- a/build.gradle
+++ b/build.gradle
@@ -366,6 +366,10 @@ android {
     androidResources {
         generateLocaleConfig false
     }
+    
+    // remove java resources from preset-utils that are not needed
+    packagingOptions.resources.excludes += "**/*.xslt"
+    packagingOptions.resources.excludes += "**/*.xlmns"
 }
 
 base {

--- a/build.gradle
+++ b/build.gradle
@@ -573,55 +573,6 @@ afterEvaluate{
     tasks.named('marathonCurrentDebugAndroidTestGenerateMarathonfile') { 
         doNotTrackState('Gradle 8 compatability hack') 
     }
-
-    // these tasks needs to be created after the uninstall tasks
-
-    // hardwired single test, this is only needed during initial developement, once the whole test suite has been run
-    // any new test will be included automatically
-    // it would probably be better to somehow get the test name interactively from the user
-    android.productFlavors.all { flavor ->
-        task ("runSingleConnected${flavor.name.capitalize()}Test",
-        dependsOn: ["install${flavor.name.capitalize()}Debug", "install${flavor.name.capitalize()}DebugAndroidTest"],
-        type: Exec) {
-            group = 'vespucci'
-            description = "Run a single test method on device (configuration needs to be edited) for the ${flavor.name} flavor"
-            def toRun = "de.blau.android.services.MapTileProviderServiceTest"
-            // commandLine adb, 'shell', 'pm', 'list', 'instrumentation'
-            commandLine adb, 'shell', 'am', 'instrument', '-w', '-e', 'class',  toRun, "de.blau.android${flavor.applicationIdSuffix}.test/androidx.test.runner.AndroidJUnitRunner"
-            finalizedBy "uninstall${flavor.name.capitalize()}DebugAndroidTest","uninstall${flavor.name.capitalize()}Debug"
-        }
-    }
-
-    // this task will generate tasks for each test that was run in the last on device test
-    // it doesn't depend on it directly as that would require waiting for all the tests to execute first
-    // so the best strategy seems to simply refresh the build after the on device tests have been ran
-    // tests are split up over two categories depending if they failed or not
-    task generateTestTasks {
-        android.productFlavors.all { flavor ->
-            def flavorName = flavor.name.toUpperCase()
-            def fileRegex = "TEST.*-${flavorName}\\.xml"
-            def fileList = new File(projectDir.getPath() +"/build/outputs/androidTest-results/connected/flavors/${flavorName}/").listFiles().findAll { it.name ==~ /${fileRegex}/ }
-            if (!fileList.empty) {
-                def tests = (new XmlParser()).parse(fileList.get(0)) // assume all tests outputs are equivalent
-                tests.'testcase'.each { testcase ->
-                    def toRun = testcase.@classname + "#" + testcase.@name
-                    task ("run${flavor.name.capitalize()}${toRun.capitalize()}",
-                    dependsOn: ["install${flavor.name.capitalize()}Debug", "install${flavor.name.capitalize()}DebugAndroidTest"],
-                    type: Exec) {
-                        if (testcase.failure.size() == 0) {
-                            group = 'sucessful tests'
-                        } else {
-                            group = "failed tests"
-                        }
-                        description = "Run test " + toRun
-                        // commandLine adb, 'shell', 'pm', 'list', 'instrumentation'
-                        commandLine adb, 'shell', 'am', 'instrument', '-w', '-e', 'class',  toRun, "de.blau.android${flavor.applicationIdSuffix}.test/androidx.test.runner.AndroidJUnitRunner"
-                        finalizedBy "uninstall${flavor.name.capitalize()}DebugAndroidTest","uninstall${flavor.name.capitalize()}Debug"
-                    }
-                }
-            }
-        }
-    }
 }
 
 ext {

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:installLocation="auto"
-    android:versionCode="3401"
     android:versionName="@string/app_version" >
 
     <uses-sdk tools:overrideLibrary="androidx.core.splashscreen" />

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -48,7 +48,7 @@
     </queries>
 
     <application
-        android:name="de.blau.android.App"
+        android:name=".App"
         android:allowBackup="true"
         android:fullBackupContent="@xml/backup"
         android:icon="@mipmap/ic_launcher"
@@ -134,7 +134,6 @@
         <activity
             android:name=".prefs.AdvancedPrefEditor"
             android:configChanges="orientation|screenSize|keyboardHidden|density|screenLayout|uiMode|fontScale|locale"
-            android:label="@string/app_name_version"
             android:theme="@style/Theme.AppCompatPrefs" />
         <activity
             android:name=".propertyeditor.PropertyEditorActivity"
@@ -181,7 +180,7 @@
             </intent-filter>
         </activity>
         <activity
-            android:name="de.blau.android.GeoUrlActivity"
+            android:name=".GeoUrlActivity"
             android:exported="true"
             tools:ignore="ExportedActivity" >
             <intent-filter>
@@ -194,7 +193,7 @@
             </intent-filter>
         </activity>
         <activity
-            android:name="de.blau.android.ShareOnOpenStreetMap"
+            android:name=".ShareOnOpenStreetMap"
             android:exported="true"
             android:icon="@drawable/osm_logo"
             android:label="@string/share_on_openstreetmap"
@@ -209,7 +208,7 @@
             </intent-filter>
         </activity>
         <activity
-            android:name="de.blau.android.RemoteControlUrlActivity"
+            android:name=".RemoteControlUrlActivity"
             android:exported="true"
             tools:ignore="ExportedActivity" >
             <intent-filter>
@@ -239,7 +238,7 @@
             </intent-filter>
         </activity>
         <activity
-            android:name="de.blau.android.OsmWebsiteUrlActivity"
+            android:name=".OsmWebsiteUrlActivity"
             android:exported="true"
             tools:ignore="ExportedActivity" >
             <intent-filter>
@@ -355,9 +354,9 @@
             android:launchMode="singleInstance"
             android:theme="@style/Theme.AppCompat" />
         <activity
-            android:name="de.blau.android.prefs.keyboard.ShortcutsActivity"
+            android:name=".prefs.keyboard.ShortcutsActivity"
             android:label="@string/config_keyboard_shortcuts_title"
-            android:parentActivityName="de.blau.android.prefs.PrefEditorActivity" 
+            android:parentActivityName=".prefs.PrefEditorActivity" 
             android:theme="@style/Theme.customActionBar" />
         <receiver
             android:name=".util.DownloadBroadcastReceiver"

--- a/src/main/java/de/blau/android/App.java
+++ b/src/main/java/de/blau/android/App.java
@@ -82,14 +82,16 @@ public class App extends Application implements android.app.Application.Activity
     private static final int    TAG_LEN   = Math.min(LOG_TAG_LEN, App.class.getSimpleName().length());
     private static final String DEBUG_TAG = App.class.getSimpleName().substring(0, TAG_LEN);
 
-    private static final String     RHINO_LAZY_LOAD = "lazyLoad";
+    private static final String RHINO_LAZY_LOAD = "lazyLoad";
+
+    private static String           appName;
     private static App              currentInstance;
-    private static StorageDelegator delegator       = new StorageDelegator();
-    private static TaskStorage      taskStorage     = new TaskStorage();
+    private static StorageDelegator delegator      = new StorageDelegator();
+    private static TaskStorage      taskStorage    = new TaskStorage();
     private static OkHttpClient     httpClient;
-    private static final Object     httpClientLock  = new Object();
+    private static final Object     httpClientLock = new Object();
     private static String           userAgent;
-    private static final Random     random          = new Random();
+    private static final Random     random         = new Random();
 
     /**
      * The logic that manipulates the model. (non-UI)
@@ -215,6 +217,16 @@ public class App extends Application implements android.app.Application.Activity
 
     private static FSTConfiguration singletonConf;
 
+    /**
+     * Get the name of the app this is used besides for the name as the directory where we store public configuration
+     * and files
+     * 
+     * @return the name of the app
+     */
+    public static String getAppName() {
+        return appName;
+    }
+
     @Override
     protected void attachBaseContext(Context base) {
         super.attachBaseContext(base);
@@ -253,7 +265,7 @@ public class App extends Application implements android.app.Application.Activity
      * Setup misc singletons
      */
     private static void setupMisc(@NonNull App app) {
-        String appName = app.getString(R.string.app_name);
+        appName = app.getString(R.string.app_name);
         String appVersion = app.getString(R.string.app_version);
         userAgent = appName + "/" + appVersion;
         currentInstance = app;

--- a/src/main/java/de/blau/android/DebugInformation.java
+++ b/src/main/java/de/blau/android/DebugInformation.java
@@ -93,7 +93,7 @@ public class DebugInformation extends ConfigurationChangeAwareActivity {
     String getDebugText(@NonNull String eol) {
         StringBuilder builder = new StringBuilder();
 
-        builder.append(getString(R.string.app_name_version) + eol);
+        builder.append(getString(R.string.app_name) + " " + getString(R.string.app_version) + eol);
         builder.append("Flavor: " + BuildConfig.FLAVOR + eol);
         ApplicationInfo appInfo = getApplicationContext().getApplicationInfo();
         builder.append("Target SDK: " + appInfo.targetSdkVersion + eol);

--- a/src/main/java/de/blau/android/contract/Paths.java
+++ b/src/main/java/de/blau/android/contract/Paths.java
@@ -2,6 +2,8 @@ package de.blau.android.contract;
 
 /**
  * Path constants for directories, files, extensions and similar.
+ * 
+ * Relative paths are relative to what App.getAppName() returns
  */
 public final class Paths {
     /**
@@ -19,7 +21,6 @@ public final class Paths {
     public static final String DIRECTORY_PATH_IMAGERY            = "imagery";
     public static final String DIRECTORY_PATH_OTHER              = "other";
     public static final String DIRECTORY_PATH_STORAGE            = "/storage";       // NOSONAR
-    public static final String DIRECTORY_PATH_VESPUCCI           = "Vespucci";
     public static final String DIRECTORY_PATH_AUTOPRESET         = "autopreset";
     public static final String DIRECTORY_PATH_TILE_CACHE         = "/tiles/";        // NOSONAR
     public static final String DIRECTORY_PATH_TILE_CACHE_CLASSIC = "/andnav2/tiles/";// NOSONAR

--- a/src/main/java/de/blau/android/photos/PhotoIndex.java
+++ b/src/main/java/de/blau/android/photos/PhotoIndex.java
@@ -108,7 +108,7 @@ public class PhotoIndex extends SQLiteOpenHelper {
         db.execSQL("CREATE INDEX lonidx ON " + PHOTOS_TABLE + " (lon)");
         db.execSQL("CREATE TABLE IF NOT EXISTS " + SOURCES_TABLE + " (dir VARCHAR, last_scan int8, tag VARCHAR DEFAULT NULL);");
         initSource(db, DCIM, null);
-        initSource(db, Paths.DIRECTORY_PATH_VESPUCCI, null);
+        initSource(db, App.getAppName(), null);
         initSource(db, OSMTRACKER, null);
         initSource(db, MEDIA_STORE, "");
     }

--- a/src/main/java/de/blau/android/util/DownloadActivity.java
+++ b/src/main/java/de/blau/android/util/DownloadActivity.java
@@ -26,6 +26,7 @@ import androidx.appcompat.app.ActionBar;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.ViewGroupCompat;
 import androidx.fragment.app.FragmentActivity;
+import de.blau.android.App;
 import de.blau.android.R;
 import de.blau.android.contract.FileExtensions;
 import de.blau.android.contract.MimeTypes;
@@ -96,7 +97,7 @@ public class DownloadActivity extends WebViewActivity {
                 // Start download
                 @SuppressWarnings("deprecation")
                 DownloadManager.Request request = new DownloadManager.Request(uri).setAllowedOverRoaming(false).setTitle(filename)
-                        .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, Paths.DIRECTORY_PATH_VESPUCCI + Paths.DELIMITER + filename)
+                        .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, App.getAppName() + Paths.DELIMITER + filename)
                         .setVisibleInDownloadsUi(true);
                 request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
                 if (!allNetworks) {

--- a/src/main/java/de/blau/android/util/FileUtil.java
+++ b/src/main/java/de/blau/android/util/FileUtil.java
@@ -57,7 +57,7 @@ public final class FileUtil {
      * @throws IOException if we can't create the directory
      */
     public static @NonNull File getPublicDirectory() throws IOException {
-        return getPublicDirectory(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), Paths.DIRECTORY_PATH_VESPUCCI);
+        return getPublicDirectory(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), App.getAppName());
     }
 
     /**
@@ -66,7 +66,7 @@ public final class FileUtil {
      * @return true if the directory exists
      */
     public static boolean publicDirectoryExists() {
-        return new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), Paths.DIRECTORY_PATH_VESPUCCI).exists();
+        return new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), App.getAppName()).exists();
     }
 
     /**
@@ -76,7 +76,7 @@ public final class FileUtil {
      * @throws IOException if we can't create the directory
      */
     public static @NonNull File getLegacyPublicDirectory() throws IOException {
-        return getPublicDirectory(Environment.getExternalStorageDirectory(), Paths.DIRECTORY_PATH_VESPUCCI);
+        return getPublicDirectory(Environment.getExternalStorageDirectory(), App.getAppName());
     }
 
     /**

--- a/src/main/res/values/appname.xml
+++ b/src/main/res/values/appname.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string translatable="false" name="app_name">Vespucci</string>
-    <string translatable="false" name="app_version">22.0.0.0</string>
-    <string translatable="false" name="app_name_version">Vespucci 22.0.0</string>
-</resources>


### PR DESCRIPTION
This decouples the applicationId from the Java package name and moves app name and version configuration to the gradle build file, allowing:

- builds with different applicationIDs that can be installed (and run) in parallel (for example for testing)
- all relevant configuration is in one place (Android gradle plugin config)
- potential future renaming of the Java package.

The build with applicationId de.blau.android (used for googles playstore) should be near identical to the previous build, the changes add a build with the applicationId io.vespucci and app name vespucci.io.

The public directory used by the app is now derived from the app name, this implies that that actually needs to be different for different applicationIds as otherwise there might be access issues.
