### PR TITLE
Ungzip error messages from tile sources before trying to display them

### DIFF
--- a/src/main/java/de/blau/android/services/util/MapTileDownloader.java
+++ b/src/main/java/de/blau/android/services/util/MapTileDownloader.java
@@ -292,12 +292,15 @@ public class MapTileDownloader extends MapAsyncTileProvider {
                             break;
                         case MimeTypes.TEXT_TYPE:
                             // this can't be a tile and is likely an error message
-                            throw new FileNotFoundException(mCtx.getString(R.string.tile_error_message, tileURLString, responseBody.string()));
+                            throw new FileNotFoundException(
+                                    mCtx.getString(R.string.tile_error_message, tileURLString, new String(MapTileProvider.unGZip(data), format.charset())));
                         case MimeTypes.APPLICATION_TYPE: // WMS errors, MVT tiles
                             switch (format.subtype().toLowerCase()) {
                             case MimeTypes.WMS_EXCEPTION_XML_SUBTYPE:
                             case MimeTypes.JSON_SUBTYPE:
-                                throw new FileNotFoundException(mCtx.getString(R.string.tile_error_message, tileURLString, responseBody.string()));
+                                MapTileProvider.unGZip(data);
+                                throw new FileNotFoundException(
+                                        mCtx.getString(R.string.tile_error_message, tileURLString, new String(MapTileProvider.unGZip(data), format.charset())));
                             case MimeTypes.MVT_SUBTYPE:
                             case MimeTypes.X_PROTOBUF_SUBTYPE:
                             case MimeTypes.OCTET_STREAM_SUBTYPE:


### PR DESCRIPTION
If the source returned a gzip text body instead of a tile (and an error code), we wouldn't decode it properly.