### PR TITLE
Fix updating relation member label after download regression

### DIFF
--- a/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
+++ b/src/androidTest/java/de/blau/android/propertyeditor/PropertyEditorTest.java
@@ -1555,7 +1555,7 @@ public class PropertyEditorTest {
     }
 
     /**
-     * Select a relation move member up 2 positions and then down one
+     * Select a relation download member 
      */
     @Test
     public void relationMemberDownload() {
@@ -1587,6 +1587,8 @@ public class PropertyEditorTest {
         selectMember("#35479120");
         clickButtonOrOverflowMenu(main.getString(R.string.download));
 
+        assertTrue(TestUtils.findText(device, true, "highway=service #35479120", 10000, false));
+        
         // exit property editor
         TestUtils.clickUp(device);
         TestUtils.clickHome(device, false);

--- a/src/main/java/de/blau/android/propertyeditor/RelationMemberSelectedActionModeCallback.java
+++ b/src/main/java/de/blau/android/propertyeditor/RelationMemberSelectedActionModeCallback.java
@@ -274,7 +274,6 @@ public class RelationMemberSelectedActionModeCallback extends SelectedRowsAction
      * @param selectedCount count
      */
     private void downloadSelected(final List<MemberEntry> selected, final int selectedCount) {
-        int i;
         Progress.showDialog(caller.getActivity(), Progress.PROGRESS_DOWNLOAD);
         PostAsyncActionHandler handler = () -> {
             if (currentAction != null) {
@@ -294,7 +293,7 @@ public class RelationMemberSelectedActionModeCallback extends SelectedRowsAction
         List<Long> nodes = new ArrayList<>();
         List<Long> ways = new ArrayList<>();
         List<Long> relations = new ArrayList<>();
-        for (i = 0; i < selectedCount; i++) {
+        for (int i = 0; i < selectedCount; i++) {
             MemberEntry row = selected.get(i);
             if (!row.downloaded()) {
                 final long ref = row.getRef();
@@ -321,8 +320,11 @@ public class RelationMemberSelectedActionModeCallback extends SelectedRowsAction
      * Update the connections and notify the adapter
      */
     private void update() {
-        for (int i = 0; i < members.size(); i++) {
-            members.get(i).setPosition(i);
+        final int size = members.size();
+        for (int i = 0; i < size; i++) {
+            final MemberEntry member = members.get(i);
+            member.setPosition(i);
+            member.update();
         }
         ((RelationMembersFragment) caller).setConnections();
         adapter.notifyDataSetChanged();


### PR DESCRIPTION
This was likely an oversight in the migration to RecyclerView.

Resolves https://github.com/MarcusWolschon/osmeditor4android/issues/3233