### PR TITLE
Get the http client as early as possible

### DIFF
--- a/src/androidTest/java/de/blau/android/TestUtils.java
+++ b/src/androidTest/java/de/blau/android/TestUtils.java
@@ -81,6 +81,17 @@ public final class TestUtils {
      * @param device the UiDevice
      */
     public static void grantPermissons(@NonNull UiDevice device) {
+        // there's no good place to do this, but if we are not starting with Splash we want to get this 
+        // asap.
+        new ExecutorTask<Void, Void, Void>() {
+
+            @Override
+            protected Void doInBackground(Void input) throws Exception {
+                App.getHttpClient();
+                return null;
+            }
+            
+        }.execute();
         clickText(device, false, "Wait", true, false, 5000);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             boolean notdone = true;

--- a/src/main/java/de/blau/android/Splash.java
+++ b/src/main/java/de/blau/android/Splash.java
@@ -152,6 +152,10 @@ public class Splash extends AppCompatActivity {
                     Log.d(DEBUG_TAG, "Init tag2link");
                     App.getTag2Link(Splash.this);
                     Log.d(DEBUG_TAG, "Init tag2link finished");
+                    
+                    Log.d(DEBUG_TAG, "Init OkHttpClient ");
+                    App.getHttpClient();
+                    Log.d(DEBUG_TAG, "Init OkHttpClient  finished");
                     return null;
                 }
             }.execute();


### PR DESCRIPTION
When running integration tests this seems to have caused a number of tests to time out, moving it to the the general startup stuff seems to be a good idea anyway.