### PR TITLE
Only show the pausing alert if we are still downloading

### DIFF
--- a/src/main/java/de/blau/android/layer/data/MapOverlay.java
+++ b/src/main/java/de/blau/android/layer/data/MapOverlay.java
@@ -443,7 +443,8 @@ public class MapOverlay<O extends OsmElement> extends NonSerializeableLayer
                             map.postInvalidate();
                         }, true, true);
                         final int code = result.getCode();
-                        if (PAUSE_AUTO_DOWNLOAD.contains(code)) {
+                        // only show the alert if we are still downloading
+                        if (PAUSE_AUTO_DOWNLOAD.contains(code) && prefs.getPanAndZoomAutoDownload()) {
                             prefs.setPanAndZoomAutoDownload(false);
                             setPrefs(prefs);
                             if (ctx instanceof FragmentActivity) {


### PR DESCRIPTION
Check if we have already paused the auto download, if yes don't show the alert dialog.