### PR TITLE
Separate out the call to the capability API endpoint for downloads

### DIFF
--- a/src/androidTest/java/de/blau/android/osm/DownloadAlongTest.java
+++ b/src/androidTest/java/de/blau/android/osm/DownloadAlongTest.java
@@ -1,30 +1,21 @@
 package de.blau.android.osm;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import javax.xml.parsers.ParserConfigurationException;
-
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.xml.sax.SAXException;
-import org.xmlpull.v1.XmlPullParserException;
-import org.xmlpull.v1.XmlPullParserFactory;
 
 import com.orhanobut.mockwebserverplus.MockWebServerPlus;
 
@@ -35,12 +26,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.ActivityTestRule;
-import androidx.test.uiautomator.By;
 import androidx.test.uiautomator.UiDevice;
-import androidx.test.uiautomator.UiObject;
-import androidx.test.uiautomator.UiObjectNotFoundException;
-import androidx.test.uiautomator.UiSelector;
-import androidx.test.uiautomator.Until;
 import de.blau.android.App;
 import de.blau.android.LayerUtils;
 import de.blau.android.Logic;
@@ -49,18 +35,12 @@ import de.blau.android.R;
 import de.blau.android.SignalHandler;
 import de.blau.android.SignalUtils;
 import de.blau.android.TestUtils;
-import de.blau.android.contract.MimeTypes;
 import de.blau.android.layer.LayerType;
-import de.blau.android.listener.UploadListener;
 import de.blau.android.prefs.API;
+import de.blau.android.prefs.API.AuthParams;
 import de.blau.android.prefs.AdvancedPrefDatabase;
 import de.blau.android.prefs.Preferences;
-import de.blau.android.prefs.API.AuthParams;
 import okhttp3.HttpUrl;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.QueueDispatcher;
-import okhttp3.mockwebserver.RecordedRequest;
-import okio.Buffer;
 
 @RunWith(AndroidJUnit4.class)
 @LargeTest
@@ -68,15 +48,9 @@ public class DownloadAlongTest {
 
     private static final String DEBUG_TAG = DownloadAlongTest.class.getSimpleName();
 
-    private static final String DOWNLOAD1_FIXTURE     = "download1";
     private static final String CAPABILITIES1_FIXTURE = "capabilities1";
 
     public static final int TIMEOUT = 90;
-
-    private static final String TRANSIENT_VALUE  = "transient value";
-    private static final String TRANSIENT        = "transient";
-    private static final String PERSISTENT_VALUE = "persistent value";
-    private static final String PERSISTENT       = "persistent";
 
     MockWebServerPlus       mockServer = null;
     Context                 context    = null;
@@ -145,9 +119,7 @@ public class DownloadAlongTest {
 
         mockServer.enqueue(CAPABILITIES1_FIXTURE);
         mockServer.enqueue("downloadalong1");
-        mockServer.enqueue(CAPABILITIES1_FIXTURE);
         mockServer.enqueue("downloadalong2");
-        mockServer.enqueue(CAPABILITIES1_FIXTURE);
         mockServer.enqueue("downloadalong3");
         TestUtils.zoomToLevel(device, main, 22);
 
@@ -157,7 +129,7 @@ public class DownloadAlongTest {
         // w49855552
         TestUtils.clickAtCoordinates(device, main.getMap(), 8.385856, 47.3895648, true);
         assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_wayselect)));
-        
+
         assertEquals(49855552L, logic.getSelectedWay().getOsmId());
         TestUtils.clickOverflowButton(device);
         TestUtils.scrollTo(main.getString(R.string.menu_download_along_way), false);
@@ -171,8 +143,6 @@ public class DownloadAlongTest {
             mockServer.server().takeRequest(10, TimeUnit.SECONDS);
             mockServer.server().takeRequest(10, TimeUnit.SECONDS);
             mockServer.server().takeRequest(10, TimeUnit.SECONDS);
-            mockServer.server().takeRequest(10, TimeUnit.SECONDS);
-            mockServer.server().takeRequest(10, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             fail(e.getMessage());
         }
@@ -180,4 +150,87 @@ public class DownloadAlongTest {
         assertNotNull(App.getDelegator().getOsmElement(Way.NAME, 210468096L));
     }
 
+    /**
+     * Select a way and then download along
+     */
+    @Test
+    public void wayTestApiNotAvailable() {
+        final CountDownLatch signal = new CountDownLatch(1);
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        InputStream is = loader.getResourceAsStream("schulstrasse.osm");
+        final Logic logic = App.getLogic();
+        logic.readOsmFile(main, is, false, new SignalHandler(signal));
+        SignalUtils.signalAwait(signal, TIMEOUT);
+
+        mockServer.enqueue("capabilities-api-offline");
+        TestUtils.zoomToLevel(device, main, 22);
+
+        TestUtils.unlock(device);
+        TestUtils.clickAwayTip(device, context);
+
+        // w49855552
+        TestUtils.clickAtCoordinates(device, main.getMap(), 8.385856, 47.3895648, true);
+        assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_wayselect)));
+
+        assertEquals(49855552L, logic.getSelectedWay().getOsmId());
+        TestUtils.clickOverflowButton(device);
+        TestUtils.scrollTo(main.getString(R.string.menu_download_along_way), false);
+        TestUtils.clickText(device, false, main.getString(R.string.menu_download_along_way), true, false);
+        TestUtils.clickAwayTip(device, context);
+        assertTrue(TestUtils.findText(device, false, main.getString(R.string.download_along_way_title), 5000));
+        TestUtils.clickText(device, false, main.getString(R.string.submit), true, false);
+
+        try {
+            mockServer.server().takeRequest(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            fail(e.getMessage());
+        }
+        TestUtils.sleep(2000);
+        assertNull(App.getDelegator().getOsmElement(Way.NAME, 210468096L));
+    }
+
+    /**
+     * Select a way and then download along
+     */
+    @Test
+    public void wayTestErrorPause() {
+        final CountDownLatch signal = new CountDownLatch(1);
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        InputStream is = loader.getResourceAsStream("schulstrasse.osm");
+        final Logic logic = App.getLogic();
+        logic.readOsmFile(main, is, false, new SignalHandler(signal));
+        SignalUtils.signalAwait(signal, TIMEOUT);
+
+        mockServer.enqueue(CAPABILITIES1_FIXTURE);
+        mockServer.enqueue("downloadalong1");
+        mockServer.enqueue("500");
+
+        TestUtils.zoomToLevel(device, main, 22);
+
+        TestUtils.unlock(device);
+        TestUtils.clickAwayTip(device, context);
+
+        // w49855552
+        TestUtils.clickAtCoordinates(device, main.getMap(), 8.385856, 47.3895648, true);
+        assertTrue(TestUtils.findText(device, false, context.getString(R.string.actionmode_wayselect)));
+
+        assertEquals(49855552L, logic.getSelectedWay().getOsmId());
+        TestUtils.clickOverflowButton(device);
+        TestUtils.scrollTo(main.getString(R.string.menu_download_along_way), false);
+        TestUtils.clickText(device, false, main.getString(R.string.menu_download_along_way), true, false);
+        TestUtils.clickAwayTip(device, context);
+        assertTrue(TestUtils.findText(device, false, main.getString(R.string.download_along_way_title), 5000));
+        TestUtils.clickText(device, false, main.getString(R.string.submit), true, false);
+
+        try {
+            mockServer.server().takeRequest(10, TimeUnit.SECONDS);
+            mockServer.server().takeRequest(10, TimeUnit.SECONDS);
+            mockServer.server().takeRequest(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            fail(e.getMessage());
+        }
+        TestUtils.sleep(2000);
+        assertNotNull(App.getDelegator().getOsmElement(Way.NAME, 210456655L));
+        assertNull(App.getDelegator().getOsmElement(Way.NAME, 210468096L));
+    }
 }

--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -3427,23 +3427,9 @@ public class Logic {
         AsyncResult result = new AsyncResult(ErrorCodes.OK);
         try {
             if (!background) {
-                if (server.hasReadOnly()) {
-                    if (server.hasMapSplitSource()) {
-                        if (!MapSplitSource.intersects(server.getMapSplitSource(), mapBox)) {
-                            return new AsyncResult(ErrorCodes.NO_DATA);
-                        }
-                    } else {
-                        server.getReadOnlyCapabilities();
-                        if (!(server.readOnlyApiAvailable() && server.readOnlyReadableDB())) {
-                            return new AsyncResult(ErrorCodes.API_OFFLINE);
-                        }
-                        server.getCapabilities();
-                    }
-                } else {
-                    server.getCapabilities();
-                    if (!(server.apiAvailable() && server.readableDB())) {
-                        return new AsyncResult(ErrorCodes.API_OFFLINE);
-                    }
+                AsyncResult checkResult = checkDataAvailable(server, mapBox);
+                if (ErrorCodes.OK != checkResult.getCode()) {
+                    return checkResult;
                 }
             }
 
@@ -3474,7 +3460,7 @@ public class Logic {
             // don't have to lock before we are here
             lock();
             if (!background) {
-                // Main maybe not available and by extension there may be no valid Map object
+                // Main maybe not be available and by extension there may be no valid Map object
                 Map currentMap = ctx instanceof Main ? ((Main) ctx).getMap() : null;
                 if (currentMap != null) {
                     // set to current or previous
@@ -3537,6 +3523,34 @@ public class Logic {
             Log.e(DEBUG_TAG, "downloadBox problem downloading " + result.getClass() + " " + result.getMessage());
         }
         return result;
+    }
+
+    /**
+     * Check if we can actually access data for download
+     * 
+     * @param server the target Server
+     * @param box the BoundingBox we want data for
+     */
+    @NonNull
+    public AsyncResult checkDataAvailable(@NonNull final Server server, @Nullable final BoundingBox box) {
+        if (server.hasReadOnly()) {
+            if (server.hasMapSplitSource()) {
+                if (box != null && !MapSplitSource.intersects(server.getMapSplitSource(), box)) {
+                    return new AsyncResult(ErrorCodes.NO_DATA);
+                }
+            } else {
+                server.getReadOnlyCapabilities();
+                if (!(server.readOnlyApiAvailable() && server.readOnlyReadableDB())) {
+                    return new AsyncResult(ErrorCodes.API_OFFLINE);
+                }
+            }
+        } else {
+            server.getCapabilities();
+            if (!(server.apiAvailable() && server.readableDB())) {
+                return new AsyncResult(ErrorCodes.API_OFFLINE);
+            }
+        }
+        return new AsyncResult(ErrorCodes.OK);
     }
 
     /**

--- a/src/main/java/de/blau/android/services/DownloadService.java
+++ b/src/main/java/de/blau/android/services/DownloadService.java
@@ -219,6 +219,13 @@ public class DownloadService extends Service {
         @Override
         protected Void doInBackground(List<BoundingBox> boxes) throws IOException {
             boxCount = boxes.size();
+            AsyncResult checkResult = logic.checkDataAvailable(server, null);
+            if (checkResult.getCode() != ErrorCodes.OK) {
+                handler.postDelayed(() -> ScreenMessage.toastTopError(DownloadService.this, R.string.api_offline_message), UPDATE_DELAY);
+                pause = true;
+                Log.d(DEBUG_TAG, "Download paused because API is not available");
+                return null;
+            }
             Log.d(DEBUG_TAG, "Download started " + boxCount + " data " + downloadData + " tasks " + downloadTasks);
             notificationUpdater = () -> {
                 if (notificationManager.areNotificationsEnabled() && !pause && !abort) {
@@ -242,12 +249,13 @@ public class DownloadService extends Service {
                     final BoundingBox box = getBox(position, boxes);
                     if (downloadData) {
                         AsyncResult result = logic.download(DownloadService.this, server, box, (OsmElement e) -> e.hasProblem(DownloadService.this, validator),
-                                null, true, false);
+                                null, true, true);
                         if (result.getCode() != ErrorCodes.OK) {
                             pause = true;
                             Log.d(DEBUG_TAG, "Pausing due to result " + result.getCode());
-                            ScreenMessage.toastTopError(DownloadService.this,
-                                    getString(R.string.toast_download_failed, TrackerService.errorCodesToStringRes(result.getCode()), result.getMessage()));
+                            handler.postDelayed(() -> ScreenMessage.toastTopError(DownloadService.this,
+                                    getString(R.string.toast_download_failed, TrackerService.errorCodesToStringRes(result.getCode()), result.getMessage())),
+                                    UPDATE_DELAY);
                             return null;
                         }
                     }
@@ -285,7 +293,7 @@ public class DownloadService extends Service {
 
         @Override
         protected void onPostExecute(Void result) {
-            boolean paused = position != 0 && boxCount > 0 && !abort;
+            boolean paused = pause && boxCount > 0 && !abort;
             if (notificationManager.areNotificationsEnabled()) {
                 Notification n = buildNotification(paused, boxCount, position).build();
                 handler.postDelayed(() -> notificationManager.notify(R.id.notification_download, n), UPDATE_DELAY);

--- a/src/testCommon/resources/fixtures/capabilities-api-offline.xml
+++ b/src/testCommon/resources/fixtures/capabilities-api-offline.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <osm version="0.6" generator="OpenStreetMap server">
+  <api>
+    <version minimum="0.6" maximum="0.6"/>
+    <area maximum="0.24"/>
+    <note_area maximum="24"/>
+    <tracepoints per_page="4999"/>
+    <waynodes maximum="2001"/>
+    <relationmembers maximum="19999"/>
+    <changesets maximum_elements="50000"/>
+    <timeout seconds="301"/>
+    <status database="online" api="offline" gpx="online"/>
+  </api>
+  <policy>
+  	<imagery>
+  	  <blacklist regex=".*\.google(apis)?\..*/(vt|kh)[\?/].*([xyz]=.*){3}.*"/>
+  	</imagery>
+  </policy>
+</osm>

--- a/src/testCommon/resources/fixtures/capabilities-api-offline.yaml
+++ b/src/testCommon/resources/fixtures/capabilities-api-offline.yaml
@@ -1,0 +1,4 @@
+statusCode: 200       
+delay: 0              
+body: 'capabilities-api-offline.xml'
+                 


### PR DESCRIPTION
In some situations you want to only check the API status once and then download multiple times.