### PR TITLE
Mapillary support broke with d1493030ed12f1dc5e123f1440164cb54df13de9

### DIFF
--- a/src/main/java/de/blau/android/layer/streetlevel/AbstractSequenceFetcher.java
+++ b/src/main/java/de/blau/android/layer/streetlevel/AbstractSequenceFetcher.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
@@ -19,6 +20,7 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 import de.blau.android.App;
 import de.blau.android.contract.MimeTypes;
+import de.blau.android.osm.OsmXml;
 import okhttp3.Call;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -53,7 +55,7 @@ public abstract class AbstractSequenceFetcher implements Runnable {
     @Override
     public void run() {
         try {
-            URL url = new URI(String.format(urlTemplate, sequenceId, apiKey)).toURL();
+            URL url = new URI(String.format(urlTemplate, sequenceId, apiKey != null ? URLEncoder.encode(apiKey, OsmXml.UTF_8) : null)).toURL();
             ArrayList<String> ids = new ArrayList<>();
             do {
                 Log.d(DEBUG_TAG, "query sequence: " + url.toString());

--- a/src/main/java/de/blau/android/layer/streetlevel/mapillary/MapillaryLoader.java
+++ b/src/main/java/de/blau/android/layer/streetlevel/mapillary/MapillaryLoader.java
@@ -7,8 +7,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.URI;
-import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -33,6 +32,7 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 
 class MapillaryLoader extends NetworkImageLoader {
+
     private static final long serialVersionUID = 2L;
 
     private static final int      TAG_LEN   = Math.min(LOG_TAG_LEN, MapillaryLoader.class.getSimpleName().length());
@@ -43,6 +43,7 @@ class MapillaryLoader extends NetworkImageLoader {
     private static final String COMPUTED_COMPASS_ANGLE_FIELD = "computed_compass_angle";
     private static final String CAPTURED_AT_FIELD            = "captured_at";
     private static final String THUMB_2048_URL_FIELD         = "thumb_2048_url";
+    private static final int    TIMEOUT                      = 20000;
 
     /**
      * Construct a new loader
@@ -61,8 +62,8 @@ class MapillaryLoader extends NetworkImageLoader {
         return () -> {
             Log.d(DEBUG_TAG, "querying mapillary server for " + key);
             try {
-                Request request = new Request.Builder().url(new URI(String.format(imageUrl, key)).toURL()).build();
-                OkHttpClient client = App.getHttpClient().newBuilder().connectTimeout(20000, TimeUnit.MILLISECONDS).readTimeout(20000, TimeUnit.MILLISECONDS)
+                Request request = new Request.Builder().url(new URL(String.format(imageUrl, key))).build();
+                OkHttpClient client = App.getHttpClient().newBuilder().connectTimeout(TIMEOUT, TimeUnit.MILLISECONDS).readTimeout(20000, TimeUnit.MILLISECONDS)
                         .build();
                 Call mapillaryCall = client.newCall(request);
                 Response mapillaryCallResponse = mapillaryCall.execute();
@@ -81,7 +82,7 @@ class MapillaryLoader extends NetworkImageLoader {
                 }
                 setImage(view, imageFile);
                 pruneCache();
-            } catch (IOException | URISyntaxException e) {
+            } catch (IOException e) {
                 Log.e(DEBUG_TAG, e.getMessage());
             }
         };

--- a/src/main/java/de/blau/android/layer/streetlevel/mapillary/MapillaryOverlay.java
+++ b/src/main/java/de/blau/android/layer/streetlevel/mapillary/MapillaryOverlay.java
@@ -131,28 +131,28 @@ public class MapillaryOverlay extends AbstractImageOverlay {
 
     @Override
     public void onSelected(FragmentActivity activity, de.blau.android.util.mvt.VectorTileDecoder.Feature f) {
-        if (isPoint(f)) {
-            // we ignore anything except the images for now
-            java.util.Map<String, Object> attributes = f.getAttributes();
-            String sequenceId = (String) attributes.get(SEQUENCE_ID_KEY);
-            Long id = (Long) attributes.get(ID_KEY);
-            if (id != null && sequenceId != null) {
-                ArrayList<String> keys = mapillaryState != null ? mapillaryState.sequenceCache.get(sequenceId) : null;
-                if (keys == null) {
-                    try {
-                        Thread t = new Thread(null, new MapillarySequenceFetcher(activity, mapillarySequencesUrl, sequenceId, id, apiKey),
-                                "Mapillary Sequence");
-                        t.start();
-                    } catch (SecurityException | IllegalThreadStateException | IllegalStateException e) {
-                        Log.e(DEBUG_TAG, "Unable to run SequenceFetcher " + e.getMessage());
-                        return;
-                    }
-                } else {
-                    showImages(activity, id, keys);
+        if (!isPoint(f)) {
+            return;
+        }
+        // we ignore anything except the images for now
+        java.util.Map<String, Object> attributes = f.getAttributes();
+        String sequenceId = (String) attributes.get(SEQUENCE_ID_KEY);
+        Long id = (Long) attributes.get(ID_KEY);
+        if (id != null && sequenceId != null) {
+            ArrayList<String> keys = mapillaryState != null ? mapillaryState.sequenceCache.get(sequenceId) : null;
+            if (keys == null) {
+                try {
+                    Thread t = new Thread(null, new MapillarySequenceFetcher(activity, mapillarySequencesUrl, sequenceId, id, apiKey), "Mapillary Sequence");
+                    t.start();
+                } catch (SecurityException | IllegalThreadStateException | IllegalStateException e) {
+                    Log.e(DEBUG_TAG, "Unable to run SequenceFetcher " + e.getMessage());
+                    return;
                 }
-                setSelected(f);
-                mapillaryState.sequenceId = sequenceId;
+            } else {
+                showImages(activity, id, keys);
             }
+            setSelected(f);
+            mapillaryState.sequenceId = sequenceId;
         }
     }
 

--- a/src/main/java/de/blau/android/layer/streetlevel/panoramax/PanoramaxOverlay.java
+++ b/src/main/java/de/blau/android/layer/streetlevel/panoramax/PanoramaxOverlay.java
@@ -370,7 +370,6 @@ public class PanoramaxOverlay extends AbstractImageOverlay {
                 return;
             }
             urls.put(idString, href.getAsString());
-
         }
     }
 


### PR DESCRIPTION
Mapillarys api key contain unsafe characters that are rejected by URI but not by URL. Unluckily encoding causes issues with String.format so there is currently no really better solution to go back to URL in some cases.