### PR TITLE
Fix Panoramax image symbol highlight missing

### DIFF
--- a/src/main/assets/panoramax-style.json
+++ b/src/main/assets/panoramax-style.json
@@ -71,7 +71,7 @@
         {
             "id": "selected_image",
             "type": "symbol",
-            "source-layer": "image",
+            "source-layer": "pictures",
             "filter": [
                 "==",
                 "id",
@@ -83,7 +83,7 @@
                 "icon-rotate": ["to-number", ["get","heading"]]
             },
             "paint": {
-                "icon-color": "rgba(100, 200, 0, 1)"
+                "icon-color": "rgba(200, 100, 0, 1)"
             }
         }
     ],


### PR DESCRIPTION
The layer "selected_image" was referencing the wrong source-layer and the colour was not really well visible.

Resolves: https://github.com/MarcusWolschon/osmeditor4android/issues/3294