### PR TITLE
Update 22.1.0 Release notes.md - Formatted links

### DIFF
--- a/documentation/docs/help/en/22.1.0 Release notes.md
+++ b/documentation/docs/help/en/22.1.0 Release notes.md
@@ -19,7 +19,7 @@ We've replaced the previous implementation that utilized a Android WebView with 
 ### Dedicated function to draw "areas"
 
 We've added an "Add area" function to the "+" button in normal mode, this works the same as the previous "Add way" but will always close the way, even if the _Snap_ function
-is disabled. See [Add area](Simple%20actions.md#add-area]. While drawing a closing line is indicated that will turn red if the area would intersect itself if closed at that point.
+is disabled. See [Add area](Simple%20actions.md#add-area). While drawing a closing line is indicated that will turn red if the area would intersect itself if closed at that point.
 
 We expect more functionality to be added to this going forward. 
 
@@ -33,7 +33,7 @@ You can now download along an OSM way, this is substantially more efficient than
 the OSM API. Using this will turn off auto-prune as leaving it enabled could lead to the data you just downloaded being immediately deleted, to make it a bit easier to 
 re-enable auto-prune we have separated the configuration for OSM data and tasks and moved it to the layer control modal. 
 
-We would further recommend disabling [Pan and zoom auto download](Main%20map%20display.md#transfer] and using authenticated reads (see the API configuration)) while using this function.
+We would further recommend disabling [Pan and zoom auto download](Main%20map%20display.md#transfer) and using authenticated reads (see the API configuration)) while using this function.
 
 A future version will support the same functionality for GPX tracks, due to time constraints it wasn't possible to include it in this release.  
 


### PR DESCRIPTION
Changed formatting for some links which had a square closing bracket `]` instead of a round closing bracket `)` in the 'url' part.