### PR TITLE
Disable optimizations in Rhino

### DIFF
--- a/src/main/java/de/blau/android/App.java
+++ b/src/main/java/de/blau/android/App.java
@@ -42,6 +42,7 @@ import androidx.multidex.MultiDex;
 import androidx.preference.PreferenceManager;
 import de.blau.android.contract.Paths;
 import de.blau.android.filter.PresetFilter;
+import de.blau.android.javascript.Utils;
 import de.blau.android.net.OkHttpCompat;
 import de.blau.android.net.UserAgentInterceptor;
 import de.blau.android.nsi.Names;
@@ -751,7 +752,7 @@ public class App extends Application implements android.app.Application.Activity
     public static org.mozilla.javascript.Scriptable getRestrictedRhinoScope(@NonNull Context ctx) {
         synchronized (rhinoLock) {
             if (rhinoScope == null) {
-                org.mozilla.javascript.Context c = rhinoHelper.enterContext();
+                org.mozilla.javascript.Context c =  Utils.getRhinoContext(ctx);
                 try {
                     // this is a fairly hackish way of sandboxing, but it does work
                     rhinoScope = new ImporterTopLevel(c);

--- a/src/main/java/de/blau/android/javascript/Utils.java
+++ b/src/main/java/de/blau/android/javascript/Utils.java
@@ -46,6 +46,7 @@ public final class Utils {
     private static final String VERSION_CODE     = "versionCode";
     private static final String TODO             = "todo";
     private static final String FEATURE          = "feature";
+    private static final int    NO_OPTIMISATIONS = -1;
 
     /**
      * Empty private constructor
@@ -65,7 +66,7 @@ public final class Utils {
     @Nullable
     public static String evalString(Context ctx, String scriptName, String script) {
         Log.d(DEBUG_TAG, "Eval " + script);
-        org.mozilla.javascript.Context rhinoContext = App.getRhinoHelper(ctx).enterContext();
+        org.mozilla.javascript.Context rhinoContext = getRhinoContext(ctx);
         try {
             Scriptable restrictedScope = App.getRestrictedRhinoScope(ctx);
             Scriptable scope = rhinoContext.newObject(restrictedScope);
@@ -94,7 +95,7 @@ public final class Utils {
     @Nullable
     public static String evalString(@NonNull Context ctx, @NonNull String scriptName, @NonNull String script, @NonNull Map<String, List<String>> originalTags,
             @NonNull Map<String, List<String>> tags, @NonNull String value, @NonNull Map<String, PresetItem> key2PresetItem, @NonNull Preset[] presets) {
-        org.mozilla.javascript.Context rhinoContext = App.getRhinoHelper(ctx).enterContext();
+        org.mozilla.javascript.Context rhinoContext = getRhinoContext(ctx);
         try {
             Map<String, List<String>> savedTags = deepCopy(tags);
             Scriptable restrictedScope = App.getRestrictedRhinoScope(ctx);
@@ -153,7 +154,7 @@ public final class Utils {
      */
     @Nullable
     public static String evalString(@NonNull Context ctx, @NonNull String scriptName, @NonNull String script, @NonNull Feature feature, @NonNull Todo todo) {
-        org.mozilla.javascript.Context rhinoContext = App.getRhinoHelper(ctx).enterContext();
+        org.mozilla.javascript.Context rhinoContext = getRhinoContext(ctx);
         try {
             Scriptable restrictedScope = App.getRestrictedRhinoScope(ctx);
             Scriptable scope = rhinoContext.newObject(restrictedScope);
@@ -171,6 +172,19 @@ public final class Utils {
         } finally {
             org.mozilla.javascript.Context.exit();
         }
+    }
+
+    /**
+     * Get a Rhino Context with disabled optimisations
+     * 
+     * @param ctx an Android Context
+     * @return a Rhino Context with disabled optimizations
+     */
+    @NonNull
+    public static org.mozilla.javascript.Context getRhinoContext(@NonNull Context ctx) {
+        org.mozilla.javascript.Context rhinoContext = App.getRhinoHelper(ctx).enterContext();
+        rhinoContext.setOptimizationLevel(NO_OPTIMISATIONS);
+        return rhinoContext;
     }
 
     /**
@@ -199,7 +213,7 @@ public final class Utils {
      */
     @Nullable
     public static String evalString(@NonNull Context ctx, @NonNull String scriptName, @NonNull String script, @NonNull Logic logic) {
-        org.mozilla.javascript.Context rhinoContext = App.getRhinoHelper(ctx).enterContext();
+        org.mozilla.javascript.Context rhinoContext = getRhinoContext(ctx);
         try {
             Scriptable restrictedScope = App.getRestrictedRhinoScope(ctx);
             Scriptable scope = rhinoContext.newObject(restrictedScope);


### PR DESCRIPTION
Without this change Rhino will crash with

java.lang.NoClassDefFoundError: Failed resolution of: Ljdk/dynalink/DynamicLinkerFactory; (this is a Java 9 feature that doesn't exist in the Android VMs).