### PR TITLE
Fix ScrollView getting stuck when content and view height very similar

### DIFF
--- a/src/main/res/layout/element_info_view.xml
+++ b/src/main/res/layout/element_info_view.xml
@@ -4,12 +4,14 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:fillViewport="true"
     android:padding="?attr/dialogPreferredPadding"
+    android:clipToPadding="false"
     tools:background="@android:color/holo_green_dark"
     tools:layout_width="match_parent">
     <HorizontalScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:padding="1dp"
         android:fillViewport="true">
         <LinearLayout


### PR DESCRIPTION
This is a known Android issue, setting android:clipToPadding="false" seems to workaround it at the expense of leaving lots of empty space at the bottom of the SV.

Fixes https://github.com/MarcusWolschon/osmeditor4android/issues/3298