### PR TITLE
Don't limit the width of dialogs if we are in multi-window mode

### DIFF
--- a/src/main/java/de/blau/android/dialogs/LayerStyle.java
+++ b/src/main/java/de/blau/android/dialogs/LayerStyle.java
@@ -9,7 +9,6 @@ import com.kunzisoft.androidclearchroma.colormode.ColorMode;
 import com.kunzisoft.androidclearchroma.listener.OnColorSelectedListener;
 
 import android.annotation.SuppressLint;
-import android.app.Dialog;
 import android.content.Context;
 import android.graphics.Paint;
 import android.graphics.Paint.Style;
@@ -41,7 +40,6 @@ import de.blau.android.layer.StyleableInterface;
 import de.blau.android.listener.DoNothingListener;
 import de.blau.android.resources.symbols.Symbols;
 import de.blau.android.util.Density;
-import de.blau.android.util.Screen;
 import de.blau.android.util.ThemeUtils;
 
 /**
@@ -364,10 +362,7 @@ public class LayerStyle extends AbstractConfigurationDialog {
     @Override
     public void onStart() {
         super.onStart();
-        Dialog dialog = getDialog();
-        if (dialog != null) {
-            dialog.getWindow().setLayout((int) (Screen.getScreenSmallDimension(getActivity()) * 0.9), ViewGroup.LayoutParams.WRAP_CONTENT);
-        }
+        de.blau.android.dialogs.Util.limitWindowWidth(this);
     }
 
     @Override

--- a/src/main/java/de/blau/android/dialogs/Util.java
+++ b/src/main/java/de/blau/android/dialogs/Util.java
@@ -5,11 +5,15 @@ import static de.blau.android.contract.Constants.LOG_TAG_LEN;
 import java.util.ArrayList;
 import java.util.List;
 
+import android.app.Dialog;
 import android.content.Context;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
+import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
@@ -19,6 +23,7 @@ import de.blau.android.R;
 import de.blau.android.osm.OsmElement;
 import de.blau.android.osm.StorageDelegator;
 import de.blau.android.util.ACRAHelper;
+import de.blau.android.util.Screen;
 import de.blau.android.util.ScreenMessage;
 
 public final class Util {
@@ -147,8 +152,7 @@ public final class Util {
             return new ArrayList<>();
         }
     }
-    
-    
+
     /**
      * Check if we have saved state for a key
      * 
@@ -159,4 +163,17 @@ public final class Util {
     public static boolean hasState(@Nullable Bundle savedState, @NonNull String key) {
         return savedState != null && savedState.containsKey(key);
     }
+
+    /**
+     * Limit the dialogs width if we are on a very wide device
+     * 
+     * @param fragment the DialogFragment
+     */
+    public static void limitWindowWidth(@NonNull DialogFragment fragment) {
+        Dialog dialog = fragment.getDialog();
+        if (dialog != null && (Build.VERSION.SDK_INT <= Build.VERSION_CODES.M || !fragment.getActivity().isInMultiWindowMode())) {
+            dialog.getWindow().setLayout((int) (Screen.getScreenSmallDimension(fragment.getActivity()) * 0.9), ViewGroup.LayoutParams.WRAP_CONTENT);
+        }
+    }
+
 }

--- a/src/main/java/de/blau/android/propertyeditor/PresetSearchResultsFragment.java
+++ b/src/main/java/de/blau/android/propertyeditor/PresetSearchResultsFragment.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import android.annotation.SuppressLint;
-import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -40,7 +39,6 @@ import de.blau.android.presets.PresetItem;
 import de.blau.android.presets.PresetSeparator;
 import de.blau.android.propertyeditor.PresetFragment.OnPresetSelectedListener;
 import de.blau.android.util.ExecutorTask;
-import de.blau.android.util.Screen;
 import de.blau.android.util.ScreenMessage;
 import de.blau.android.util.ThemeUtils;
 import de.blau.android.util.Util;
@@ -270,10 +268,7 @@ public class PresetSearchResultsFragment extends DialogFragment implements Updat
     @Override
     public void onStart() {
         super.onStart();
-        Dialog dialog = getDialog();
-        if (dialog != null) {
-            dialog.getWindow().setLayout((int) (Screen.getScreenSmallDimension(getActivity()) * 0.9), ViewGroup.LayoutParams.WRAP_CONTENT);
-        }
+        de.blau.android.dialogs.Util.limitWindowWidth(this);
     }
 
     @Override

--- a/src/main/java/de/blau/android/util/InfoDialogFragment.java
+++ b/src/main/java/de/blau/android/util/InfoDialogFragment.java
@@ -2,7 +2,6 @@ package de.blau.android.util;
 
 import java.util.Locale;
 
-import android.app.Dialog;
 import android.os.Bundle;
 import android.text.Spanned;
 import android.view.LayoutInflater;
@@ -14,16 +13,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import de.blau.android.R;
 
-public abstract class InfoDialogFragment extends CancelableDialogFragment {
-
-    @Override
-    public void onStart() {
-        super.onStart();
-        Dialog dialog = getDialog();
-        if (dialog != null) {
-            dialog.getWindow().setLayout((int) (Screen.getScreenSmallDimension(getActivity()) * 0.9), ViewGroup.LayoutParams.WRAP_CONTENT);
-        }
-    }
+public abstract class InfoDialogFragment extends SizedFixedDialogFragment {
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {

--- a/src/main/java/de/blau/android/util/SizedFixedDialogFragment.java
+++ b/src/main/java/de/blau/android/util/SizedFixedDialogFragment.java
@@ -1,8 +1,5 @@
 package de.blau.android.util;
 
-import android.app.Dialog;
-import android.view.ViewGroup;
-
 /**
  * Fixed width version of DialogFragment
  */
@@ -11,10 +8,6 @@ public abstract class SizedFixedDialogFragment extends CancelableDialogFragment 
     @Override
     public void onStart() {
         super.onStart();
-        Dialog dialog = getDialog();
-        if (dialog != null) {
-            int dialogWidth = (int) (Screen.getScreenSmallDimension(getActivity()) * 0.9);
-            dialog.getWindow().setLayout(dialogWidth, ViewGroup.LayoutParams.WRAP_CONTENT);
-        }
+        de.blau.android.dialogs.Util.limitWindowWidth(this);
     }
 }


### PR DESCRIPTION
This fixes dialog/modals getting squashed in multi-window mode due to us using the smallest window dimension to determine a reasonable size (this breaks of very small windows).