### PR TITLE
Fix <init>

### DIFF
--- a/src/main/java/de/blau/android/presets/Preset.java
+++ b/src/main/java/de/blau/android/presets/Preset.java
@@ -165,10 +165,11 @@ public class Preset implements Serializable {
     /**
      * create a dummy preset
      */
-    Preset() {
-        mru = null;
-        isDefault = false;
-    }
+Preset() {
+    mru = null;
+    isDefault = false;
+    MessageDigest digest = MessageDigest.getInstance("SHA-256"); // Initialize with a valid algorithm
+}
 
     /**
      * Create a dummy Preset instance with an empty root PresetGroup

--- a/src/main/java/de/blau/android/presets/Preset.java
+++ b/src/main/java/de/blau/android/presets/Preset.java
@@ -170,20 +170,22 @@ Preset() {
     isDefault = false;
     MessageDigest digest = MessageDigest.getInstance("SHA-256"); // Initialize with a valid algorithm
 }
-
-    /**
-     * Create a dummy Preset instance with an empty root PresetGroup
-     * 
-     * @return a dummy Preset instance
-     */
-    @NonNull
-    public static Preset dummyInstance() {
-        Preset preset = new Preset(); // dummy preset to hold the elements of all
-        PresetGroup rootGroup = new PresetGroup(preset, null, "", null);
-        rootGroup.setItemSort(false);
-        preset.setRootGroup(rootGroup);
-        return preset;
-    }
+/**
+ * Create a dummy Preset instance with an empty root PresetGroup
+ * 
+ * @return a dummy Preset instance
+ */
+@NonNull
+public static Preset dummyInstance() {
+    Preset preset = new Preset(); // dummy preset to hold the elements of all
+    byte[] data = "";
+    MessageDigest messageDigest = MessageDigest.getInstance("MD5");
+    messageDigest.update(data);
+    PresetGroup rootGroup = new PresetGroup(preset, null, "", messageDigest);
+    rootGroup.setItemSort(false);
+    preset.setRootGroup(rootGroup);
+    return preset;
+}
 
     /**
      * Creates a preset object.

--- a/src/main/java/de/blau/android/presets/Preset.java
+++ b/src/main/java/de/blau/android/presets/Preset.java
@@ -170,15 +170,8 @@ Preset() {
     isDefault = false;
     MessageDigest digest = MessageDigest.getInstance("SHA-256"); // Initialize with a valid algorithm
 }
-/**
- * Create a dummy Preset instance with an empty root PresetGroup
- * 
- * @return a dummy Preset instance
- */
-@NonNull
 public static Preset dummyInstance() {
-    Preset preset = new Preset(); // dummy preset to hold the elements of all
-    byte[] data = "";
+    byte[] data = "Example Data".getBytes(); // Initialize data with some valid data
     MessageDigest messageDigest = MessageDigest.getInstance("MD5");
     messageDigest.update(data);
     PresetGroup rootGroup = new PresetGroup(preset, null, "", messageDigest);


### PR DESCRIPTION
# Fix: `<init>`

## Explanation

The `dummyInstance()` method creates a new `Preset` instance with an empty

---

## Modified Method

| Property | Value |
|---|---|
| Method | `<init>` |
| Class | `de.blau.android.presets.Preset` |
| File | `/mnt/c/Users/Antonow/Documents/tcc_v3/outputs/cloned_projects/de.blau.android_3404.apk/src/main/java/de/blau/android/presets/Preset.java` |
| Status | `SUCCESS` |

---

## Changed File

```text
/mnt/c/Users/Antonow/Documents/tcc_v3/outputs/cloned_projects/de.blau.android_3404.apk/src/main/java/de/blau/android/presets/Preset.java
```

---


## Validation Checklist

- [x] Method replaced in source file
- [x] Repository updated
- [x] Commit generated
- [ ] Manual review required
- [ ] CI validation pending

---

Repair Pipeline