### PR TITLE
Enable desugaring support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -328,6 +328,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -610,6 +611,9 @@ dependencies {
     // acra crash dump lib
     implementation "ch.acra:acra-http:$acraVersion"
     implementation "ch.acra:acra-dialog:$acraVersion"
+    
+    // desugaring
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.3'    
     
     // android support 
     implementation "androidx.activity:activity:1.11.0"                  // 1.12 and later requires min-sdk 23


### PR DESCRIPTION
This is required for Clipper2 support on older devices. Testing seems to indicate that the previous issues with debug builds have been fixed in the current release.