### PR TITLE
Split single lock

### DIFF
--- a/src/main/java/de/blau/android/Logic.java
+++ b/src/main/java/de/blau/android/Logic.java
@@ -34,7 +34,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.regex.Matcher;
 
 import javax.net.ssl.SSLProtocolException;
@@ -235,7 +235,9 @@ public class Logic {
     /**
      * This is used instead of synchronized
      */
-    private ReentrantLock lock = new ReentrantLock();
+    private ReentrantReadWriteLock           lock      = new ReentrantReadWriteLock();
+    private ReentrantReadWriteLock.WriteLock writeLock = lock.writeLock();
+    private ReentrantReadWriteLock.ReadLock  readLock  = lock.readLock();
 
     /**
      * Stores the {@link Preferences} as soon as they are available.
@@ -795,7 +797,7 @@ public class Logic {
             }
         }
         try {
-            lock();
+            lockWrites();
             if (createCheckpoint) {
                 createCheckpoint(activity, R.string.undo_action_set_tags);
             }
@@ -804,7 +806,7 @@ public class Logic {
             handleDelegatorException(activity, ex, createCheckpoint);
             throw ex; // rethrow
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -826,7 +828,7 @@ public class Logic {
             return false;
         }
         try {
-            lock();
+            lockWrites();
             List<Relation> originalParents = osmElement.hasParentRelations() ? new ArrayList<>(osmElement.getParentRelations()) : null;
             createCheckpoint(activity, R.string.undo_action_update_relations);
             getDelegator().updateParentRelations(osmElement, parents);
@@ -838,7 +840,7 @@ public class Logic {
             handleDelegatorException(activity, ex, true);
             throw ex; // rethrow
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -859,7 +861,7 @@ public class Logic {
             return false;
         }
         try {
-            lock();
+            lockWrites();
             createCheckpoint(activity, R.string.undo_action_update_relations);
             getDelegator().updateRelation((Relation) osmElement, members);
             return true;
@@ -867,7 +869,7 @@ public class Logic {
             handleDelegatorException(activity, ex, true);
             throw ex; // rethrow
         } finally {
-            unlock();
+            unlockWrites();
         }
 
     }
@@ -1095,7 +1097,7 @@ public class Logic {
         float minLenForHandle = currentStyle.getMinLenForHandle();
 
         try {
-            lock();
+            lockReads();
             List<Way> ways = getSelectedWays();
             if (ways == null) {
                 return null;
@@ -1135,7 +1137,7 @@ public class Logic {
                 }
             }
         } finally {
-            unlock();
+            unlockReads();
         }
         return result;
     }
@@ -1210,7 +1212,7 @@ public class Logic {
      */
     @NonNull
     private List<Node> getClickableNodes() {
-        List<Node> nodes = getNodes(map.getViewBox());
+        List<Node> nodes = getDelegator().getNodes(map.getViewBox());
         if (filter == null) {
             return nodes;
         }
@@ -1339,11 +1341,17 @@ public class Logic {
     @NonNull
     public Set<OsmElement> findClickableElements(@NonNull BoundingBox viewBox, @NonNull List<OsmElement> excludes) {
         Set<OsmElement> result = new HashSet<>();
-        final Storage currentStorage = getDelegator().getCurrentStorage();
-        result.addAll(currentStorage.getNodes(viewBox));
-        result.addAll(currentStorage.getWays(viewBox));
-        if (returnRelations) {
-            result.addAll(currentStorage.getRelations());
+        final StorageDelegator delegator = getDelegator();
+        try { // we probably could move this to StorageDelegator
+            delegator.lockReads();
+            final Storage currentStorage = delegator.getCurrentStorage();
+            result.addAll(currentStorage.getNodes(viewBox));
+            result.addAll(currentStorage.getWays(viewBox));
+            if (returnRelations) {
+                result.addAll(currentStorage.getRelations());
+            }
+        } finally {
+            delegator.unlockReads();
         }
         for (OsmElement e : excludes) {
             result.remove(e);
@@ -1359,7 +1367,7 @@ public class Logic {
      */
     @NonNull
     public List<Way> getWaysForNode(@NonNull final Node node) {
-        return getDelegator().getCurrentStorage().getWays(node);
+        return getDelegator().getWaysForNode(node);
     }
 
     /**
@@ -1371,22 +1379,12 @@ public class Logic {
     @NonNull
     public List<Way> getFilteredWaysForNode(@NonNull final Node node) {
         List<Way> ways = new ArrayList<>();
-        for (Way w : getDelegator().getCurrentStorage().getWays(node)) {
+        for (Way w : getWaysForNode(node)) {
             if (getFilter() == null || filter.include(w, false)) {
                 ways.add(w);
             }
         }
         return ways;
-    }
-
-    /**
-     * Test if the given Node is an end node of a Way. Isolated nodes not part of a way are not considered an end node.
-     * 
-     * @param node Node to test.
-     * @return true if the Node is an end node of a Way, false otherwise.
-     */
-    public boolean isEndNode(@Nullable final Node node) {
-        return getDelegator().getCurrentStorage().isEndNode(node);
     }
 
     /**
@@ -1427,7 +1425,7 @@ public class Logic {
                 return;
             }
             try {
-                lock();
+                lockReads();
                 Task selectedTask = null;
                 de.blau.android.layer.tasks.MapOverlay taskLayer = map.getTaskLayer();
                 if (taskLayer != null) {
@@ -1514,20 +1512,20 @@ public class Logic {
                     }
                 }
             } finally {
-                unlock();
+                unlockReads();
             }
         }
         Log.d(DEBUG_TAG, "handleTouchEventDown creating checkpoints");
         if ((draggingNode || draggingWay)) {
             try {
-                lock();
+                lockWrites();
                 if (draggingMultiselect) {
                     createCheckpoint(activity, R.string.undo_action_moveobjects);
                 } else {
                     createCheckpoint(activity, draggingNode ? R.string.undo_action_movenode : R.string.undo_action_moveway);
                 }
             } finally {
-                unlock();
+                unlockWrites();
             }
         }
     }
@@ -1557,11 +1555,11 @@ public class Logic {
      */
     void handleTouchEventUp(final float x, final float y) {
         try {
-            lock();
+            lockReads();
             handleNode = null;
             draggingHandle = false;
         } finally {
-            unlock();
+            unlockReads();
         }
     }
 
@@ -1570,7 +1568,7 @@ public class Logic {
      */
     public void showCrosshairsForCentroid() {
         try {
-            lock();
+            lockReads();
             int[] coords = calcCentroid(selectionStack.getFirst().getAll());
             if (coords.length == 2) {
                 centroidX = lonE7ToX(coords[1]);
@@ -1580,7 +1578,7 @@ public class Logic {
                 Log.e(DEBUG_TAG, "Unable to calcualte centroid for selection");
             }
         } finally {
-            unlock();
+            unlockReads();
         }
     }
 
@@ -1598,7 +1596,7 @@ public class Logic {
      */
     void handleTouchEventMove(@NonNull Main main, final float absoluteX, final float absoluteY, final float relativeX, final float relativeY) {
         try {
-            lock();
+            lockWrites();
             final Selection currentSelection = selectionStack.getFirst();
             if (draggingNode || draggingWay || draggingHandle || draggingNote) {
                 int lat = yToLatE7(absoluteY);
@@ -1693,7 +1691,7 @@ public class Logic {
         } catch (IllegalOperationException e) { // generated by moving a note
             ScreenMessage.barError(main, e.getMessage());
         } finally {
-            unlock();
+            unlockWrites();
         }
         invalidateMap();
     }
@@ -1905,7 +1903,7 @@ public class Logic {
             throws OsmIllegalOperationException {
         Log.d(DEBUG_TAG, "performAdd");
         try {
-            lock();
+            lockWrites();
             if (createCheckpoint) {
                 createCheckpoint(activity, R.string.undo_action_add);
             }
@@ -1958,7 +1956,7 @@ public class Logic {
             handleDelegatorException(activity, ex, true);
             throw ex; // rethrow
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -2062,7 +2060,7 @@ public class Logic {
     public Node performAddNode(@Nullable final FragmentActivity activity, int lonE7, int latE7) {
         Log.d(DEBUG_TAG, "performAddNode");
         try {
-            lock();
+            lockWrites();
             createCheckpoint(activity, R.string.undo_action_add);
             Node newNode = getDelegator().getFactory().createNodeWithNewId(latE7, lonE7);
             getDelegator().insertElementSafe(newNode);
@@ -2073,7 +2071,7 @@ public class Logic {
             handleDelegatorException(activity, ex, true);
             throw ex; // rethrow
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -2094,7 +2092,7 @@ public class Logic {
     public Node performAddOnWay(@Nullable Activity activity, @Nullable List<Way> ways, final float x, final float y, boolean forceNew)
             throws OsmIllegalOperationException {
         try {
-            lock();
+            lockWrites();
             Node savedSelectedNode = getSelectedNode();
             Node newSelectedNode = addOnWay(activity, ways, x, y, forceNew);
             if (newSelectedNode == null) {
@@ -2104,7 +2102,7 @@ public class Logic {
             setSelectedNode(newSelectedNode);
             return newSelectedNode;
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -2140,7 +2138,7 @@ public class Logic {
      */
     public void performEraseNode(@Nullable final FragmentActivity activity, @NonNull final Node node, boolean createCheckpoint) {
         try {
-            lock();
+            lockWrites();
             if (createCheckpoint) {
                 createCheckpoint(activity, R.string.undo_action_deletenode);
             }
@@ -2149,7 +2147,7 @@ public class Logic {
             invalidateMap();
             outsideOfDownload(activity, node.getLon(), node.getLat());
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -2203,7 +2201,7 @@ public class Logic {
      */
     public void performEraseWay(@Nullable final FragmentActivity activity, @NonNull final Way way, final boolean deleteOrphanNodes, boolean createCheckpoint) {
         try {
-            lock();
+            lockWrites();
             if (createCheckpoint) {
                 createCheckpoint(activity, R.string.undo_action_deleteway);
             }
@@ -2223,7 +2221,7 @@ public class Logic {
             handleDelegatorException(activity, ex, true);
             throw ex; // rethrow
         } finally {
-            unlock();
+            unlockWrites();
         }
         invalidateMap();
     }
@@ -2237,7 +2235,7 @@ public class Logic {
      */
     public void performEraseRelation(@Nullable final FragmentActivity activity, @NonNull final Relation relation, boolean createCheckpoint) {
         try {
-            lock();
+            lockWrites();
             if (createCheckpoint) {
                 createCheckpoint(activity, R.string.undo_action_delete_relation);
             }
@@ -2247,7 +2245,7 @@ public class Logic {
             handleDelegatorException(activity, ex, true);
             throw ex; // rethrow
         } finally {
-            unlock();
+            unlockWrites();
         }
         invalidateMap();
     }
@@ -2262,7 +2260,7 @@ public class Logic {
      */
     public void performEraseMultipleObjects(@Nullable final FragmentActivity activity, @NonNull List<OsmElement> selection) {
         try {
-            lock();
+            lockWrites();
             // need to make three passes
             createCheckpoint(activity, R.string.undo_action_delete_objects);
             displayAttachedObjectWarning(activity, selection); // needs to be done before removal
@@ -2282,7 +2280,7 @@ public class Logic {
                 }
             }
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -2323,7 +2321,7 @@ public class Logic {
     @NonNull
     public List<Result> performSplit(@Nullable final FragmentActivity activity, @NonNull final Way way, @NonNull final Node node, boolean fromEnd) {
         try {
-            lock();
+            lockWrites();
             createCheckpoint(activity, R.string.undo_action_split_way);
             List<Result> result = getDelegator().splitAtNode(way, node, fromEnd);
             invalidateMap();
@@ -2332,7 +2330,7 @@ public class Logic {
             handleDelegatorException(activity, ex, true);
             throw ex; // rethrow
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -2352,7 +2350,7 @@ public class Logic {
     public List<Result> performClosedWaySplit(@Nullable FragmentActivity activity, @NonNull Way way, @NonNull Node node1, @NonNull Node node2,
             boolean createPolygons) {
         try {
-            lock();
+            lockWrites();
             createCheckpoint(activity, R.string.undo_action_split_way);
             displayAttachedObjectWarning(activity, way);
             List<Result> results = getDelegator().splitAtNodes(way, node1, node2, createPolygons);
@@ -2365,7 +2363,7 @@ public class Logic {
             handleDelegatorException(activity, ex, true);
             throw ex; // rethrow
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -2381,7 +2379,7 @@ public class Logic {
     @NonNull
     public List<Result> performExtractSegment(@Nullable FragmentActivity activity, @NonNull Way way, @NonNull Node node1, @NonNull Node node2) {
         try {
-            lock();
+            lockWrites();
             createCheckpoint(activity, R.string.undo_action_extract_segment);
             displayAttachedObjectWarning(activity, way);
             List<Result> result = null;
@@ -2410,7 +2408,7 @@ public class Logic {
             handleDelegatorException(activity, ex, true);
             throw ex;
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -2455,7 +2453,7 @@ public class Logic {
      */
     public void performRemoveNodeFromWay(@Nullable FragmentActivity activity, @NonNull Way way, @NonNull Node node) {
         try {
-            lock();
+            lockWrites();
             createCheckpoint(activity, R.string.undo_action_remove_node_from_way);
             displayAttachedObjectWarning(activity, node);
             getDelegator().removeNodeFromWay(way, node);
@@ -2463,7 +2461,7 @@ public class Logic {
             handleDelegatorException(activity, ex, true);
             throw ex;
         } finally {
-            unlock();
+            unlockWrites();
         }
         invalidateMap();
     }
@@ -2481,7 +2479,7 @@ public class Logic {
     public void performRemoveEndNodeFromWay(@Nullable FragmentActivity activity, boolean fromEnd, @NonNull Way way, boolean deleteNode,
             boolean createCheckPoint) {
         try {
-            lock();
+            lockWrites();
             if (createCheckPoint) {
                 createCheckpoint(activity, R.string.undo_action_remove_node_from_way);
             }
@@ -2491,7 +2489,7 @@ public class Logic {
             handleDelegatorException(activity, ex, createCheckPoint);
             throw ex;
         } finally {
-            unlock();
+            unlockWrites();
         }
         invalidateMap();
     }
@@ -2509,7 +2507,7 @@ public class Logic {
     public List<Result> performMerge(@Nullable final FragmentActivity activity, @NonNull Way mergeInto, @NonNull Way mergeFrom) {
         createCheckpoint(activity, R.string.undo_action_merge_ways);
         try {
-            lock();
+            lockWrites();
             displayAttachedObjectWarning(activity, mergeInto, mergeFrom, true); // needs to be done before merge
             MergeAction action = new MergeAction(getDelegator(), mergeInto, mergeFrom, getSelectedIds());
             return action.mergeWays();
@@ -2517,7 +2515,7 @@ public class Logic {
             handleDelegatorException(activity, ex, true);
             throw ex; // rethrow
         } finally {
-            unlock();
+            unlockWrites();
             invalidateMap();
         }
     }
@@ -2532,7 +2530,7 @@ public class Logic {
     @NonNull
     public List<Result> performMerge(@Nullable FragmentActivity activity, @NonNull List<OsmElement> sortedWays) {
         try {
-            lock();
+            lockWrites();
             createCheckpoint(activity, R.string.undo_action_merge_ways);
             displayAttachedObjectWarning(activity, sortedWays, true); // needs to be done before merge
             if (sortedWays.isEmpty()) {
@@ -2571,7 +2569,7 @@ public class Logic {
             handleDelegatorException(activity, ex, true);
             throw ex; // rethrow
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -2584,7 +2582,7 @@ public class Logic {
      */
     public List<Result> performPolygonMerge(@Nullable FragmentActivity activity, @NonNull List<Way> ways) {
         try {
-            lock();
+            lockWrites();
             createCheckpoint(activity, R.string.undo_action_merge_polygons);
             displayAttachedObjectWarning(activity, ways, true); // needs to be done before merge
             if (!(ways.size() == 2 && ways.get(0).isClosed() && ways.get(1).isClosed())) {
@@ -2596,7 +2594,7 @@ public class Logic {
             handleDelegatorException(activity, ex, true);
             throw ex; // rethrow
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -2678,7 +2676,7 @@ public class Logic {
             return null;
         }
         try {
-            lock();
+            lockWrites();
             createCheckpoint(activity, R.string.undo_action_extract_node);
             displayAttachedObjectWarning(activity, node); // this needs to be done -before- we replace the node
             Node newNode = getDelegator().replaceNode(node);
@@ -2688,7 +2686,7 @@ public class Logic {
             handleDelegatorException(activity, ex, true);
             throw ex; // rethrow
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -2759,7 +2757,7 @@ public class Logic {
             return overallResult;
         }
         try {
-            lock();
+            lockWrites();
             createCheckpoint(activity, R.string.undo_action_join);
             Result result = null;
             for (OsmElement element : elements) {
@@ -2790,7 +2788,7 @@ public class Logic {
                 }
             }
         } finally {
-            unlock();
+            unlockWrites();
         }
         invalidateMap();
         return overallResult;
@@ -2812,7 +2810,7 @@ public class Logic {
         List<Result> result = null;
         final float tolerance = map.getDataStyleManager().getCurrent().getWayToleranceValue() / 2f;
         try {
-            lock();
+            lockWrites();
             createCheckpoint(activity, R.string.undo_action_join);
             for (OsmElement element : elements) {
                 if (!(element instanceof Way)) {
@@ -2884,7 +2882,7 @@ public class Logic {
                 }
             }
         } finally {
-            unlock();
+            unlockWrites();
         }
         invalidateMap();
         return result != null ? result : new ArrayList<>();
@@ -2898,7 +2896,7 @@ public class Logic {
      */
     public void performUnjoinWays(@Nullable FragmentActivity activity, @NonNull Node node) {
         try {
-            lock();
+            lockWrites();
             createCheckpoint(activity, R.string.undo_action_unjoin_ways);
             displayAttachedObjectWarning(activity, node); // needs to be done before unjoin
             getDelegator().unjoinWays(node);
@@ -2906,7 +2904,7 @@ public class Logic {
             handleDelegatorException(activity, ex, true);
             throw ex; // rethrow
         } finally {
-            unlock();
+            unlockWrites();
             invalidateMap();
         }
     }
@@ -2922,7 +2920,7 @@ public class Logic {
     @NonNull
     public List<Node> performUnjoinWay(@Nullable FragmentActivity activity, @NonNull Way way, @Nullable String primaryKey) {
         try {
-            lock();
+            lockWrites();
             final StorageDelegator delegator = getDelegator();
             createCheckpoint(activity, R.string.undo_action_unjoin_ways);
             if (!delegator.isInDownload(way)) {
@@ -2934,7 +2932,7 @@ public class Logic {
             handleDelegatorException(activity, ex, true);
             throw ex; // rethrow
         } finally {
-            unlock();
+            unlockWrites();
             invalidateMap();
         }
     }
@@ -2952,14 +2950,14 @@ public class Logic {
     @NonNull
     public List<Result> performReverse(@Nullable FragmentActivity activity, @NonNull Way way) {
         try {
-            lock();
+            lockWrites();
             createCheckpoint(activity, R.string.undo_action_reverse_way);
             return getDelegator().reverseWay(way);
         } catch (OsmIllegalOperationException | StorageException ex) {
             handleDelegatorException(activity, ex, true);
             throw ex; // rethrow
         } finally {
-            unlock();
+            unlockWrites();
             invalidateMap();
         }
     }
@@ -2972,11 +2970,11 @@ public class Logic {
      */
     public void performAppendStart(@Nullable Way way, @Nullable Node node) {
         try {
-            lock();
+            lockWrites();
             setSelectedNode(node);
             setSelectedWay(way);
         } finally {
-            unlock();
+            unlockWrites();
         }
         invalidateMap();
     }
@@ -2998,7 +2996,7 @@ public class Logic {
             throws OsmIllegalOperationException {
         Log.d(DEBUG_TAG, "performAppendAppend");
         try {
-            lock();
+            lockWrites();
             if (createCheckpoint) {
                 createCheckpoint(activity, R.string.undo_action_append);
             }
@@ -3024,7 +3022,7 @@ public class Logic {
             }
             throw e;
         } finally {
-            unlock();
+            unlockWrites();
         }
         invalidateMap();
     }
@@ -3043,7 +3041,7 @@ public class Logic {
     public <T extends GeoPoint> List<Result> performReplaceGeometry(@Nullable final FragmentActivity activity, @NonNull Way target, @NonNull List<T> geometry) {
         StorageDelegator delegator = getDelegator();
         try {
-            lock();
+            lockWrites();
             createCheckpoint(activity, R.string.undo_action_replace_geometry);
             if (!delegator.isInDownload(target)) {
                 throw new OsmIllegalOperationException(App.getString(activity, R.string.toast_all_way_nodes_download));
@@ -3091,7 +3089,7 @@ public class Logic {
             handleDelegatorException(activity, ex, true);
             throw ex; // rethrow
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -3172,7 +3170,7 @@ public class Logic {
     private Node getClickedNodeOrCreatedWayNode(@Nullable List<Way> ways, final float x, final float y, boolean forceNew) throws OsmIllegalOperationException {
         Node node = null;
         try {
-            lock();
+            lockWrites();
             if (!forceNew) {
                 node = getClickedNode(x, y);
                 if (node != null) {
@@ -3235,7 +3233,7 @@ public class Logic {
                 }
             }
         } finally {
-            unlock();
+            unlockWrites();
         }
         return node;
     }
@@ -3469,7 +3467,7 @@ public class Logic {
                 }
             }
             // don't have to lock before we are here
-            lock();
+            lockWrites();
             if (!background) {
                 // Main maybe not be available and by extension there may be no valid Map object
                 Map currentMap = ctx instanceof Main ? ((Main) ctx).getMap() : null;
@@ -3524,7 +3522,7 @@ public class Logic {
         } catch (Exception e) {
             result = new AsyncResult(ErrorCodes.UNKNOWN_ERROR, e.getMessage());
         } finally {
-            unlock();
+            unlockWrites();
         }
         if (result.getCode() != ErrorCodes.OK) {
             removeBoundingBox(mapBox);
@@ -4147,7 +4145,7 @@ public class Logic {
         }
         final StorageDelegator delegator = getDelegator();
         try {
-            delegator.lock();
+            delegator.lockWrites();
             if (e.getName().equals(Node.NAME)) {
                 delegator.removeNode((Node) e);
             } else if (e.getName().equals(Way.NAME)) {
@@ -4157,7 +4155,7 @@ public class Logic {
             }
             delegator.removeFromUpload(e, OsmElement.STATE_DELETED);
         } finally {
-            delegator.unlock();
+            delegator.unlockWrites();
         }
     }
 
@@ -4172,10 +4170,10 @@ public class Logic {
         createCheckpoint(activity, R.string.undo_action_fix_conflict);
         final StorageDelegator delegator = getDelegator();
         try {
-            delegator.lock();
+            delegator.lockWrites();
             getDelegator().removeFromUpload(e, OsmElement.STATE_UNCHANGED); // this will allow merging to replace it
         } finally {
-            delegator.unlock();
+            delegator.unlockWrites();
         }
         downloadElement(activity, e.getName(), e.getOsmId(), false, true, new PostAsyncActionHandler() {
 
@@ -4453,7 +4451,7 @@ public class Logic {
                     OsmChangeParser oscParser = new OsmChangeParser();
                     oscParser.clearBoundingBoxes(); // this removes the default bounding box
                     oscParser.start(in);
-                    lock();
+                    lockWrites();
                     List<Long> missing = new ArrayList<>();
                     for (Way w : oscParser.getStorage().getWays()) {
                         for (Node n : w.getNodes()) {
@@ -4492,7 +4490,7 @@ public class Logic {
                     return new AsyncResult(sd.isDirty() ? ErrorCodes.OUT_OF_MEMORY_DIRTY : ErrorCodes.OUT_OF_MEMORY);
                 } finally {
                     SavingHelper.close(is);
-                    unlock();
+                    unlockWrites();
                 }
                 return new AsyncResult(ErrorCodes.OK, null);
             }
@@ -4506,8 +4504,9 @@ public class Logic {
      */
     void save(@NonNull final Context context) {
         try {
+            // this is locked in StorageDelegator
             getDelegator().writeToFile(context);
-            lock();
+            lockReads();
             App.getTaskStorage().writeToFile(context);
             if (map != null) {
                 map.saveLayerState(context);
@@ -4515,7 +4514,7 @@ public class Logic {
         } catch (IOException e) {
             Log.e(DEBUG_TAG, "Problem saving", e);
         } finally {
-            unlock();
+            unlockReads();
         }
     }
 
@@ -4545,7 +4544,7 @@ public class Logic {
      */
     void saveEditingState(@NonNull Main main) {
         try {
-            lock();
+            lockReads();
             if (editingStateRead) {
                 EditState editState = new EditState(main, this, main.getImageFileName(), null, viewBox, main.getFollowGPS(),
                         prefs.getServer().getOpenChangeset());
@@ -4555,7 +4554,7 @@ public class Logic {
                 Log.w(DEBUG_TAG, "EditingState not loaded skipping save");
             }
         } finally {
-            unlock();
+            unlockReads();
         }
     }
 
@@ -5169,12 +5168,12 @@ public class Logic {
      */
     public void setSelectedNode(@Nullable final Node selectedNode) {
         try {
-            lock();
+            lockWrites();
             selectionStack.getFirst().setNode(selectedNode);
             map.setSelectedNodes(selectionStack.getFirst().getNodes());
             resetFilterCache();
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -5185,11 +5184,11 @@ public class Logic {
      */
     public void addSelectedNode(@NonNull final Node selectedNode) {
         try {
-            lock();
+            lockWrites();
             selectionStack.getFirst().add(selectedNode);
             resetFilterCache();
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -5199,10 +5198,10 @@ public class Logic {
     @Nullable
     public final Node getSelectedNode() {
         try {
-            lock();
+            lockReads();
             return selectionStack.getFirst().getNode();
         } finally {
-            unlock();
+            unlockReads();
         }
     }
 
@@ -5214,10 +5213,10 @@ public class Logic {
     @Nullable
     public List<Node> getSelectedNodes() {
         try {
-            lock();
+            lockReads();
             return selectionStack.getFirst().getNodes();
         } finally {
-            unlock();
+            unlockReads();
         }
     }
 
@@ -5228,10 +5227,10 @@ public class Logic {
      */
     public int selectedNodesCount() {
         try {
-            lock();
+            lockReads();
             return selectionStack.getFirst().nodeCount();
         } finally {
-            unlock();
+            unlockReads();
         }
     }
 
@@ -5242,12 +5241,12 @@ public class Logic {
      */
     public void removeSelectedNode(@NonNull Node node) {
         try {
-            lock();
+            lockWrites();
             if (selectionStack.getFirst().remove(node)) {
                 resetFilterCache();
             }
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -5258,12 +5257,12 @@ public class Logic {
      */
     public void setSelectedWay(@Nullable final Way selectedWay) {
         try {
-            lock();
+            lockWrites();
             selectionStack.getFirst().setWay(selectedWay);
             map.setSelectedWays(selectionStack.getFirst().getWays());
             resetFilterCache();
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -5274,11 +5273,11 @@ public class Logic {
      */
     public void addSelectedWay(@NonNull final Way selectedWay) {
         try {
-            lock();
+            lockWrites();
             selectionStack.getFirst().add(selectedWay);
             resetFilterCache();
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -5288,10 +5287,10 @@ public class Logic {
     @Nullable
     public final Way getSelectedWay() {
         try {
-            lock();
+            lockReads();
             return selectionStack.getFirst().getWay();
         } finally {
-            unlock();
+            unlockReads();
         }
     }
 
@@ -5303,10 +5302,10 @@ public class Logic {
     @Nullable
     public List<Way> getSelectedWays() {
         try {
-            lock();
+            lockReads();
             return selectionStack.getFirst().getWays();
         } finally {
-            unlock();
+            unlockReads();
         }
     }
 
@@ -5317,10 +5316,10 @@ public class Logic {
      */
     public int selectedWaysCount() {
         try {
-            lock();
+            lockReads();
             return selectionStack.getFirst().wayCount();
         } finally {
-            unlock();
+            unlockReads();
         }
     }
 
@@ -5331,12 +5330,12 @@ public class Logic {
      */
     public void removeSelectedWay(@NonNull Way way) {
         try {
-            lock();
+            lockWrites();
             if (selectionStack.getFirst().remove(way)) {
                 resetFilterCache();
             }
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -5348,14 +5347,14 @@ public class Logic {
 
     public void setSelectedRelation(@Nullable final Relation selectedRelation) {
         try {
-            lock();
+            lockWrites();
             selectionStack.getFirst().setRelation(selectedRelation);
             if (selectedRelation != null) {
                 setSelectedRelationMembers(selectedRelation);
             }
             resetFilterCache();
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -5366,7 +5365,7 @@ public class Logic {
      */
     public void removeSelectedRelation(@NonNull Relation relation) {
         try {
-            lock();
+            lockWrites();
             if (selectionStack.getFirst().remove(relation)) {
                 setSelectedRelationNodes(null); // de-select all
                 setSelectedRelationWays(null);
@@ -5379,7 +5378,7 @@ public class Logic {
                 resetFilterCache();
             }
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -5390,12 +5389,12 @@ public class Logic {
      */
     public void addSelectedRelation(@NonNull final Relation selectedRelation) {
         try {
-            lock();
+            lockWrites();
             selectionStack.getFirst().add(selectedRelation);
             setSelectedRelationMembers(selectedRelation);
             resetFilterCache();
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -5407,10 +5406,10 @@ public class Logic {
     @Nullable
     public List<Relation> getSelectedRelations() {
         try {
-            lock();
+            lockReads();
             return selectionStack.getFirst().getRelations();
         } finally {
-            unlock();
+            unlockReads();
         }
     }
 
@@ -5421,10 +5420,10 @@ public class Logic {
      */
     public int selectedRelationsCount() {
         try {
-            lock();
+            lockReads();
             return selectionStack.getFirst().relationCount();
         } finally {
-            unlock();
+            unlockReads();
         }
     }
 
@@ -5435,14 +5434,14 @@ public class Logic {
      */
     public void setSelection(@NonNull List<OsmElement> elements) {
         try {
-            lock();
+            lockWrites();
             Selection currentSelection = selectionStack.getFirst();
             for (OsmElement e : elements) {
                 currentSelection.add(e);
             }
             resetFilterCache();
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -5462,9 +5461,9 @@ public class Logic {
      */
     @NonNull
     public List<OsmElement> getSelectedElements() {
+        List<OsmElement> result = new ArrayList<>();
         try {
-            lock();
-            List<OsmElement> result = new ArrayList<>();
+            lockReads();
             final Selection currentSelection = selectionStack.getFirst();
             List<Node> selectedNodes = currentSelection.getNodes();
             if (selectedNodes != null) {
@@ -5480,7 +5479,7 @@ public class Logic {
             }
             return result;
         } finally {
-            unlock();
+            unlockReads();
         }
     }
 
@@ -5491,10 +5490,10 @@ public class Logic {
      */
     public Ids getSelectedIds() {
         try {
-            lock();
+            lockReads();
             return selectionStack.getFirst().getIds();
         } finally {
-            unlock();
+            unlockReads();
         }
     }
 
@@ -5545,39 +5544,11 @@ public class Logic {
      */
     public boolean isSelected(@Nullable OsmElement e) {
         try {
-            lock();
+            lockReads();
             return e != null && selectionStack.getFirst().contains(e);
         } finally {
-            unlock();
+            unlockReads();
         }
-    }
-
-    /**
-     * Get a list of all nodes currently in storage
-     * 
-     * @return unmodifiable list of all nodes currently loaded
-     */
-    public List<Node> getNodes() {
-        return getDelegator().getCurrentStorage().getNodes();
-    }
-
-    /**
-     * Get a list of all nodes contained in bounding box box currently in storage
-     * 
-     * @param box the bounding box
-     * @return unmodifiable list of all nodes currently loaded contained in box
-     */
-    public List<Node> getNodes(BoundingBox box) {
-        return getDelegator().getCurrentStorage().getNodes(box);
-    }
-
-    /**
-     * Get a list of all modified (created, modified, deleted) nodes currently in storage
-     * 
-     * @return all modified nodes currently loaded
-     */
-    public List<Node> getModifiedNodes() {
-        return getDelegator().getApiStorage().getNodes();
     }
 
     /**
@@ -5688,12 +5659,7 @@ public class Logic {
      * @return a list of all pending changes to upload
      */
     public List<OsmElement> getPendingChangedElements() {
-        try {
-            lock();
-            return getDelegator().listChangedElements();
-        } finally {
-            unlock();
-        }
+        return getDelegator().listChangedElements();
     }
 
     /**
@@ -5709,10 +5675,10 @@ public class Logic {
     @SuppressWarnings("unchecked")
     public <T extends OsmElement> void setClickableElements(Set<T> clickable) {
         try {
-            lock();
+            lockWrites();
             clickableElements = (Set<OsmElement>) clickable;
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -5724,10 +5690,10 @@ public class Logic {
     @Nullable
     public Set<OsmElement> getClickableElements() {
         try {
-            lock();
+            lockReads();
             return clickableElements;
         } finally {
-            unlock();
+            unlockReads();
         }
     }
 
@@ -6028,7 +5994,7 @@ public class Logic {
             return;
         }
         try {
-            lock();
+            lockWrites();
             for (RelationMember rm : r.getMembers()) {
                 OsmElement e = rm.getElement();
                 if (e != null) {
@@ -6052,7 +6018,7 @@ public class Logic {
                 }
             }
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -6118,7 +6084,7 @@ public class Logic {
      */
     public void setSelectedRelationRelations(List<Relation> relations) {
         try {
-            lock();
+            lockWrites();
             selectedRelationRelations = relations;
             if (selectedRelationRelations != null) {
                 for (Relation r : selectedRelationRelations) {
@@ -6126,7 +6092,7 @@ public class Logic {
                 }
             }
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -6147,14 +6113,14 @@ public class Logic {
      */
     private void addSelectedRelationRelation(@NonNull Relation relation, int depth) {
         try {
-            lock();
+            lockWrites();
             if (selectedRelationRelations == null) {
                 selectedRelationRelations = new LinkedList<>();
             }
             selectedRelationRelations.add(relation);
             setSelectedRelationMembers(relation, depth);
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -6165,12 +6131,12 @@ public class Logic {
      */
     public void removeSelectedRelationRelation(@NonNull Relation relation) {
         try {
-            lock();
+            lockWrites();
             if (selectedRelationRelations != null) {
                 selectedRelationRelations.remove(relation);
             }
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -6182,10 +6148,10 @@ public class Logic {
     @Nullable
     public List<Relation> getSelectedRelationRelations() {
         try {
-            lock();
+            lockReads();
             return selectedRelationRelations;
         } finally {
-            unlock();
+            unlockReads();
         }
     }
 
@@ -6194,7 +6160,7 @@ public class Logic {
      */
     public void reselectRelationMembers() {
         try {
-            lock();
+            lockWrites();
             List<Relation> selected = getSelectedRelations();
             if (selected != null && !selected.isEmpty()) {
                 if (selectedRelationNodes != null) {
@@ -6211,7 +6177,7 @@ public class Logic {
                 }
             }
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -6237,10 +6203,10 @@ public class Logic {
     @NonNull
     public Deque<Selection> getSelectionStack() {
         try {
-            lock();
+            lockReads();
             return selectionStack;
         } finally {
-            unlock();
+            unlockReads();
         }
     }
 
@@ -6251,7 +6217,7 @@ public class Logic {
      */
     public void setSelectionStack(@NonNull Deque<Selection> stack) {
         try {
-            lock();
+            lockWrites();
             if (!stack.isEmpty()) { // the stack needs to have at least one element
                 selectionStack.clear();
                 selectionStack.addAll(stack);
@@ -6260,7 +6226,7 @@ public class Logic {
                 Log.e(DEBUG_TAG, "Attempt to set empty selection stack");
             }
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -6269,14 +6235,14 @@ public class Logic {
      */
     private void selectFromTop() {
         try {
-            lock();
+            lockWrites();
             final Selection currentSelection = selectionStack.getFirst();
             map.setSelectedNodes(currentSelection.getNodes());
             map.setSelectedWays(currentSelection.getWays());
             reselectRelationMembers();
             resetFilterCache();
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -6285,7 +6251,7 @@ public class Logic {
      */
     public void popSelection() {
         try {
-            lock();
+            lockWrites();
             if (selectionStack.size() > 1) {
                 selectionStack.pop();
                 selectFromTop();
@@ -6293,7 +6259,7 @@ public class Logic {
                 Log.e(DEBUG_TAG, "Attempt to pop last selection from stack");
             }
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -6302,10 +6268,10 @@ public class Logic {
      */
     public void pushSelection() {
         try {
-            lock();
+            lockWrites();
             pushSelection(new Selection());
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -6316,11 +6282,11 @@ public class Logic {
      */
     public void pushSelection(@NonNull Selection selection) {
         try {
-            lock();
+            lockWrites();
             selectionStack.push(selection);
             selectFromTop();
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -6331,14 +6297,14 @@ public class Logic {
      */
     public void replaceSelection(@NonNull Selection selection) {
         try {
-            lock();
+            lockWrites();
             if (selectionStack.size() > 1) {
                 selectionStack.pop();
             }
             selectionStack.push(selection);
             selectFromTop();
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -6693,20 +6659,6 @@ public class Logic {
      */
     private static StorageDelegator getDelegator() {
         return App.getDelegator();
-    }
-
-    /**
-     * Lock the StorageDelegator
-     */
-    public void getDataLock() {
-        getDelegator().lock();
-    }
-
-    /**
-     * Unlock the StorageDelegator
-     */
-    public void dataUnlock() {
-        getDelegator().unlock();
     }
 
     /**
@@ -7076,23 +7028,37 @@ public class Logic {
     /**
      * Try to set the reading lock
      */
-    public boolean tryLock() {
-        return lock.tryLock();
+    public boolean tryReadLock() {
+        return readLock.tryLock();
+    }
+
+    /**
+     * Set the write lock
+     */
+    void lockWrites() {
+        writeLock.lock();
+    }
+
+    /**
+     * Free the write lock checking if it is currently held
+     */
+    public void unlockWrites() {
+        if (writeLock.isHeldByCurrentThread()) {
+            writeLock.unlock();
+        }
     }
 
     /**
      * Set the reading lock
      */
-    void lock() {
-        lock.lock();
+    void lockReads() {
+        readLock.lock();
     }
 
     /**
-     * Free the reading lock checking if it is currently held
+     * Free the read lock
      */
-    public void unlock() {
-        if (lock.isHeldByCurrentThread()) {
-            lock.unlock();
-        }
+    public void unlockReads() {
+        readLock.unlock();
     }
 }

--- a/src/main/java/de/blau/android/Main.java
+++ b/src/main/java/de/blau/android/Main.java
@@ -1217,12 +1217,12 @@ public class Main extends AuthorisationEnabledActivity
         }
         if (loadBox != null) { // zoom only
             try {
-                logic.lock();
+                logic.lockWrites();
                 map.getViewBox().fitToBoundingBox(getMap(), loadBox);
                 map.invalidate();
                 logic.saveEditingState(this);
             } finally {
-                logic.unlock();
+                logic.unlockWrites();
             }
         }
     }
@@ -3822,7 +3822,7 @@ public class Main extends AuthorisationEnabledActivity
             int focusLat = GeoMath.yToLatE7(map.getHeight(), map.getWidth(), viewBox, focusY);
             Logic logic = App.getLogic();
             try {
-                logic.lock();
+                logic.lockWrites();
                 viewBox.zoom(Math.max(0.8f, Math.min(1.2f, scaleFactor)) - 1.0f);
                 int newfocusLon = GeoMath.xToLonE7(map.getWidth(), viewBox, focusX);
                 int newfocusLat = GeoMath.yToLatE7(map.getHeight(), map.getWidth(), viewBox, focusY);
@@ -3832,7 +3832,7 @@ public class Main extends AuthorisationEnabledActivity
                     // ignored
                 }
             } finally {
-                logic.unlock();
+                logic.unlockWrites();
             }
             map.getDataStyleManager().updateStrokes(logic.strokeWidth(viewBox.getWidth()));
             if (logic.isRotationMode()) {

--- a/src/main/java/de/blau/android/layer/data/MapOverlay.java
+++ b/src/main/java/de/blau/android/layer/data/MapOverlay.java
@@ -474,16 +474,17 @@ public class MapOverlay<O extends OsmElement> extends NonSerializeableLayer
         final Logic logic = App.getLogic();
         tmpDrawingEditMode = logic.getMode();
         tmpFilter = logic.getFilter();
-        try {
-            if (logic.tryLock()) {
+
+        if (logic.tryReadLock()) {
+            try {
                 tmpDrawingSelectedNodes = logic.getSelectedNodes();
                 tmpDrawingSelectedWays = logic.getSelectedWays();
                 tmpClickableElements = logic.getClickableElements();
                 tmpDrawingSelectedRelationWays = logic.getSelectedRelationWays();
                 tmpDrawingSelectedRelationNodes = logic.getSelectedRelationNodes();
+            } finally {
+                logic.unlockReads();
             }
-        } finally {
-            logic.unlock();
         }
         tmpPresets = App.getCurrentPresets(context);
         tmpLocked = logic.isUiLocked();
@@ -493,15 +494,17 @@ public class MapOverlay<O extends OsmElement> extends NonSerializeableLayer
         inNodeIconZoomRange = zoomLevel > currentStyle.getIconZoomLimit();
 
         viewBox.set(map.getViewBox());
-        try {
-            if (delegator.tryLock()) {
+
+        if (delegator.tryReadLock()) {
+            try {
                 delegator.getCurrentStorage().getBoundingBoxes(boundingBoxResult);
-            } else {
-                Log.w(DEBUG_TAG, "BoundingBoxes already locked, reusing existing data");
+            } finally {
+                delegator.unlockReads();
             }
-        } finally {
-            delegator.unlock();
+        } else {
+            Log.w(DEBUG_TAG, "BoundingBoxes already locked, reusing existing data");
         }
+
         downloadedBoxes.clear();
         for (BoundingBox box : boundingBoxResult) {
             if (box.intersects(viewBox)) {
@@ -534,18 +537,18 @@ public class MapOverlay<O extends OsmElement> extends NonSerializeableLayer
 
         // first find all nodes and ways that we need to display
         // if the delegator is locked re-render what we already have
-        try {
-            if (delegator.tryLock()) {
+        if (delegator.tryReadLock()) {
+            try {
                 nodesResult.clear();
                 waysResult.clear();
                 final Storage currentStorage = delegator.getCurrentStorage();
                 currentStorage.getNodes(viewBox, nodesResult);
                 currentStorage.getWays(viewBox, waysResult);
-            } else {
-                Log.w(DEBUG_TAG, "Delegator already locked, rerendering existing data");
+            } finally {
+                delegator.unlockReads();
             }
-        } finally {
-            delegator.unlock();
+        } else {
+            Log.w(DEBUG_TAG, "Delegator already locked, rerendering existing data");
         }
 
         // the following should guarantee that if the selected node is off screen but the handle not, the handle gets
@@ -1981,7 +1984,7 @@ public class MapOverlay<O extends OsmElement> extends NonSerializeableLayer
 
     @Override
     public void setAutoPrune(boolean enable) {
-       prefs.setAutoPruneData(enable);
+        prefs.setAutoPruneData(enable);
     }
 
     @Override

--- a/src/main/java/de/blau/android/osm/MergeAction.java
+++ b/src/main/java/de/blau/android/osm/MergeAction.java
@@ -121,13 +121,13 @@ public class MergeAction {
 
         // replace references to mergeFrom node in ways with mergeInto
         try {
-            delegator.lock();
+            delegator.lockWrites();
             Storage currentStorage = delegator.getCurrentStorage();
             for (Way way : currentStorage.getWays((Node) mergeFrom)) {
                 delegator.replaceNodeInWay((Node) mergeFrom, (Node) mergeInto, way);
             }
         } finally {
-            delegator.unlock();
+            delegator.unlockWrites();
         }
         // if we swapped from and into, set position from original into
         if (origCoords != null) {
@@ -275,10 +275,10 @@ public class MergeAction {
         w1.addNodes(newNodes, atBeginning);
         w1.updateState(OsmElement.STATE_MODIFIED);
         try {
-            delegator.lock();
+            delegator.lockWrites();
             delegator.getApiStorage().insertElementSafe(w1);
         } finally {
-            delegator.unlock();
+            delegator.unlockWrites();
         }
         delegator.onElementChanged(null, w1);
         mergeElementsRelations(w1, w2);
@@ -367,12 +367,12 @@ public class MergeAction {
         // undo - mergeInto way saved here, mergeFrom way will not be changed directly and will be saved in removeWay
         delegator.dirty();
         try {
-            delegator.lock();
+            delegator.lockWrites();
             UndoStorage undo = delegator.getUndo();
             undo.save(p1);
             undo.save(p2);
         } finally {
-            delegator.unlock();
+            delegator.unlockWrites();
         }
 
         List<List<Node>> outputRings = new ArrayList<>();
@@ -558,11 +558,11 @@ public class MergeAction {
                 Map<String, String> tags = RelationUtils.addTypeTag(Tags.VALUE_MULTIPOLYGON, result.getTags());
                 delegator.setTags(result, tags);
                 try {
-                    delegator.lock();
+                    delegator.lockWrites();
                     delegator.getUndo().createCheckpoint(map.getContext().getString(R.string.undo_action_move_tags), selection);
                     delegator.recordImagery(map);
                 } finally {
-                    delegator.unlock();
+                    delegator.unlockWrites();
                 }
                 RelationUtils.moveOuterTags(delegator, (Relation) result);
             }
@@ -589,7 +589,7 @@ public class MergeAction {
      */
     private void removeUntaggedNodes(@NonNull List<Node> list) {
         try {
-            delegator.lock();
+            delegator.lockWrites();
             Storage currentStorage = delegator.getCurrentStorage();
             for (Node n : list) {
                 if (!n.hasTags() && currentStorage.getWays(n).isEmpty()) {
@@ -597,7 +597,7 @@ public class MergeAction {
                 }
             }
         } finally {
-            delegator.unlock();
+            delegator.unlockWrites();
         }
     }
 
@@ -735,7 +735,7 @@ public class MergeAction {
         List<Relation> toRelations = mergeInto.getParentRelations() != null ? mergeInto.getParentRelations() : new ArrayList<>();
         Set<OsmElement> changedElements = new HashSet<>();
         try {
-            delegator.lock();
+            delegator.lockWrites();
             UndoStorage undo = delegator.getUndo();
             Storage apiStorage = delegator.getApiStorage();
             for (Relation r : fromRelations) {
@@ -759,7 +759,7 @@ public class MergeAction {
                 }
             }
         } finally {
-            delegator.unlock();
+            delegator.unlockWrites();
         }
         delegator.onElementChanged(null, new ArrayList<>(changedElements));
     }

--- a/src/main/java/de/blau/android/osm/StorageDelegator.java
+++ b/src/main/java/de/blau/android/osm/StorageDelegator.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import android.app.Activity;
 import android.content.Context;
@@ -93,7 +93,9 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
     /**
      * when reading state lockout writing/reading
      */
-    private transient ReentrantLock lock = new ReentrantLock();
+    private transient ReentrantReadWriteLock           lock      = new ReentrantReadWriteLock();
+    private transient ReentrantReadWriteLock.WriteLock writeLock = lock.writeLock();
+    private transient ReentrantReadWriteLock.ReadLock  readLock  = lock.readLock();
 
     /**
      * Indicates whether changes have been made since the last save to disk. Since a newly created storage is not saved,
@@ -134,7 +136,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
      */
     public void reset(boolean dirty) {
         try {
-            lock();
+            lockWrites();
             this.dirty = dirty;
             apiStorage = new Storage();
             currentStorage = new Storage();
@@ -142,7 +144,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
             factory = new OsmElementFactory();
             imagery = new ArrayList<>();
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -153,13 +155,13 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
      */
     public void setCurrentStorage(@NonNull final Storage currentStorage) {
         try {
-            lock();
+            lockWrites();
             dirty = true;
             apiStorage = new Storage();
             this.currentStorage = currentStorage;
             undo = new UndoStorage(currentStorage, apiStorage);
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -210,10 +212,10 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
      */
     public void clearUndo() {
         try {
-            lock();
+            lockWrites();
             undo = new UndoStorage(currentStorage, apiStorage);
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -222,12 +224,12 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
      */
     public void clearUndo(@NonNull List<OsmElement> elements) {
         try {
-            lock();
+            lockWrites();
             for (OsmElement element : elements) {
                 undo.removeFromAll(element);
             }
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -264,14 +266,14 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
      */
     public void insertElementSafe(@NonNull final OsmElement elem) {
         try {
-            lock();
+            lockWrites();
             dirty = true;
             undo.save(elem);
             apiStorage.insertElementSafe(elem);
             currentStorage.insertElementSafe(elem);
             onElementChanged((OsmElement) null, elem);
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -282,14 +284,14 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
      */
     private void insertElementUnsafe(@NonNull final OsmElement elem) {
         try {
-            lock();
+            lockWrites();
             dirty = true;
             undo.save(elem);
             apiStorage.insertElementUnsafe(elem);
             currentStorage.insertElementUnsafe(elem);
             onElementChanged((OsmElement) null, elem);
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -301,7 +303,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
      */
     public void setTags(@NonNull final OsmElement elem, @Nullable final Map<String, String> tags) {
         try {
-            lock();
+            lockWrites();
             dirty = true;
             undo.save(elem);
             if (elem.setTags(tags)) {
@@ -313,7 +315,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
                 onElementChanged(null, elem);
             }
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -490,13 +492,13 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
      */
     public void fixupApiStorage() {
         try {
-            lock();
+            lockWrites();
             long minNodeId = fixupApiStorage(currentStorage.getNodes());
             long minWayId = fixupApiStorage(currentStorage.getWays());
             long minRelationId = fixupApiStorage(currentStorage.getRelations());
             getFactory().setIdSequences(minNodeId, minWayId, minRelationId);
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -536,7 +538,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
         dirty = true;
         Relation relation = factory.createRelationWithNewId();
         try {
-            lock();
+            lockWrites();
             insertElementUnsafe(relation);
             if (members != null) {
                 for (OsmElement e : members) {
@@ -548,7 +550,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
                 }
             }
         } finally {
-            unlock();
+            unlockWrites();
         }
         return relation;
     }
@@ -565,7 +567,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
         dirty = true;
         Relation relation = factory.createRelationWithNewId();
         try {
-            lock();
+            lockWrites();
             insertElementUnsafe(relation);
             for (RelationMember member : members) {
                 if (member.downloaded()) {
@@ -579,7 +581,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
                 }
             }
         } finally {
-            unlock();
+            unlockWrites();
         }
         return relation;
     }
@@ -612,12 +614,12 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
         undo.save(way);
         validateWayNodeCount(way.nodeCount() + 1);
         try {
-            lock();
+            lockWrites();
             apiStorage.insertElementSafe(way);
             way.addNode(node);
             way.updateState(OsmElement.STATE_MODIFIED);
         } finally {
-            unlock();
+            unlockWrites();
         }
         onElementChanged(null, way);
     }
@@ -635,12 +637,12 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
         undo.save(way);
         validateWayNodeCount(way.nodeCount() + nodes.size());
         try {
-            lock();
+            lockWrites();
             apiStorage.insertElementSafe(way);
             way.addNodes(nodes, false);
             way.updateState(OsmElement.STATE_MODIFIED);
         } finally {
-            unlock();
+            unlockWrites();
         }
         onElementChanged(null, way);
     }
@@ -658,13 +660,13 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
         undo.save(way);
         validateWayNodeCount(nodes.size());
         try {
-            lock();
+            lockWrites();
             way.removeAllNodes();
             apiStorage.insertElementSafe(way);
             way.addNodes(nodes, false);
             way.updateState(OsmElement.STATE_MODIFIED);
         } finally {
-            unlock();
+            unlockWrites();
         }
         onElementChanged(null, way);
     }
@@ -711,13 +713,13 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
         undo.save(way);
         validateWayNodeCount(way.nodeCount() + 1);
         try {
-            lock();
+            lockWrites();
             apiStorage.insertElementSafe(way);
             way.addNodeAfter(nodeBeforeIndex, newNode);
             way.updateState(OsmElement.STATE_MODIFIED);
             onElementChanged(null, way);
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -735,13 +737,13 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
         undo.save(way);
         validateWayNodeCount(way.nodeCount() + 1);
         try {
-            lock();
+            lockWrites();
             apiStorage.insertElementSafe(way);
             way.appendNode(refNode, nextNode);
             way.updateState(OsmElement.STATE_MODIFIED);
             onElementChanged(null, way);
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -757,12 +759,12 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
         dirty = true;
         undo.save(node);
         try {
-            lock();
+            lockWrites();
             invalidateWayBoundingBox(node);
             updateLatLon(node, latE7, lonE7);
             onElementChanged(null, node);
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -1160,7 +1162,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
             }
             // prepare updated nodes for upload
             try {
-                lock();
+                lockWrites();
                 for (int wayIndex = 0; wayIndex < wayList.size(); wayIndex++) {
                     List<Node> nodes = wayList.get(wayIndex).getNodes();
                     Coordinates[] coords = coordsArray.get(wayIndex);
@@ -1170,7 +1172,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
                     }
                 }
             } finally {
-                unlock();
+                unlockWrites();
             }
         }
         // Don't call onElementChanged
@@ -2268,7 +2270,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
         Log.d(DEBUG_TAG, "updateParentRelations new parents size " + parents.size());
         List<Relation> origParents = e.getParentRelations() != null ? new ArrayList<>(e.getParentRelations()) : new ArrayList<>();
         try {
-            lock();
+            lockWrites();
             for (Relation origParent : origParents) { // find changes to existing memberships
                 if (!parents.containsKey(origParent.getOsmId())) {
                     removeElementFromRelation(e, origParent); // saves undo state
@@ -2324,7 +2326,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
                 }
             }
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -2452,7 +2454,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
         undo.save(origElement);
         undo.save(newElement);
         try {
-            lock();
+            lockWrites();
             for (RelationMember rm : relation.getAllMembers(origElement)) {
                 rm.setElement(newElement);
             }
@@ -2463,7 +2465,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
             relation.updateState(OsmElement.STATE_MODIFIED);
             insertElementSafe(relation);
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -2534,7 +2536,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
         List<OsmElement> toCopy = new ArrayList<>();
         Map<OsmElement, OsmElement> processed = new HashMap<>();
         try {
-            lock();
+            lockReads();
             for (OsmElement e : elements) {
                 if (e instanceof Node) {
                     toCopy.add(duplicateNode((Node) e, 0, 0, processed, false));
@@ -2550,7 +2552,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
                 clipboards.push(clipboard);
             }
         } finally {
-            unlock();
+            unlockReads();
         }
     }
 
@@ -2566,7 +2568,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
         List<OsmElement> toCut = new ArrayList<>();
         Map<Long, Node> replacedNodes = new HashMap<>();
         try {
-            lock();
+            lockWrites();
             for (OsmElement e : elements) {
                 if (e instanceof Relation) {
                     throw new IllegalArgumentException("Cutting of Relations not supported");
@@ -2624,7 +2626,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
             clipboard.cutTo(toCut, lat, lon);
             clipboards.push(clipboard);
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -2932,10 +2934,10 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
     public Storage getCurrentStorage() {
         // this doesn't make a lot of sense and needs to be re-visted
         try {
-            lock();
+            lockReads();
             return currentStorage;
         } finally {
-            unlock();
+            unlockReads();
         }
     }
 
@@ -2943,10 +2945,10 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
     @NonNull
     public List<BoundingBox> getBoundingBoxes() {
         try {
-            lock();
+            lockReads();
             return currentStorage.getBoundingBoxes();
         } finally {
-            unlock();
+            unlockReads();
         }
     }
 
@@ -2958,10 +2960,10 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
     public void setOriginalBox(@NonNull final BoundingBox box) {
         dirty = true;
         try {
-            lock();
+            lockWrites();
             currentStorage.setBoundingBox(box);
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -2969,10 +2971,10 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
     public void addBoundingBox(@NonNull BoundingBox box) {
         dirty = true;
         try {
-            lock();
+            lockWrites();
             currentStorage.addBoundingBox(box);
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -2984,10 +2986,10 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
     public void deleteBoundingBox(@NonNull BoundingBox box) {
         dirty = true;
         try {
-            lock();
+            lockWrites();
             currentStorage.deleteBoundingBox(box);
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -3003,7 +3005,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
         // if we are simply expanding the area no need keep the old bounding boxes
         dirty = true;
         try {
-            lock();
+            lockWrites();
             List<BoundingBox> bbs = new ArrayList<>(currentStorage.getBoundingBoxes());
             for (BoundingBox bb : bbs) {
                 if (bb != null) {
@@ -3019,7 +3021,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
             }
             currentStorage.addBoundingBox(box);
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -3106,6 +3108,38 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
     }
 
     /**
+     * Get a list of all nodes contained in bounding box box currently in storage
+     * 
+     * @param box the bounding box
+     * @return unmodifiable list of all nodes currently loaded contained in box
+     */
+    @NonNull
+    public List<Node> getNodes(@NonNull BoundingBox box) {
+        try {
+            lockReads();
+            return getCurrentStorage().getNodes(box);
+        } finally {
+            unlockReads();
+        }
+    }
+
+    /**
+     * Get a list of all the Ways connected to the given Node.
+     * 
+     * @param node The Node.
+     * @return A list of all Ways connected to the Node.
+     */
+    @NonNull
+    public List<Way> getWaysForNode(@NonNull final Node node) {
+        try {
+            lockReads();
+            return getCurrentStorage().getWays(node);
+        } finally {
+            unlockReads();
+        }
+    }
+
+    /**
      * Stores the current storage data to the default storage file
      * 
      * @param ctx Android Context
@@ -3118,7 +3152,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
             Log.i(DEBUG_TAG, "storage delegator empty or not dirty, skipping save");
             return;
         }
-        if (lock.tryLock()) {
+        if (tryReadLock()) {
             try {
                 if (savingHelper.save(ctx, FILENAME, this, true)) {
                     dirty = false;
@@ -3139,7 +3173,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
                 SavingHelper.export(ctx, this); // ctx == null is checked in method
                 Log.d(DEBUG_TAG, "save of state file failed, written emergency change file");
             } finally {
-                lock.unlock();
+                unlockReads();
             }
         } else {
             Log.i(DEBUG_TAG, "storage delegator locked, skipping save");
@@ -3167,7 +3201,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
      */
     public boolean readFromFile(@NonNull Context context, @NonNull String filename) {
         try {
-            lock();
+            lockWrites();
             StorageDelegator newDelegator = savingHelper.load(context, filename, true);
             if (newDelegator != null) {
                 Log.d(DEBUG_TAG, "read saved state");
@@ -3191,7 +3225,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
                 return false;
             }
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -3203,19 +3237,23 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
      */
     public List<String> listChanges(final Resources aResources) {
         List<String> retval = new ArrayList<>();
+        try {
+            lockReads();
+            for (Node node : new ArrayList<>(apiStorage.getNodes())) {
+                retval.add(node.getStateDescription(aResources));
+            }
 
-        for (Node node : new ArrayList<>(apiStorage.getNodes())) {
-            retval.add(node.getStateDescription(aResources));
-        }
+            for (Way way : new ArrayList<>(apiStorage.getWays())) {
+                retval.add(way.getStateDescription(aResources));
+            }
 
-        for (Way way : new ArrayList<>(apiStorage.getWays())) {
-            retval.add(way.getStateDescription(aResources));
+            for (Relation relation : new ArrayList<>(apiStorage.getRelations())) {
+                retval.add(relation.getStateDescription(aResources));
+            }
+            return retval;
+        } finally {
+            unlockReads();
         }
-
-        for (Relation relation : new ArrayList<>(apiStorage.getRelations())) {
-            retval.add(relation.getStateDescription(aResources));
-        }
-        return retval;
     }
 
     /**
@@ -3225,10 +3263,15 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
      */
     public List<OsmElement> listChangedElements() {
         List<OsmElement> retval = new ArrayList<>();
-        retval.addAll(new ArrayList<>(apiStorage.getNodes()));
-        retval.addAll(new ArrayList<>(apiStorage.getWays()));
-        retval.addAll(new ArrayList<>(apiStorage.getRelations()));
-        return retval;
+        try {
+            lockReads();
+            retval.addAll(new ArrayList<>(apiStorage.getNodes()));
+            retval.addAll(new ArrayList<>(apiStorage.getWays()));
+            retval.addAll(new ArrayList<>(apiStorage.getRelations()));
+            return retval;
+        } finally {
+            unlockReads();
+        }
     }
 
     /**
@@ -3306,7 +3349,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
             }
             server.openChangeset(closeOpenChangeset, comment, tmpSource, imagery, extraTags);
             try {
-                lock();
+                lockReads();
                 int startCount = apiStorage.getElementCount();
                 if (fullUpload) {
                     server.diffUpload(this, apiStorage);
@@ -3325,7 +3368,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
                 uploadedCount = startCount - apiStorage.getElementCount();
                 elementCount = elementCount - uploadedCount;
             } finally {
-                unlock();
+                unlockReads();
             }
             if (closeChangeset || split) { // always close when splitting
                 server.closeChangeset();
@@ -3439,10 +3482,10 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
     @Override
     public void export(OutputStream outputStream) throws Exception {
         try {
-            lock();
+            lockReads();
             OsmXml.writeOsmChange(getApiStorage(), outputStream, null, Integer.MAX_VALUE, App.getUserAgent());
         } finally {
-            unlock();
+            unlockReads();
         }
     }
 
@@ -3471,7 +3514,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
         List<OsmElement> newElements = new ArrayList<>(); // elements that we need to run postMerg on
 
         try {
-            lock();
+            lockWrites();
 
             // make temp copy of current storage (we may have to abort
             Storage temp = new Storage(currentStorage);
@@ -3637,7 +3680,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
             currentStorage = temp;
             undo.setCurrentStorage(temp);
         } finally {
-            unlock();
+            unlockWrites();
         }
         // no need to do this in the locked block
         if (postMerge != null) {
@@ -3861,7 +3904,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
             }
         }
         try {
-            lock();
+            lockWrites();
             for (Way w : currentStorage.getWays()) {
                 final long wayId = w.getOsmId();
                 if (apiStorage.getWay(wayId) == null && !box.intersects(w.getBounds()) && !keepWays.contains(wayId) && !hasModifiedNodes(w)
@@ -3895,7 +3938,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
             }
             BoundingBox.prune(this, box);
         } finally {
-            unlock();
+            unlockWrites();
         }
         dirty();
     }
@@ -3964,7 +4007,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
         LongHashSet keepNodes = new LongHashSet();
         LongHashSet keepRelations = new LongHashSet();
         try {
-            lock();
+            lockWrites();
             for (Way w : currentStorage.getWays()) {
                 if (apiStorage.getWay(w.getOsmId()) == null) {
                     currentStorage.removeWay(w);
@@ -3998,7 +4041,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
             }
             fixupBacklinks();
         } finally {
-            unlock();
+            unlockWrites();
         }
         dirty();
     }
@@ -4037,7 +4080,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
         final String ABORTMESSAGE = "applyOsc aborting %s is unchanged/created";
 
         try {
-            lock();
+            lockWrites();
             // make temp copy of current storage (we may have to abort
             Storage tempCurrent = new Storage(currentStorage);
             Storage tempApi = new Storage(apiStorage);
@@ -4251,7 +4294,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
             currentStorage = tempCurrent;
             apiStorage = tempApi;
         } finally {
-            unlock();
+            unlockWrites();
         }
         return true; // Success
     }
@@ -4296,7 +4339,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
      */
     public void undoLast(@Nullable Context ctx, @NonNull OsmElement element) {
         try {
-            lock();
+            lockWrites();
             List<de.blau.android.osm.UndoStorage.Checkpoint> checkpoints = undo.getUndoCheckpoints(element);
             if (checkpoints.isEmpty()) {
                 Log.e(DEBUG_TAG, "No undo checkpoint found for " + element.getDescription());
@@ -4314,7 +4357,7 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
             }
             fixupBacklinks();
         } finally {
-            unlock();
+            unlockWrites();
         }
     }
 
@@ -4347,12 +4390,17 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
      * @return true if the coordinates are in one of the bounding boxes
      */
     public boolean isInDownload(int lonE7, int latE7) {
-        for (BoundingBox bb : new ArrayList<>(currentStorage.getBoundingBoxes())) { // make shallow copy
-            if (bb != null && bb.isIn(lonE7, latE7)) {
-                return true;
+        try {
+            lockReads();
+            for (BoundingBox bb : new ArrayList<>(currentStorage.getBoundingBoxes())) { // make shallow copy
+                if (bb != null && bb.isIn(lonE7, latE7)) {
+                    return true;
+                }
             }
+            return false;
+        } finally {
+            unlockReads();
         }
-        return false;
     }
 
     /**
@@ -4366,24 +4414,29 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
     public boolean isInDownload(@NonNull Way w) {
         List<Node> toCheck = new ArrayList<>(w.getNodes());
         List<Node> inDownload = new ArrayList<>();
-        for (BoundingBox bb : new ArrayList<>(currentStorage.getBoundingBoxes())) { // make shallow copy
-            if (bb == null) {
-                continue;
-            }
-            for (Node n : toCheck) {
-                if ((bb.isIn(n.getLon(), n.getLat())) || n.isNew()) {
-                    inDownload.add(n);
+        try {
+            lockReads();
+            for (BoundingBox bb : new ArrayList<>(currentStorage.getBoundingBoxes())) { // make shallow copy
+                if (bb == null) {
+                    continue;
                 }
+                for (Node n : toCheck) {
+                    if ((bb.isIn(n.getLon(), n.getLat())) || n.isNew()) {
+                        inDownload.add(n);
+                    }
+                }
+                if (!inDownload.isEmpty()) {
+                    toCheck.removeAll(inDownload);
+                }
+                if (toCheck.isEmpty()) {
+                    return true;
+                }
+                inDownload.clear();
             }
-            if (!inDownload.isEmpty()) {
-                toCheck.removeAll(inDownload);
-            }
-            if (toCheck.isEmpty()) {
-                return true;
-            }
-            inDownload.clear();
+            return false;
+        } finally {
+            unlockReads();
         }
-        return false;
     }
 
     /**
@@ -4420,23 +4473,37 @@ public class StorageDelegator implements Serializable, Exportable, DataStorage {
     /**
      * Try to set the reading lock
      */
-    public boolean tryLock() {
-        return lock.tryLock();
+    public boolean tryReadLock() {
+        return readLock.tryLock();
+    }
+
+    /**
+     * Set the write lock
+     */
+    public void lockWrites() {
+        writeLock.lock();
+    }
+
+    /**
+     * Free the write lock checking if it is currently held
+     */
+    public void unlockWrites() {
+        if (writeLock.isHeldByCurrentThread()) {
+            writeLock.unlock();
+        }
     }
 
     /**
      * Set the reading lock
      */
-    public void lock() {
-        lock.lock();
+    public void lockReads() {
+        readLock.lock();
     }
 
     /**
-     * Free the reading lock checking if it is currently held
+     * Free the read lock
      */
-    public void unlock() {
-        if (lock.isHeldByCurrentThread()) {
-            lock.unlock();
-        }
+    public void unlockReads() {
+        readLock.unlock();
     }
 }

--- a/src/main/java/de/blau/android/osm/UndoStorage.java
+++ b/src/main/java/de/blau/android/osm/UndoStorage.java
@@ -551,7 +551,7 @@ public class UndoStorage implements Serializable {
             List<UndoElement> list = new ArrayList<>(elements.values());
             final StorageDelegator delegator = App.getDelegator();
             try {
-                delegator.lock();
+                delegator.lockWrites();
                 if (redoCheckpoint != null) {
                     for (UndoElement ue : list) {
                         redoCheckpoint.add(getUptodateElement(ue.element)); // save current state
@@ -578,7 +578,7 @@ public class UndoStorage implements Serializable {
 
                 delegator.fixupBacklinks();
             } finally {
-                delegator.unlock();
+                delegator.unlockWrites();
             }
             return ok;
         }

--- a/src/main/java/de/blau/android/osm/UpdateFromChanges.java
+++ b/src/main/java/de/blau/android/osm/UpdateFromChanges.java
@@ -35,7 +35,7 @@ public final class UpdateFromChanges {
     public static boolean update(@NonNull StorageDelegator delegator, @NonNull Storage changes) {
 
         try {
-            delegator.lock();
+            delegator.lockWrites();
             // make temp copy of current storage (we may have to abort
             Storage tempApi = new Storage(delegator.getApiStorage());
             Storage tempCurrent = new Storage(delegator.getCurrentStorage());
@@ -147,7 +147,7 @@ public final class UpdateFromChanges {
             delegator.dirty();
 
         } finally {
-            delegator.unlock();
+            delegator.unlockWrites();
         }
         return true;
     }


### PR DESCRIPTION
This replaces the previous single locks in StorageDelegator and Logic with an ReentrantReadWriteLock that allows concurrent reads. This should at least help a bit with state saving (when you have very large layers and lots of data) cause the app to seemingly hang for a dozen seconds or so when the automatic saves kick in. 

This additionally moves some methods from Logic to StorageDelegator as they need to use the locks there.