### PR TITLE
Starting a foreground service can throw a SecutiryException, catch it

### DIFF
--- a/src/main/java/de/blau/android/services/DownloadService.java
+++ b/src/main/java/de/blau/android/services/DownloadService.java
@@ -355,7 +355,13 @@ public class DownloadService extends Service {
             return false;
         }
         NotificationCompat.Builder notificationBuilder = buildNotification(false, 0, 0);
-        ServiceCompat.startForeground(this, R.id.notification_download, notificationBuilder.build(), ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC);
+        try {
+            ServiceCompat.startForeground(this, R.id.notification_download, notificationBuilder.build(), ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC);
+        } catch (SecurityException sex) {
+            Log.e(DEBUG_TAG, "Starting download foreground service failed with " + sex.getMessage());
+            ScreenMessage.toastTopError(DownloadService.this, getString(R.string.download_service_start_failure, sex.getMessage()));
+            return false;
+        }
         return true;
     }
 

--- a/src/main/java/de/blau/android/services/TrackerService.java
+++ b/src/main/java/de/blau/android/services/TrackerService.java
@@ -479,7 +479,13 @@ public class TrackerService extends Service {
         notificationBuilder.setSmallIcon(R.drawable.ic_notification_vespucci).setOngoing(true).setUsesChronometer(true).setContentIntent(pendingAppIntent)
                 .setColor(ContextCompat.getColor(this, R.color.osm_green))
                 .addAction(R.drawable.ic_notification_vespucci, getString(R.string.exit_title), pendingExitIntent);
-        ServiceCompat.startForeground(this, R.id.notification_tracker, notificationBuilder.build(), ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION);
+        try {
+            ServiceCompat.startForeground(this, R.id.notification_tracker, notificationBuilder.build(), ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION);
+        } catch (SecurityException sex) {
+            Log.e(DEBUG_TAG, "Starting gpx foreground service failed with " + sex.getMessage());
+            ScreenMessage.toastTopError(TrackerService.this, getString(R.string.gps_service_start_failure, sex.getMessage()));
+            return false;
+        }
         init();
         if (externalListener != null) {
             externalListener.onStateChanged();


### PR DESCRIPTION
This might be a Android 16 behaviour change, in any case we need to catch the exception and toast.