### PR TITLE
Actually save tile in onSaveInstanceState

### DIFF
--- a/src/main/java/de/blau/android/dialogs/TileSourceDiagnostics.java
+++ b/src/main/java/de/blau/android/dialogs/TileSourceDiagnostics.java
@@ -171,4 +171,9 @@ public class TileSourceDiagnostics extends CancelableDialogFragment {
         builder.setView(sv);
         return builder.create();
     }
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        outState.putSerializable(TILE_KEY, tile);
+    }
 }


### PR DESCRIPTION
This caused a crash if the test dialog was resumed.