### PR TITLE
Styleable colour to highlight newly created or modified ways and nodes

### DIFF
--- a/documentation/docs/tutorials/data_styling.md
+++ b/documentation/docs/tutorials/data_styling.md
@@ -1,5 +1,5 @@
 ## Vespucci Data Styling
-_Documentation for Vespucci 22.1 Style file format version 0.3.3_
+_Documentation for Vespucci 22.2 Style file format version 0.3.3_
 
 The data styling configuration is not a work of art, it was created ad hoc (in other words it is an awful hack) to allow slightly more flexible configuration of the rendering.
 
@@ -70,16 +70,20 @@ Name                          | Description
 gps_track                     | Default style for GPX tracks
 infotext                      | 
 attribution_text              | Text style for attribution notices on the map
-viewbox                       |
+viewbox                       | Colour for the viewbox background (dimmed for non-downloaded areas)
 way_tolerance                 | Styling for area around a way for touch purposes
-way_tolerance_2               | 
+way_tolerance_2               | Same as above but less transparent for highlighting selectable ways
+way_tolerance_modified        | Styling for area around a modified or newly created way
+way_tolerance_modified_2      | Same as above but less transparent for highlighting selectable ways
 way                           | Default way style
 selected_way                  | Selected way style
 selected_relation_way         | Style for relation member ways when the relation is selected
 problem_way                   | Style for a way with an issue
 hidden_way                    | Style for faint way rendering (used when filters are active)
 node_tolerance                | Styling for area around a node for touch purposes
-node_tolerance_2              | 
+node_tolerance_2              | Same as above but less transparent for highlighting selectable nodes
+node_tolerance_modified       | Styling for area around a modified or newly created node
+node_tolerance_modified_2     | Same as above but less transparent for highlighting selectable nodes
 node_untagged                 | Styling for an untagged node
 node_thin                     | 
 node_tagged                   | Style for a tagged node without icon

--- a/src/main/assets/styles/Color-round-no-mp.xml
+++ b/src/main/assets/styles/Color-round-no-mp.xml
@@ -10,9 +10,13 @@
     <feature type="selected_way" updateWidth="true" widthFactor="2.0" color="fffcfa74" style="STROKE" cap="ROUND" join="ROUND" />
     <feature type="way_tolerance" updateWidth="false" widthFactor="1.0" color="28bd8d46" style="STROKE" cap="BUTT" join="MITER" strokeWidth="40.0" />
     <feature type="way_tolerance_2" updateWidth="false" widthFactor="1.0" color="7fbd8d46" style="STROKE" cap="BUTT" join="MITER" strokeWidth="40.0" />
+    <feature type="way_tolerance_modified" updateWidth="false" widthFactor="1.0" color="5046adbd" style="STROKE" cap="BUTT" join="MITER" strokeWidth="40.0" />
+    <feature type="way_tolerance_modified_2" updateWidth="false" widthFactor="1.0" color="7f46adbd" style="STROKE" cap="BUTT" join="MITER" strokeWidth="40.0" />
     <feature type="gps_track" updateWidth="false" widthFactor="1.0" color="ff0000ff" style="STROKE" cap="ROUND" join="ROUND" strokeWidth="2.0" />
     <feature type="node_tolerance" updateWidth="false" widthFactor="1.0" color="28bd8d46" style="FILL" cap="BUTT" join="MITER" strokeWidth="40.0" />
     <feature type="node_tolerance_2" updateWidth="false" widthFactor="1.0" color="7fbd8d46" style="FILL" cap="BUTT" join="MITER" strokeWidth="40.0" />
+    <feature type="node_tolerance_modified" updateWidth="false" widthFactor="1.0" color="5046adbd" style="FILL" cap="BUTT" join="MITER" strokeWidth="40.0" />
+    <feature type="node_tolerance_modified_2" updateWidth="false" widthFactor="1.0" color="7f46adbd" style="FILL" cap="BUTT" join="MITER" strokeWidth="40.0" />
     <feature type="infotext" updateWidth="false" widthFactor="1.0" color="ff000000" style="FILL" cap="BUTT" join="MITER" strokeWidth="0.0" typefacestyle="0" textsize="12.0" />
     <feature type="viewbox" updateWidth="false" widthFactor="1.0" color="7d0f0f0f" style="FILL" cap="BUTT" join="MITER" strokeWidth="0.0" />
     <feature type="gps_pos" updateWidth="false" widthFactor="2.0" color="ff0000ff" style="FILL" cap="ROUND" join="ROUND" strokeWidth="2.0" />

--- a/src/main/assets/styles/Color-round.xml
+++ b/src/main/assets/styles/Color-round.xml
@@ -10,9 +10,13 @@
     <feature type="selected_way" updateWidth="true" widthFactor="2.0" color="fffcfa74" style="STROKE" cap="ROUND" join="ROUND" />
     <feature type="way_tolerance" updateWidth="false" widthFactor="1.0" color="28bd8d46" style="STROKE" cap="BUTT" join="MITER" strokeWidth="40.0" />
     <feature type="way_tolerance_2" updateWidth="false" widthFactor="1.0" color="7fbd8d46" style="STROKE" cap="BUTT" join="MITER" strokeWidth="40.0" />
+    <feature type="way_tolerance_modified" updateWidth="false" widthFactor="1.0" color="5046adbd" style="STROKE" cap="BUTT" join="MITER" strokeWidth="40.0" />
+    <feature type="way_tolerance_modified_2" updateWidth="false" widthFactor="1.0" color="7f46adbd" style="STROKE" cap="BUTT" join="MITER" strokeWidth="40.0" />
     <feature type="gps_track" updateWidth="false" widthFactor="1.0" color="ff0000ff" style="STROKE" cap="ROUND" join="ROUND" strokeWidth="2.0" />
     <feature type="node_tolerance" updateWidth="false" widthFactor="1.0" color="28bd8d46" style="FILL" cap="BUTT" join="MITER" strokeWidth="40.0" />
     <feature type="node_tolerance_2" updateWidth="false" widthFactor="1.0" color="7fbd8d46" style="FILL" cap="BUTT" join="MITER" strokeWidth="40.0" />
+    <feature type="node_tolerance_modified" updateWidth="false" widthFactor="1.0" color="5046adbd" style="FILL" cap="BUTT" join="MITER" strokeWidth="40.0" />
+    <feature type="node_tolerance_modified_2" updateWidth="false" widthFactor="1.0" color="7f46adbd" style="FILL" cap="BUTT" join="MITER" strokeWidth="40.0" />
     <feature type="infotext" updateWidth="false" widthFactor="1.0" color="ff000000" style="FILL" cap="BUTT" join="MITER" strokeWidth="0.0" typefacestyle="0" textsize="12.0" />
     <feature type="viewbox" updateWidth="false" widthFactor="1.0" color="7d0f0f0f" style="FILL" cap="BUTT" join="MITER" strokeWidth="0.0" />
     <feature type="gps_pos" updateWidth="false" widthFactor="2.0" color="ff0000ff" style="FILL" cap="ROUND" join="ROUND" strokeWidth="2.0" />

--- a/src/main/assets/styles/No-path-patterns.xml
+++ b/src/main/assets/styles/No-path-patterns.xml
@@ -10,9 +10,13 @@
     <feature type="selected_way" updateWidth="true" widthFactor="2.0" color="fffcfa74" style="STROKE" cap="ROUND" join="ROUND" />
     <feature type="way_tolerance" updateWidth="false" widthFactor="1.0" color="28bd8d46" style="STROKE" cap="BUTT" join="MITER" strokeWidth="40.0" />
     <feature type="way_tolerance_2" updateWidth="false" widthFactor="1.0" color="7fbd8d46" style="STROKE" cap="BUTT" join="MITER" strokeWidth="40.0" />
+    <feature type="way_tolerance_modified" updateWidth="false" widthFactor="1.0" color="5046adbd" style="STROKE" cap="BUTT" join="MITER" strokeWidth="40.0" />
+    <feature type="way_tolerance_modified_2" updateWidth="false" widthFactor="1.0" color="7f46adbd" style="STROKE" cap="BUTT" join="MITER" strokeWidth="40.0" />
     <feature type="gps_track" updateWidth="false" widthFactor="1.0" color="ff0000ff" style="STROKE" cap="ROUND" join="ROUND" strokeWidth="2.0" />
     <feature type="node_tolerance" updateWidth="false" widthFactor="1.0" color="28bd8d46" style="FILL" cap="BUTT" join="MITER" strokeWidth="40.0" />
     <feature type="node_tolerance_2" updateWidth="false" widthFactor="1.0" color="7fbd8d46" style="FILL" cap="BUTT" join="MITER" strokeWidth="40.0" />
+    <feature type="node_tolerance_modified" updateWidth="false" widthFactor="1.0" color="5046adbd" style="FILL" cap="BUTT" join="MITER" strokeWidth="40.0" />
+    <feature type="node_tolerance_modified_2" updateWidth="false" widthFactor="1.0" color="7f46adbd" style="FILL" cap="BUTT" join="MITER" strokeWidth="40.0" />
     <feature type="infotext" updateWidth="false" widthFactor="1.0" color="ff000000" style="FILL" cap="BUTT" join="MITER" strokeWidth="0.0" typefacestyle="0" textsize="12.0" />
     <feature type="viewbox" updateWidth="false" widthFactor="1.0" color="7d0f0f0f" style="FILL" cap="BUTT" join="MITER" strokeWidth="0.0" />
     <feature type="gps_pos" updateWidth="false" widthFactor="2.0" color="ff0000ff" style="FILL" cap="ROUND" join="ROUND" strokeWidth="2.0" />

--- a/src/main/assets/styles/Pen-round.xml
+++ b/src/main/assets/styles/Pen-round.xml
@@ -8,11 +8,15 @@
     <feature type="way_direction" updateWidth="true" widthFactor="0.8" color="ffb9121b" style="STROKE" cap="SQUARE" join="MITER" />
     <feature type="handle" updateWidth="true" widthFactor="0.8" color="ffb9121b" style="STROKE" cap="SQUARE" join="MITER" />
     <feature type="selected_way" updateWidth="true" widthFactor="2.0" color="fffcfa74" style="STROKE" cap="ROUND" join="ROUND" />
-    <feature type="way_tolerance" updateWidth="false" widthFactor="1.0" color="28bd8d46" style="STROKE" cap="BUTT" join="MITER" strokeWidth="20.0" />
-    <feature type="way_tolerance_2" updateWidth="false" widthFactor="1.0" color="7fbd8d46" style="STROKE" cap="BUTT" join="MITER" strokeWidth="20.0" />
+    <feature type="way_tolerance" updateWidth="false" widthFactor="1.0" color="28bd8d46" style="STROKE" cap="BUTT" join="MITER" strokeWidth="40.0" />
+    <feature type="way_tolerance_2" updateWidth="false" widthFactor="1.0" color="7fbd8d46" style="STROKE" cap="BUTT" join="MITER" strokeWidth="40.0" />
+    <feature type="way_tolerance_modified" updateWidth="false" widthFactor="1.0" color="5046adbd" style="STROKE" cap="BUTT" join="MITER" strokeWidth="40.0" />
+    <feature type="way_tolerance_modified_2" updateWidth="false" widthFactor="1.0" color="7f46adbd" style="STROKE" cap="BUTT" join="MITER" strokeWidth="40.0" />
     <feature type="gps_track" updateWidth="false" widthFactor="1.0" color="ff0000ff" style="STROKE" cap="ROUND" join="ROUND" strokeWidth="2.0" />
-    <feature type="node_tolerance" updateWidth="false" widthFactor="1.0" color="28bd8d46" style="FILL" cap="BUTT" join="MITER" strokeWidth="20.0" />
-    <feature type="node_tolerance_2" updateWidth="false" widthFactor="1.0" color="7fbd8d46" style="FILL" cap="BUTT" join="MITER" strokeWidth="20.0" />
+    <feature type="node_tolerance" updateWidth="false" widthFactor="1.0" color="28bd8d46" style="FILL" cap="BUTT" join="MITER" strokeWidth="40.0" />
+    <feature type="node_tolerance_2" updateWidth="false" widthFactor="1.0" color="7fbd8d46" style="FILL" cap="BUTT" join="MITER" strokeWidth="40.0" />
+    <feature type="node_tolerance_modified" updateWidth="false" widthFactor="1.0" color="5046adbd" style="FILL" cap="BUTT" join="MITER" strokeWidth="40.0" />
+    <feature type="node_tolerance_modified_2" updateWidth="false" widthFactor="1.0" color="7f46adbd" style="FILL" cap="BUTT" join="MITER" strokeWidth="40.0" />
     <feature type="infotext" updateWidth="false" widthFactor="1.0" color="ff000000" style="FILL" cap="BUTT" join="MITER" strokeWidth="0.0" typefacestyle="0" textsize="12.0" />
     <feature type="viewbox" updateWidth="false" widthFactor="1.0" color="7d0f0f0f" style="FILL" cap="BUTT" join="MITER" strokeWidth="0.0" />
     <feature type="gps_pos" updateWidth="false" widthFactor="2.0" color="ff0000ff" style="FILL" cap="ROUND" join="ROUND" strokeWidth="4.0" />

--- a/src/main/java/de/blau/android/layer/data/MapOverlay.java
+++ b/src/main/java/de/blau/android/layer/data/MapOverlay.java
@@ -250,10 +250,14 @@ public class MapOverlay<O extends OsmElement> extends NonSerializeableLayer
     /** Caches the Paint used for node tolerance */
     private Paint nodeTolerancePaint;
     private Paint nodeTolerancePaint2;
+    private Paint nodeToleranceModifiedPaint;
+    private Paint nodeToleranceModifiedPaint2;
 
     /** Caches the Paint used for way tolerance */
     private Paint wayTolerancePaint;
     private Paint wayTolerancePaint2;
+    private Paint wayToleranceModifiedPaint;
+    private Paint wayToleranceModifiedPaint2;
 
     private Paint nodeDragRadiusPaint;
 
@@ -1046,10 +1050,18 @@ public class MapOverlay<O extends OsmElement> extends NonSerializeableLayer
 
         // draw tolerance
         if (drawTolerance && (!filterMode || (filterMode && filteredObject))) {
-            if (showTolerance && tmpClickableElements == null) {
-                drawNodeTolerance(canvas, isTagged, x, y, nodeTolerancePaint);
-            } else if (tmpClickableElements != null && tmpClickableElements.contains(node)) {
-                drawNodeTolerance(canvas, isTagged, x, y, nodeTolerancePaint2);
+            if (!node.isUnchanged()) {
+                if (tmpClickableElements == null) {
+                    drawNodeTolerance(canvas, isTagged, x, y, nodeToleranceModifiedPaint);
+                } else if (tmpClickableElements.contains(node)) {
+                    drawNodeTolerance(canvas, isTagged, x, y, nodeToleranceModifiedPaint2);
+                }
+            } else {
+                if (showTolerance && tmpClickableElements == null) {
+                    drawNodeTolerance(canvas, isTagged, x, y, nodeTolerancePaint);
+                } else if (tmpClickableElements != null && tmpClickableElements.contains(node)) {
+                    drawNodeTolerance(canvas, isTagged, x, y, nodeTolerancePaint2);
+                }
             }
         }
 
@@ -1501,11 +1513,17 @@ public class MapOverlay<O extends OsmElement> extends NonSerializeableLayer
         FeatureStyle labelFontStyleSmall = labelTextStyleSmall;
 
         // draw way tolerance
-        if (drawTolerance) {
-            if (showTolerance && tmpClickableElements == null) {
-                canvas.drawLines(linePoints, 0, pointsSize, wayTolerancePaint);
-            } else if (isClickable) {
+        if (!way.isUnchanged()) {
+            if (isClickable) {
+                canvas.drawLines(linePoints, 0, pointsSize, wayToleranceModifiedPaint2);
+            } else {
+                canvas.drawLines(linePoints, 0, pointsSize, wayToleranceModifiedPaint);
+            }
+        } else if (drawTolerance) {
+            if (isClickable) {
                 canvas.drawLines(linePoints, 0, pointsSize, wayTolerancePaint2);
+            } else if (showTolerance) {
+                canvas.drawLines(linePoints, 0, pointsSize, wayTolerancePaint);
             }
         }
 
@@ -1865,9 +1883,13 @@ public class MapOverlay<O extends OsmElement> extends NonSerializeableLayer
         // changes when style changes
         nodeTolerancePaint = styles.getInternal(DataStyle.NODE_TOLERANCE).getPaint();
         nodeTolerancePaint2 = styles.getInternal(DataStyle.NODE_TOLERANCE_2).getPaint();
+        nodeToleranceModifiedPaint = styles.getInternal(DataStyle.NODE_TOLERANCE_MODIFIED).getPaint();
+        nodeToleranceModifiedPaint2 = styles.getInternal(DataStyle.NODE_TOLERANCE_MODIFIED_2).getPaint();
         wayTolerancePaint = styles.getInternal(DataStyle.WAY_TOLERANCE).getPaint();
+        wayToleranceModifiedPaint = styles.getInternal(DataStyle.WAY_TOLERANCE_MODIFIED).getPaint();
         nodeToleranceRadius = wayTolerancePaint.getStrokeWidth() / 2;
         wayTolerancePaint2 = styles.getInternal(DataStyle.WAY_TOLERANCE_2).getPaint();
+        wayToleranceModifiedPaint2 = styles.getInternal(DataStyle.WAY_TOLERANCE_MODIFIED_2).getPaint();
         labelBackground = styles.getInternal(DataStyle.LABELTEXT_BACKGROUND).getPaint();
 
         // general node style

--- a/src/main/java/de/blau/android/resources/DataStyle.java
+++ b/src/main/java/de/blau/android/resources/DataStyle.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
@@ -68,6 +69,8 @@ public final class DataStyle extends DefaultHandler {
     public static final String VIEWBOX                       = "viewbox";
     public static final String WAY_TOLERANCE                 = "way_tolerance";
     public static final String WAY_TOLERANCE_2               = "way_tolerance_2";
+    public static final String WAY_TOLERANCE_MODIFIED        = "way_tolerance_modified";
+    public static final String WAY_TOLERANCE_MODIFIED_2      = "way_tolerance_modified_2";
     public static final String WAY                           = "way";
     public static final String SELECTED_WAY                  = "selected_way";
     public static final String SELECTED_RELATION_WAY         = "selected_relation_way";
@@ -75,6 +78,8 @@ public final class DataStyle extends DefaultHandler {
     public static final String HIDDEN_WAY                    = "hidden_way";
     public static final String NODE_TOLERANCE                = "node_tolerance";
     public static final String NODE_TOLERANCE_2              = "node_tolerance_2";
+    public static final String NODE_TOLERANCE_MODIFIED       = "node_tolerance_modified";
+    public static final String NODE_TOLERANCE_MODIFIED_2     = "node_tolerance_modified_2";
     public static final String NODE_UNTAGGED                 = "node_untagged";
     public static final String NODE_THIN                     = "node_thin";
     public static final String NODE_TAGGED                   = "node_tagged";
@@ -162,6 +167,9 @@ public final class DataStyle extends DefaultHandler {
     private static final String PRESET                = "preset";
     private static final String OFFSET_ATTR           = "offset";
     private static final String TEXT_COLOR_ATTR       = "textColor";
+
+    private static final List NODE_TOLERANCES = Arrays.asList(NODE_TOLERANCE, NODE_TOLERANCE_2, NODE_TOLERANCE_MODIFIED, NODE_TOLERANCE_MODIFIED_2);
+    private static final List WAY_TOLERANCES  = Arrays.asList(WAY_TOLERANCE, WAY_TOLERANCE_2, WAY_TOLERANCE_MODIFIED, WAY_TOLERANCE_MODIFIED_2);
 
     private static final int  DEFAULT_MIN_VISIBLE_ZOOM     = 15;
     public static final float DEFAULT_GPX_STROKE_WIDTH     = 4.0f;
@@ -945,6 +953,20 @@ public final class DataStyle extends DefaultHandler {
         fp.getPaint().setStrokeWidth(Density.dpToPx(ctx, wayToleranceValue));
         internalStyles.put(WAY_TOLERANCE_2, fp);
 
+        fp = new FeatureStyle(WAY_TOLERANCE_MODIFIED, baseWayStyle);
+        fp.setColor(ContextCompat.getColor(ctx, R.color.blue_highlight));
+        fp.setUpdateWidth(false);
+        fp.getPaint().setAlpha(TOLERANCE_ALPHA);
+        fp.getPaint().setStrokeWidth(Density.dpToPx(ctx, wayToleranceValue));
+        internalStyles.put(WAY_TOLERANCE_MODIFIED, fp);
+
+        fp = new FeatureStyle(WAY_TOLERANCE_MODIFIED_2, baseWayStyle);
+        fp.setColor(ContextCompat.getColor(ctx, R.color.blue_highlight));
+        fp.setUpdateWidth(false);
+        fp.getPaint().setAlpha(TOLERANCE_ALPHA_2);
+        fp.getPaint().setStrokeWidth(Density.dpToPx(ctx, wayToleranceValue));
+        internalStyles.put(WAY_TOLERANCE_MODIFIED_2, fp);
+
         fp = new FeatureStyle(SELECTED_NODE);
         int cccBeige = ContextCompat.getColor(ctx, R.color.ccc_beige);
         fp.setColor(cccBeige);
@@ -1052,6 +1074,30 @@ public final class DataStyle extends DefaultHandler {
         fp.getPaint().setAlpha(TOLERANCE_ALPHA_2);
         fp.getPaint().setStrokeWidth(Density.dpToPx(ctx, nodeToleranceValue));
         internalStyles.put(NODE_TOLERANCE_2, fp);
+
+        fp = new FeatureStyle(NODE_TOLERANCE_MODIFIED);
+        fp.setColor(ContextCompat.getColor(ctx, R.color.blue_highlight));
+        fp.setUpdateWidth(false);
+        fp.getPaint().setStyle(Style.FILL);
+        fp.getPaint().setAlpha(TOLERANCE_ALPHA);
+        fp.getPaint().setStrokeWidth(Density.dpToPx(ctx, nodeToleranceValue));
+        internalStyles.put(NODE_TOLERANCE_MODIFIED, fp);
+
+        fp = new FeatureStyle(NODE_TOLERANCE_2);
+        fp.setColor(ContextCompat.getColor(ctx, R.color.ccc_ocher));
+        fp.setUpdateWidth(false);
+        fp.getPaint().setStyle(Style.FILL);
+        fp.getPaint().setAlpha(TOLERANCE_ALPHA_2);
+        fp.getPaint().setStrokeWidth(Density.dpToPx(ctx, nodeToleranceValue));
+        internalStyles.put(NODE_TOLERANCE_2, fp);
+
+        fp = new FeatureStyle(NODE_TOLERANCE_MODIFIED_2);
+        fp.setColor(ContextCompat.getColor(ctx, R.color.blue_highlight));
+        fp.setUpdateWidth(false);
+        fp.getPaint().setStyle(Style.FILL);
+        fp.getPaint().setAlpha(TOLERANCE_ALPHA_2);
+        fp.getPaint().setStrokeWidth(Density.dpToPx(ctx, nodeToleranceValue));
+        internalStyles.put(NODE_TOLERANCE_MODIFIED_2, fp);
 
         fp = new FeatureStyle(INFOTEXT);
         fp.setColor(Color.BLACK);
@@ -1379,9 +1425,9 @@ public final class DataStyle extends DefaultHandler {
                         float strokeWidth = Density.dpToPx(ctx, Float.parseFloat(strokeWidthString));
                         tempFeatureStyle.setStrokeWidth(strokeWidth);
                         // special case if we are setting internal tolerance values
-                        if (type.equals(NODE_TOLERANCE)) {
+                        if (NODE_TOLERANCES.contains(type)) {
                             nodeToleranceValue = strokeWidth;
-                        } else if (type.equals(WAY_TOLERANCE)) {
+                        } else if (WAY_TOLERANCES.contains(type)) {
                             wayToleranceValue = strokeWidth;
                         }
                     }

--- a/src/main/res/values/colors.xml
+++ b/src/main/res/values/colors.xml
@@ -10,6 +10,7 @@
 	<color name="ccc_beige">#f6e497</color>
 	<color name="ccc_white">#fcfae1</color>
 	<color name="ccc_ocher">#bd8d46</color>
+    <color name="blue_highlight">#46adbd</color>
 	<color name="grey">#0F0F0F</color>
 	<color name="light_grey">#eeeeee</color>
 	<color name="dark_grey">#aaaaaa</color>


### PR DESCRIPTION
This adds support for using a different colour for the tolerance area for newly created or modified nodes and ways.

Note:

- this will always be rendered even if showing the tolerance area is turned off
- this doesn't support relations

Resolves https://github.com/MarcusWolschon/osmeditor4android/issues/3161