### PR TITLE
Stop Android Linkify from using substrings

### DIFF
--- a/src/main/java/de/blau/android/dialogs/ImageInfo.java
+++ b/src/main/java/de/blau/android/dialogs/ImageInfo.java
@@ -127,7 +127,7 @@ public class ImageInfo extends InfoDialogFragment {
             String path = ContentResolverUtil.getPath(getContext(), uri);
             Log.i(DEBUG_TAG, "path " + path + " uri " + uri.toString());
             if (path != null) {
-                tl.addView(TableLayoutUtils.createRow(activity, R.string.File, path, tp));
+                tl.addView(TableLayoutUtils.createRow(activity, R.string.File, path, false, tp));
             }
             if (showUri || path == null) {
                 tl.addView(TableLayoutUtils.createRow(activity, R.string.URI, uri.toString(), tp));

--- a/src/main/java/de/blau/android/dialogs/TableLayoutUtils.java
+++ b/src/main/java/de/blau/android/dialogs/TableLayoutUtils.java
@@ -9,6 +9,8 @@ import android.text.TextUtils.TruncateAt;
 import android.text.method.LinkMovementMethod;
 import android.text.style.StyleSpan;
 import android.text.util.Linkify;
+import android.text.util.Linkify.TransformFilter;
+import android.util.Patterns;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -377,6 +379,18 @@ public final class TableLayoutUtils {
         return tr;
     }
 
+    private static final Linkify.MatchFilter matchFilter = (CharSequence s, int start, int end) -> {
+        // Reject if not preceded by whitespace
+        if (start > 0 && !Character.isWhitespace(s.charAt(start - 1))) {
+            return false;
+        }
+        // Reject if not followed by whitespace
+        if (end < s.length() && !Character.isWhitespace(s.charAt(end))) {
+            return false;
+        }
+        return true;
+    };
+
     /**
      * Add a new cell to a TableRow
      * 
@@ -394,11 +408,13 @@ public final class TableLayoutUtils {
         if (cellText != null) {
             cell.setText(cellText);
             cell.setMinEms(FIRST_CELL_WIDTH);
-            boolean hasLink = Linkify.addLinks(cell, Linkify.WEB_URLS);
+            SpannableString spannable = new SpannableString(cell.getText());
+            boolean hasLink = Linkify.addLinks(spannable, Patterns.WEB_URL, null, matchFilter, null);
 
             // note order of the following seems to be relevant to enable both selecting and clicking the link
             cell.setTextIsSelectable(true);
             if (isUrl || hasLink) {
+                cell.setText(spannable);
                 cell.setMovementMethod(LinkMovementMethod.getInstance());
             }
 


### PR DESCRIPTION
Reject potential matches from Linkify if they are not surrounded by whitespace.

Resolves https://github.com/MarcusWolschon/osmeditor4android/issues/3367